### PR TITLE
LATimes.com anti-ad block fix

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -7,3 +7,5 @@
 @@||tags.tiqcdn.com/utag/*/utag.js$domain=cnet.com
 ! Twitch main video
 ||cloudfront.net/esf.js$domain=twitch.tv
+! LA Times forced-whitelisting modal fix
+||tribdss.com/meter/assets$script,domain=www.latimes.com


### PR DESCRIPTION
Fixes the overlay that blocks content unless the user whitelists