### PR TITLE
Fix a few more delivery.vidible.tv embedded video sites

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -154,9 +154,9 @@
 @@||captcha.vresp.com^$domain=lawfirmkpi.com
 ! https://community.brave.com/t/ad-not-bloked-properly/63628
 ||readthedocs.org/api/v2/sustainability/$script,domain=pyexcel.org
-! Embedded video on engadget.com
-||delivery.vidible.tv/jsonp/$script,domain=engadget.com
-@@||delivery.vidible.tv/jsonp/$script,domain=engadget.com
+! Embedded vidible.tv video
+||delivery.vidible.tv/jsonp/$script,domain=engadget.com|popculture.com|comicbook.com
+@@||delivery.vidible.tv/jsonp/$script,domain=engadget.com|popculture.com|comicbook.com
 ! LinkedIn in embed
 ||platform.linkedin.com/$tag=linked-in-embeds
 @@||platform.linkedin.com/$tag=linked-in-embeds

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -155,8 +155,8 @@
 ! https://community.brave.com/t/ad-not-bloked-properly/63628
 ||readthedocs.org/api/v2/sustainability/$script,domain=pyexcel.org
 ! Embedded vidible.tv video
-||delivery.vidible.tv/jsonp/$script,domain=engadget.com|popculture.com|comicbook.com
-@@||delivery.vidible.tv/jsonp/$script,domain=engadget.com|popculture.com|comicbook.com
+||delivery.vidible.tv/jsonp/$script
+@@||delivery.vidible.tv/jsonp/$script
 ! LinkedIn in embed
 ||platform.linkedin.com/$tag=linked-in-embeds
 @@||platform.linkedin.com/$tag=linked-in-embeds


### PR DESCRIPTION
2 More sites, using vidible.tv which breaks embedded video sites. 

`https://delivery.vidible.tv/jsonp/pid=59230a471de5a12beaabb43d/vid=5b5a338bf507753499853025/58d96f1dcd4fed198a0d2a59.js?m.embeded=cms_video_plugin_chromeExtension&m.onLoad=setPlayer`

2 Sample sites:

`https://popculture.com/tv-shows/2019/07/03/good-trouble-daisy-eagan-details-how-industry-improved-lgbtq-representation/`

`https://comicbook.com/2019/07/04/mad-magazine-shutdown-details-revealed/`

