### PR TITLE
Prevent adblock tracking script on jpost

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -164,6 +164,8 @@
 ||washingtonpost.com/pb/api/*/adblocker-feature$xmlhttprequest,first-party
 ! Fix blankpage issue https://github.com/brave/brave-browser/issues/4049
 ||dianomi.com/cgi-bin/smartads.pl$xmlhttprequest,domain=inc.com
+! Adblock-Tracking: jpost.com
+@@||bitsngo.net/widget-scripts/extra_content/ads.js$script,domain=jpost.com
 ! Anti-adblock: stream2watch.ws
 @@||stream2watch.ws/js/advertisement.js$script
 ! Fix facebook logins on messenger.com https://github.com/brave/brave-browser/issues/4173


### PR DESCRIPTION
Used to track adblock users, whitelisting script is harmless, and is good for adblock privacy.