### PR TITLE
Add tags to optional filters

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -89,46 +89,52 @@
 @@https://analytics.*/piwik.$~third-party
 ! Fix for Suicide Prevention Lifeline Chat (brave/brave-browser#3492)
 @@||geoplugin.net/javascript.gp$script,xmlhttprequest,domain=suicidepreventionlifeline.org
-! Note that options will be added to exclude these filters soon. They
-! are added both as a blocking rule and as an exception rule so that
-! an exception is hit and will override what's in tracking protection protection.
-! Facebook logins
-||connect.facebook.com/*/sdk.js$script
-@@||connect.facebook.com/*/sdk.js$script
-||connect.facebook.net/*/sdk.js$script
-@@||connect.facebook.net/*/sdk.js$script
-||facebook.com/connect/
-@@||facebook.com/connect/
-||www.facebook.com/connect
-@@||www.facebook.com/connect
-||staticxx.facebook.com/connect/
-@@||staticxx.facebook.com/connect/
-||graph.facebook.com/
-@@||graph.facebook.com/
-! Facebook embeds
-||staticxx.facebook.com/
-@@||staticxx.facebook.com/
-||xx.fbcdn.net/
-@@||xx.fbcdn.net/
-||www.facebook.com/*/plugin
-@@||www.facebook.com/*/plugin
-||www.facebook.com/plugins/
-@@||www.facebook.com/plugins/
-||www.facebook.com/rsrc.php
-@@||www.facebook.com/rsrc.php
-||www.facebook.com/ajax/bz
-@@||www.facebook.com/ajax/bz
-! Twitter embeds
-||platform.twitter.com/
-@@||platform.twitter.com/
-||syndication.twitter.com
-@@||syndication.twitter.com
-||pbs.twimg.com/
-@@||pbs.twimg.com/
-||cdn.syndication.twimg.com/
-@@||cdn.syndication.twimg.com/
 ! Block additional trackers
 ||sp1.nypost.com$third-party
 ||sp.nasdaq.com$third-party
 ||lesechos.fr/xtcore.js$third-party
 ||y8.com/js/sdkloader/outstream.js$third-party
+! Note that options will be added to exclude these filters soon. They
+! are added both as a blocking rule and as an exception rule so that
+! an exception is hit and will override what's in tracking protection protection.
+! Facebook logins and embeds
+||connect.facebook.com/*/sdk.js$script,tag=fb-embeds
+@@||connect.facebook.com/*/sdk.js$script,tag=fb-embeds
+||connect.facebook.net/*/sdk.js$script,tag=fb-embeds
+@@||connect.facebook.net/*/sdk.js$script,tag=fb-embeds
+||facebook.com/connect/$tag=fb-embeds
+@@||facebook.com/connect/$tag=fb-embeds
+||www.facebook.com/connect$tag=fb-embeds
+@@||www.facebook.com/connect$tag=fb-embeds
+||staticxx.facebook.com/connect/$tag=fb-embeds
+@@||staticxx.facebook.com/connect/$tag=fb-embeds
+||graph.facebook.com/$tag=fb-embeds
+@@||graph.facebook.com/$tag=fb-embeds
+||staticxx.facebook.com/$tag=fb-embeds
+@@||staticxx.facebook.com/$tag=fb-embeds
+||xx.fbcdn.net/$tag=fb-embeds
+@@||xx.fbcdn.net/$tag=fb-embeds
+||www.facebook.com/*/plugin$tag=fb-embeds
+@@||www.facebook.com/*/plugin$tag=fb-embeds
+||www.facebook.com/plugins/$tag=fb-embeds
+@@||www.facebook.com/plugins/$tag=fb-embeds
+||www.facebook.com/rsrc.php$tag=fb-embeds
+@@||www.facebook.com/rsrc.php$tag=fb-embeds
+||www.facebook.com/ajax/bz$tag=fb-embeds
+@@||www.facebook.com/ajax/bz$tag=fb-embeds
+! Twitter embeds
+||platform.twitter.com/$tag=twitter-embeds
+@@||platform.twitter.com/$tag=twitter-embeds
+||syndication.twitter.com$tag=twitter-embeds
+@@||syndication.twitter.com$tag=twitter-embeds
+||pbs.twimg.com/$tag=twitter-embeds
+@@||pbs.twimg.com/$tag=twitter-embeds
+||cdn.syndication.twimg.com/$tag=twitter-embeds
+@@||cdn.syndication.twimg.com/$tag=twitter-embeds
+! LinkedIn in embed
+||platform.linkedin.com/$tag=linked-in-embeds
+@@||platform.linkedin.com/$tag=linked-in-embeds
+||www.linkedin.com/pages-extensions/FollowCompany$tag=linked-in-embeds
+@@||www.linkedin.com/pages-extensions/FollowCompany$tag=linked-in-embeds
+||static.licdn.com/sc/p$tag=linked-in-embeds
+@@||static.licdn.com/sc/p$tag=linked-in-embeds


### PR DESCRIPTION
This adds tags to the optional filters.
A tagged filter is only matched if the ad_block_client has called addTag with that tag value. 
We have preferences now in brave-core to add those tags.