### PR TITLE
Nytimes is tracking adblock users

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -182,6 +182,8 @@
 @@||haaretz.com/htz/js/advertisement.js
 ! Anti-adblock: mediaite.com
 @@||mediaite.com/adbait/adsbygoogle.js
+! Adblock-Tracking: nytimes.com
+@@||nyt.com/ads/google/adsbygoogle.js$script,domain=nytimes.com
 ! Anti-adblock: dreamdth.com
 @@||dreamdth.com/js/wutime_adblock/ads.js$script
 ! Anti-adblock: notebookcheck.net / notebookcheck.com


### PR DESCRIPTION
Just a simple javascript to track anyone using adblock software.

`window._adBlockCheck = true;`

Sample page: `https://www.nytimes.com/2019/06/28/us/politics/donald-trump-jr-kamala-harris.html`
