### PR TITLE
Fix cvs.com account creation and remove duplicate rule already in easylist.txt

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -58,7 +58,6 @@
 ||bounceexchange.com^$third-party
 ||npttech.com/advertising.js$important,script
 ||tiqcdn.com^$third-party
-||forkitz.com^
 ||aolcdn.com/*/adsWrapper.js$script
 ||keywee.co$third-party
 ||summerhamster.com^

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -3,8 +3,6 @@
 @@||adm.fwmrm.net^*/AdManager.js$domain=msnbc.com|sky.com|cnbc.com 
 ||novately.com^$third-party
 ||webspectator.com^$third-party
-! Would be nice to find an alt fix, but unbreaks cnet video
-@@||tags.tiqcdn.com/utag/*/utag.js$domain=cnet.com
 ! Twitch main video
 ||cloudfront.net/esf.js$domain=twitch.tv
 ! LA Times forced-whitelisting modal fix
@@ -57,7 +55,6 @@
 ! fixes for several requests bypassing default blocklists
 ||bounceexchange.com^$third-party
 ||npttech.com/advertising.js$important,script
-||tiqcdn.com^$third-party
 ||aolcdn.com/*/adsWrapper.js$script
 ||keywee.co$third-party
 ||summerhamster.com^


### PR DESCRIPTION
Someone reported refill subscriptions doesn't work for cvs.com
I don't know how to refill a subscription for that but I went to create an account and it failed because of the rule that we added only to brave for `||tiqcdn.com^$third-party`

Since I removed this rule, I could remove a previous fix we did to allow it on cnet.com where the same rule broke videos there `@@||tags.tiqcdn.com/utag/*/utag.js$domain=cnet.com`

Then I also noticed that this rule we have exactly `||forkitz.com^` is already on easylist.txt.

Fix https://github.com/brave/adblock-lists/issues/41

Likely fixes:
https://github.com/brave/brave-browser/issues/3020
