### PR TITLE
Fix video playback on abcnews.go.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -197,6 +197,8 @@
 ! Anti-adblock: washingtonpost.com
 ||pubads.g.doubleclick.net^$xmlhttprequest,domain=washingtonpost.com
 @@||pubads.g.doubleclick.net^$xmlhttprequest,domain=washingtonpost.com
+! Fix abcnews.go.com video playback
+@@||akamaihd.net/player/2.106.5/akamai/amp/chartbeatanalytics/Chartbeatanalytics.min.js$domain=abcnews.go.com
 ! Allow ads on DDG: brave-browser/issues#4533
 @@||duckduckgo.com/m.js
 @@||duckduckgo.com/share/spice/amazon/


### PR DESCRIPTION
Was originally 2 filters that would need white listing. But decided to land one fix in EP and Here (because of existing filters already exist in EP). Both Whitelists were needed to get video playback. Required a bit of debugging, it seemed to affect only affect Brave.

https://github.com/easylist/easylist/commit/70b40a4972d3108cbac1764b769d6049ac62fac2
 