### PR TITLE
Filter for dnsperf no longer needed, is fix upstream in Easyprivacy

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -146,7 +146,5 @@
 @@||www.linkedin.com/pages-extensions/FollowCompany$tag=linked-in-embeds
 ||static.licdn.com/sc/p$tag=linked-in-embeds
 @@||static.licdn.com/sc/p$tag=linked-in-embeds
-! Fix AJAX requests in https://www.dnsperf.com
-@@||perfops.net^$script,xmlhttprequest,domain=dnsperf.com
 ! Fix https://github.com/brave/brave-browser/issues/4507 (mirrors uBO fix, rewritten so that brave/ad-block supports)
 ||washingtonpost.com/pb/api/*/adblocker-feature$xmlhttprequest,first-party


### PR DESCRIPTION
This was fixed recently and add script; https://github.com/easylist/easylist/commit/d26ec8ae2129ac78af8a6e5267be9332016bee66