### PR TITLE
Block the mining of jsecoin

### DIFF
--- a/coin-miners.txt
+++ b/coin-miners.txt
@@ -1,1 +1,2 @@
 ||coin-hive.com$third-party
+||jsecoin.com$third-party

--- a/coin-miners.txt
+++ b/coin-miners.txt
@@ -1,2 +1,2 @@
 ||coin-hive.com$third-party
-||jsecoin.com$third-party
+||load.jsecoin.com$third-party


### PR DESCRIPTION
Here's a sample of what is added to the publisher's site:

```js
<script type="text/javascript">
(function() {
var trackingurl = 'https://load.jsecoin.com/server/load/3864/sampsonblog.com/0/0/';
var d=document, j=d.createElement('script'), s=d.getElementsByTagName('script')[0];
j.type='text/javascript'; j.async=true; j.defer=true; j.src=trackingurl; s.parentNode.insertBefore(j,s);
})();
</script>
```

No indication is given that the location will ever be anything other than _load.jsecoin.com_.