### PR TITLE
Fix video playing on https://www.nbclosangeles.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -148,3 +148,5 @@
 @@||static.licdn.com/sc/p$tag=linked-in-embeds
 ! Fix AJAX requests in https://www.dnsperf.com
 @@||perfops.net^$script,xmlhttprequest,domain=dnsperf.com
+! Fix video playing on https://www.nbclosangeles.com
+@@||nbclosangeles.com/includes/AppMeasurement.js$domain=nbclosangeles.com


### PR DESCRIPTION
This is a tracking script, so only merge if webcompat > privacy