### PR TITLE
Move hardcoded exceptions rules to more specific rules and unify exception handling

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -88,6 +88,7 @@
 ! Allow 1P piwik since it's no different than server logs
 @@https://analytics.*/piwik.$~third-party
 ! Fully block Facebook everywhere just like our Disconnect blocking but unbreak logins like from quora.com and twitch.tv
+! Note that options will be added to exclude these filters soon.
 ||facebook.com$third-party
 ||facebook.net$third-party
 ||staticxx.facebook.com$third-party
@@ -97,3 +98,11 @@
 @@||www.facebook.com/connect
 @@||staticxx.facebook.com/connect/
 @@||graph.facebook.com/
+! Block all twitter.com third-party but allow embedded tweets
+! Note that options will be added to exclude these filters soon.
+||twitter.com$third-party
+@@||platform.twitter.com/
+@@||syndication.twitter.com;
+||twimg.com$third-party
+@@||pbs.twimg.com/
+@@||cdn.syndication.twimg.com/

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -98,11 +98,19 @@
 @@||www.facebook.com/connect
 @@||staticxx.facebook.com/connect/
 @@||graph.facebook.com/
+! Block fbcdn.net everywhere but allow Facebook embeds
+||fbcdn.net$third-party,domain=~facebook.com
+@@||staticxx.facebook.com/
+@@||xx.fbcdn.net/
+@@||www.facebook.com/*/plugin
+@@||www.facebook.com/plugins/
+@@||www.facebook.com/rsrc.php
+@@||www.facebook.com/ajax/bz
 ! Block all twitter.com third-party but allow embedded tweets
 ! Note that options will be added to exclude these filters soon.
 ||twitter.com$third-party
 @@||platform.twitter.com/
 @@||syndication.twitter.com;
-||twimg.com$third-party
+||twimg.com$third-party,domain=~twitter.com
 @@||pbs.twimg.com/
 @@||cdn.syndication.twimg.com/

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -39,7 +39,6 @@
 ! fb widget audience, ad and marketing tracking
 ||connect.facebook.net/*/fbevents.js$third-party
 ||facebook.com/tr^$image,third-party
-||graph.facebook.com^$third-party
 ! theatlantic.com anti-blocker filters
 ||theatlantic.blueconic.net$domain=theatlantic.com
 ||theatlantic.com/please-support-us^
@@ -88,3 +87,13 @@
 ||pdfjs.robwu.nl
 ! Allow 1P piwik since it's no different than server logs
 @@https://analytics.*/piwik.$~third-party
+! Fully block Facebook everywhere just like our Disconnect blocking but unbreak logins like from quora.com and twitch.tv
+||facebook.com$third-party
+||facebook.net$third-party
+||staticxx.facebook.com$third-party
+@@||connect.facebook.com/*/sdk.js$script
+@@||connect.facebook.net/*/sdk.js$script
+@@||facebook.com/connect/
+@@||www.facebook.com/connect
+@@||staticxx.facebook.com/connect/
+@@||graph.facebook.com/


### PR DESCRIPTION
Related issue: [brave/brave-browser#3475](https://github.com/brave/brave-browser/issues/3475)'
Related PR: https://github.com/brave/brave-core/pull/1770

This is the first part of a series of work that will be done within the next few weeks. 
It unifies exception handling in one place.

In a later PR, we will be adding metadata to filter rules, and exposing options to control those rules.
It will be opt-out options at first, and then a later iteration will try going to opt-in with UX to notify the user that things are broken.

See this issue for a description of the follow up work that will be done:
https://github.com/brave/brave-browser/issues/3475


This is specifically for:
- Facebook login buttons
- Facebook embed posts
- Twitter embeds

Note that this does not change existing functionality, it just moves a hardcoded c++ list to a more unified place where we can iterate on to add options to exclude them.

For a test plan, see the linked issue above.