### PR TITLE
Adblock Tracking Script on https://www.thedailybeast.com/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -177,6 +177,8 @@
 ||dianomi.com/cgi-bin/smartads.pl$xmlhttprequest,domain=inc.com
 ! Adblock-Tracking: jpost.com
 @@||bitsngo.net/widget-scripts/extra_content/ads.js$script,domain=jpost.com
+! Adblock-Tracking: thedailybeast.com
+@@||thedailybeast.com/static/advert.js$script
 ! Anti-adblock: stream2watch.ws
 @@||stream2watch.ws/js/advertisement.js$script
 ! Fix facebook logins on messenger.com https://github.com/brave/brave-browser/issues/4173


### PR DESCRIPTION
Just Adblock tracking script;

`​https://www.thedailybeast.com/static/advert.js`

`// If an ad blocker is enabled, this file should not be loaded by the browser`
`// You can detect if the id is on the page to see if an ad blocker is not enabled`
`const adBlockDetectionDiv = window.document.createElement('div');`
`adBlockDetectionDiv.id = 'ad-block-not-enabled';`
`adBlockDetectionDiv.style.display = 'none';`
`window.document.body.appendChild(adBlockDetectionDiv);`
`window.canRunAds = 'true';`