### PR TITLE
Fix images not displaying on drudgereport.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -212,7 +212,7 @@
 @@||ebay.com/experience/listing_auto_complete/$xmlhttprequest
 ! thehindu.com (https://github.com/brave/brave-browser/issues/4808)
 @@||thgim.com/static/js/ads.min.js$script,domain=thehindu.com
-! drudgereport.com (images not shown, to be removed after brave-rust landing)
+! drudgereport.com (images not shown)
 ||twimg.com^$image,domain=drudgereport.com
 @@||twimg.com^$image,domain=drudgereport.com
 ! Anti-adblock: washingtonpost.com

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -212,6 +212,9 @@
 @@||ebay.com/experience/listing_auto_complete/$xmlhttprequest
 ! thehindu.com (https://github.com/brave/brave-browser/issues/4808)
 @@||thgim.com/static/js/ads.min.js$script,domain=thehindu.com
+! drudgereport.com (images not shown, to be removed after brave-rust landing)
+||twimg.com^$image,domain=drudgereport.com
+@@||twimg.com^$image,domain=drudgereport.com
 ! Anti-adblock: washingtonpost.com
 ||pubads.g.doubleclick.net^$xmlhttprequest,domain=washingtonpost.com
 @@||pubads.g.doubleclick.net^$xmlhttprequest,domain=washingtonpost.com


### PR DESCRIPTION
Fixed in Adblock-Rust, but not in Brave release/beta. Just quick fix to for images being blocked. Can be removed once Adblock-Rust lands in Release

Reported here; https://old.reddit.com/r/brave_browser/comments/c7f44y/brave_blocks_pictures_from_drudgereport_if/