### PR TITLE
Fix AJAX requests in https://www.dnsperf.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -146,3 +146,5 @@
 @@||www.linkedin.com/pages-extensions/FollowCompany$tag=linked-in-embeds
 ||static.licdn.com/sc/p$tag=linked-in-embeds
 @@||static.licdn.com/sc/p$tag=linked-in-embeds
+! Fix AJAX requests in https://www.dnsperf.com
+@@||perfops.net^$script,xmlhttprequest,domain=dnsperf.com


### PR DESCRIPTION
uBlock origin has following unbreak rule: `@@||perfops.net^$script,domain=cdnperf.com`

This change adds a similar exception to unbreak https://www.dnsperf.com/.  Won't be needed if / when ublock extends the above rule to cover dnsperf too