### PR TITLE
Fixes ebay autocomplete brave/brave-browser#5019

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -192,6 +192,9 @@
 ! redditcommentsearch.com (https://community.brave.com/t/redditcommentsearch-doesnt-work-with-shields-on/66496)
 ||pay.reddit.com/user/$script,domain=redditcommentsearch.com
 @@||pay.reddit.com/user/$script,domain=redditcommentsearch.com
+! ebay.co.uk + ebay.com and other ebay regions (https://github.com/brave/brave-browser/issues/5019)
+||ebay.com/experience/listing_auto_complete/$xmlhttprequest
+@@||ebay.com/experience/listing_auto_complete/$xmlhttprequest
 ! thehindu.com (https://github.com/brave/brave-browser/issues/4808)
 @@||thgim.com/static/js/ads.min.js$script,domain=thehindu.com
 ! Anti-adblock: washingtonpost.com


### PR DESCRIPTION
Was reported for ebay.co.uk, but affects all the ebay domains. Made generic for ebay; 

```
https://www.ebay.de/sl/sell
https://www.ebay.fr/sl/sell
https://www.ebay.com/sl/sell
https://www.ebay.co.uk/sl/sell
...
```