### PR TITLE
Fix Merch direct powered sites brave/brave-browser#4752

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -148,6 +148,8 @@
 @@||www.linkedin.com/pages-extensions/FollowCompany$tag=linked-in-embeds
 ||static.licdn.com/sc/p$tag=linked-in-embeds
 @@||static.licdn.com/sc/p$tag=linked-in-embeds
+! Fix Merch Direct sites https://github.com/brave/brave-browser/issues/4752
+@@||js.stripe.com^$script
 ! Fix https://github.com/brave/brave-browser/issues/4507 (mirrors uBO fix, rewritten so that brave/ad-block supports)
 ||washingtonpost.com/pb/api/*/adblocker-feature$xmlhttprequest,first-party
 ! Fix blankpage issue https://github.com/brave/brave-browser/issues/4049


### PR DESCRIPTION
Generic due to the amount of sites using merch direct, also stripe.com is used on many sites.