### PR TITLE
Fix "ad blocker" message on WP, fixes brave/brave-browser#4507

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -148,3 +148,5 @@
 @@||static.licdn.com/sc/p$tag=linked-in-embeds
 ! Fix AJAX requests in https://www.dnsperf.com
 @@||perfops.net^$script,xmlhttprequest,domain=dnsperf.com
+! Fix https://github.com/brave/brave-browser/issues/4507 (mirrors uBO fix, rewritten so that brave/ad-block supports)
+||washingtonpost.com/pb/api/*/adblocker-feature$xmlhttprequest,first-party


### PR DESCRIPTION
Rewritten version of uBO rule `||washingtonpost.com/pb/api/*/adblocker-feature$xhr,1p`

from https://github.com/uBlockOrigin/uAssets/blob/master/filters/filters.txt