### PR TITLE
allow ads on DDG search, fixes brave-browser/issues#4533

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -166,4 +166,3 @@
 ! Allow ads on DDG: brave-browser/issues#4533
 @@||duckduckgo.com/m.js
 @@||duckduckgo.com/share/spice/amazon/
-

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -163,3 +163,7 @@
 @@||wallpapersite.com/scripts/ads.js$script
 ! Anti-adblock: wallpapershome.com
 @@||wallpapershome.com/scripts/ads.js$script
+! Allow ads on DDG: brave-browser/issues#4533
+@@||duckduckgo.com/m.js
+@@||duckduckgo.com/share/spice/amazon/
+


### PR DESCRIPTION
This adds the ads in the top row in this screenshot back in 
<img width="1160" alt="Screen Shot 2019-06-10 at 10 46 32 PM" src="https://user-images.githubusercontent.com/76526/59246605-a4c04300-8bd1-11e9-823d-20845a14bc68.png">
