### PR TITLE
Fix https://www.messenger.com/ (Missing Block filters)

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -172,6 +172,8 @@
 ! Anti-adblock: stream2watch.ws
 @@||stream2watch.ws/js/advertisement.js$script
 ! Fix facebook logins on messenger.com https://github.com/brave/brave-browser/issues/4173
+||facebook.com/login/$domain=messenger.com
+||connect.facebook.net^$domain=messenger.com
 @@||facebook.com/login/$domain=messenger.com
 @@||connect.facebook.net^$domain=messenger.com
 ! Anti-adblock: wallpapersite.com (https://www.reddit.com/r/brave_browser/comments/bx784t/websites_detecting_adblocker_even_when_shield/)


### PR DESCRIPTION
We missed the blocking filters of https://github.com/brave/adblock-lists/pull/66