### PR TITLE
Fixes brave/brave-browser#3418

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -172,6 +172,9 @@
 @@||wallpapershome.com/scripts/ads.js$script
 ! Anti-adblock: dreamdth.com
 @@||dreamdth.com/js/wutime_adblock/ads.js$script
+! Anti-adblock: kbb.com
+||kbb.com/static/js/global/app-measurement$script
+@@||kbb.com/static/js/global/app-measurement$script
 ! thehindu.com (https://github.com/brave/brave-browser/issues/4808)
 @@||thgim.com/static/js/ads.min.js$script,domain=thehindu.com
 ! Allow ads on DDG: brave-browser/issues#4533


### PR DESCRIPTION
Considered anti-adblock because they're always countering whitelists/checking Easylist filters.