### PR TITLE
Anti-adblock on haaretz.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -173,6 +173,8 @@
 @@||wallpapersite.com/scripts/ads.js$script
 ! Anti-adblock: wallpapershome.com
 @@||wallpapershome.com/scripts/ads.js$script
+! Anti-adblock: haaretz.com
+@@||haaretz.com/htz/js/advertisement.js
 ! Anti-adblock: mediaite.com
 @@||mediaite.com/adbait/adsbygoogle.js
 ! Anti-adblock: dreamdth.com


### PR DESCRIPTION
Fix Anti-adblock on haaretz.com, site checks for this script and will throw up a new screen.