### PR TITLE
block common darkMiner script host

### DIFF
--- a/coin-miners.txt
+++ b/coin-miners.txt
@@ -324,6 +324,9 @@ $xmlhttprequest,domain=a-o.ninja|adfreetv.ch|alltube.pl|alltube.tv|auroravid.to|
 ||jyhfuqoh.info^$third-party
 ||kdowqlpt.info^$third-party
 
+! Common source for deepMiner source on hacked sites.
+||greenindex.dynamic-dns.net/jqueryeasyui.js^$third-party
+
 ! Filters optimized for uBlock -------------------------------------------------
 !#include nocoin-ublock.txt
 !-------------------------------------------------------------------------------


### PR DESCRIPTION
added `||greenindex.dynamic-dns.net/jqueryeasyui.js^$third-party` rule

This URL is used by code injected on a large number of hacked sites to server darkMiner script.  Its blocked by all IPs I have access too, and seems to be on a large number of Chinese sites, so possibly IP filtering by the server, but good to protect users against either way.