### PR TITLE
Block domain anchored ctnet2.in third-party URLs

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -1,7 +1,6 @@
 ||ntv.io^$third-party
 @@||creative.sonobi.com
-@@||adm.fwmrm.net^*/AdManager.js$domain=msnbc.com|sky.com|cnbc.com
-||novately.com^$third-party
+@@||adm.fwmrm.net^*/AdManager.js$domain=msnbc.com|sky.com|cnbc.com ||novately.com^$third-party
 ||webspectator.com^$third-party
 ! Would be nice to find an alt fix, but unbreaks cnet video
 @@||tags.tiqcdn.com/utag/*/utag.js$domain=cnet.com
@@ -51,4 +50,4 @@
 ||murdoog.com^$third-party
 ! Admiral anti-ad blocking fix 
 ||functionalclam.com^$third-party
-
+||ctnet2.in$third-party


### PR DESCRIPTION
As seen for the popup div on coinmarketcap.com

<img width="407" alt="screen shot 2017-09-17 at 4 17 36 pm" src="https://user-images.githubusercontent.com/831718/30525139-143569da-9bcf-11e7-9857-fc82d105857e.png">

