### PR TITLE
Video playback is broken on https://www.zdnet.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -164,8 +164,8 @@
 ! Fix addthis.com issues on rhmodern.com  https://github.com/brave/brave-browser/issues/3653
 @@||s7.addthis.com^$script,domain=rhmodern.com
 ! 2mdn video playback script
-||2mdn.net/instream/html5/ima3.js$script
-@@||2mdn.net/instream/html5/ima3.js$script
+||2mdn.net/instream/html5/ima3.js$script,domain=zdnet.com
+@@||2mdn.net/instream/html5/ima3.js$script,domain=zdnet.com
 ! Fix https://github.com/brave/brave-browser/issues/4507 (mirrors uBO fix, rewritten so that brave/ad-block supports)
 ||washingtonpost.com/pb/api/*/adblocker-feature$xmlhttprequest,first-party
 ! Fix blankpage issue https://github.com/brave/brave-browser/issues/4049

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -166,6 +166,8 @@
 ! 2mdn video playback script
 ||2mdn.net/instream/html5/ima3.js$script,domain=zdnet.com|techrepublic.com
 @@||2mdn.net/instream/html5/ima3.js$script,domain=zdnet.com|techrepublic.com
+! Adblock-Tracking: cbs sites
+@@||cbsistatic.com^*/advertisement*.js$script,domain=zdnet.com|techrepublic.com
 ! Fix https://github.com/brave/brave-browser/issues/4507 (mirrors uBO fix, rewritten so that brave/ad-block supports)
 ||washingtonpost.com/pb/api/*/adblocker-feature$xmlhttprequest,first-party
 ! Fix blankpage issue https://github.com/brave/brave-browser/issues/4049

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -163,6 +163,9 @@
 @@||static.licdn.com/sc/p$tag=linked-in-embeds
 ! Fix addthis.com issues on rhmodern.com  https://github.com/brave/brave-browser/issues/3653
 @@||s7.addthis.com^$script,domain=rhmodern.com
+! 2mdn video playback script
+||2mdn.net/instream/html5/ima3.js$script
+@@||2mdn.net/instream/html5/ima3.js$script
 ! Fix https://github.com/brave/brave-browser/issues/4507 (mirrors uBO fix, rewritten so that brave/ad-block supports)
 ||washingtonpost.com/pb/api/*/adblocker-feature$xmlhttprequest,first-party
 ! Fix blankpage issue https://github.com/brave/brave-browser/issues/4049

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -164,8 +164,8 @@
 ! Fix addthis.com issues on rhmodern.com  https://github.com/brave/brave-browser/issues/3653
 @@||s7.addthis.com^$script,domain=rhmodern.com
 ! 2mdn video playback script
-||2mdn.net/instream/html5/ima3.js$script,domain=zdnet.com
-@@||2mdn.net/instream/html5/ima3.js$script,domain=zdnet.com
+||2mdn.net/instream/html5/ima3.js$script,domain=zdnet.com|techrepublic.com
+@@||2mdn.net/instream/html5/ima3.js$script,domain=zdnet.com|techrepublic.com
 ! Fix https://github.com/brave/brave-browser/issues/4507 (mirrors uBO fix, rewritten so that brave/ad-block supports)
 ||washingtonpost.com/pb/api/*/adblocker-feature$xmlhttprequest,first-party
 ! Fix blankpage issue https://github.com/brave/brave-browser/issues/4049


### PR DESCRIPTION
Made it domain specific, but it may need to be generic depending on how popular this specific script is.

Filter is blocked via disconnect; this fix's it.