### PR TITLE
sfgate fix-sailthru fix-grpc-fix

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -15,3 +15,9 @@
 ||troncdata.com^$script,image,domain=latimes.com
 ||polarmobile.com^$script,image,domain=latimes.com
 ||ntv.io^$script,image,domain=latimes.com
+! Hearst anti-ad blocking fix
+||aps.hearstnp.com^$script,image
+! Sailthru native ad aggregator fix
+||ak.sail-horizon.com^$script,image
+! gRPC client ad tracking data fix boston.com sfgate.com
+||g.3gl.net^$domain=sfgate.com|boston.com


### PR DESCRIPTION
fixes for sfgate, sailthru native ads and grpc tracking from boston.com and sfgate.com