### PR TITLE
Remove creative.sonobi.com exception

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -1,5 +1,4 @@
 ||ntv.io^$third-party
-@@||creative.sonobi.com
 @@||adm.fwmrm.net^*/AdManager.js$domain=msnbc.com|sky.com|cnbc.com 
 ||novately.com^$third-party
 ||webspectator.com^$third-party


### PR DESCRIPTION
It was at one point used for prototype ad images, but we don't use that anymore