### PR TITLE
Fix https://deora.dev/corgi/ and also fix any other sites using Reddit api

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -83,6 +83,9 @@
 @@||gateway.reddit.com^
 ! https://github.com/brave/adblock-lists/issues/39
 @@||alb.reddit.com^
+! Allow sites to use reddit api
+||reddit.com^*/.json?$script,third-party
+@@||reddit.com^*/.json?$script,third-party
 ! DDG 1P analytics and optimization
 @@||improving.duckduckgo.com^$~third-party
 ! Disable PDFJS which we include by default's telemetry
@@ -208,6 +211,9 @@
 ! ebay.co.uk + ebay.com and other ebay regions (https://github.com/brave/brave-browser/issues/5019)
 ||ebay.com/experience/listing_auto_complete/$xmlhttprequest
 @@||ebay.com/experience/listing_auto_complete/$xmlhttprequest
+! Allow reddit on https://deora.dev/corgi/
+||reddit.com/r/$script,domain=deora.dev
+@@||reddit.com/r/$script,domain=deora.dev
 ! thehindu.com (https://github.com/brave/brave-browser/issues/4808)
 @@||thgim.com/static/js/ads.min.js$script,domain=thehindu.com
 ! Anti-adblock: washingtonpost.com


### PR DESCRIPTION
2 changes, one for Brave Nightly (which has the wildcard fix) and fix the site in question.

Was notified via twitter; https://twitter.com/BrendanEich/status/1144377788427730945

We can remove the deora.dev once adblock-rust is in release.