### PR TITLE
Fix video playback on https://www.maxpreps.com/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -196,6 +196,9 @@
 @@||googletagservices.com/tag/js/gpt.js$script,domain=spiegel.de
 @@||mxcdn.net/bb-mx/$script,domain=spiegel.de
 @@||imagesrv.adition.com/banners/$image,domain=spiegel.de
+! Video playback on maxpreps.com (script source on cbssports.com)
+||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=cbssports.com
+@@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=cbssports.com
 ! Fix foxnews video playback
 ||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=foxbusiness.com|foxnews.com
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=foxbusiness.com|foxnews.com


### PR DESCRIPTION
Sample video; 

`https://www.maxpreps.com/video/watch/new-jersey-s-most-dominant-football-teams?v=36c936cb-5ffe-4dbe-8688-521ab2300c23`

Similar issue to the Foxnews issue, same script is used; imasdk.googleapis.com/js/sdkloader/ima3.js

Filter exists in Easylist. Disconnect list overrules the Easylist_whitelist we have.