### PR TITLE
Allow Twitter video embeds scoped to Twitter option

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -131,6 +131,14 @@
 @@||pbs.twimg.com/$tag=twitter-embeds
 ||cdn.syndication.twimg.com/$tag=twitter-embeds
 @@||cdn.syndication.twimg.com/$tag=twitter-embeds
+||twitter.com/i/videos/tweet/$tag=twitter-embeds
+@@||twitter.com/i/videos/tweet/$tag=twitter-embeds
+||abs.twimg.com/web-video-player/$tag=twitter-embeds
+@@||abs.twimg.com/web-video-player/$tag=twitter-embeds
+||api.twitter.com/1.1/$tag=twitter-embeds
+@@||api.twitter.com/1.1/$tag=twitter-embeds
+||video.twimg.com/ext_tw_video$tag=twitter-embeds
+@@||video.twimg.com/ext_tw_video$tag=twitter-embeds
 ! LinkedIn in embed
 ||platform.linkedin.com/$tag=linked-in-embeds
 @@||platform.linkedin.com/$tag=linked-in-embeds


### PR DESCRIPTION
This fixes Twitter video embeds like this:
https://www.dailywire.com/news/45415/tucker-carlson-unloads-ocasio-cortez-moron-nasty-ryan-saavedra
