### PR TITLE
Fix sites using embeded video from vidible.tv

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -154,9 +154,9 @@
 @@||captcha.vresp.com^$domain=lawfirmkpi.com
 ! https://community.brave.com/t/ad-not-bloked-properly/63628
 ||readthedocs.org/api/v2/sustainability/$script,domain=pyexcel.org
-! Embedded video on engadget.com
-||delivery.vidible.tv/jsonp/$script,domain=engadget.com
-@@||delivery.vidible.tv/jsonp/$script,domain=engadget.com
+! Embedded vidible video's
+||delivery.vidible.tv/jsonp/$script
+@@||delivery.vidible.tv/jsonp/$script
 ! LinkedIn in embed
 ||platform.linkedin.com/$tag=linked-in-embeds
 @@||platform.linkedin.com/$tag=linked-in-embeds

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -155,8 +155,10 @@
 ! https://community.brave.com/t/ad-not-bloked-properly/63628
 ||readthedocs.org/api/v2/sustainability/$script,domain=pyexcel.org
 ! Embedded vidible video's
-@@||vidible.tv/prod/$script
-||vidible.tv/prod/$script
+@@||vidible.tv/prod/$xmlhttprequest,media,image
+||vidible.tv/prod/$xmlhttprequest,media,image
+@@||vidible.tv/prod/player/js/$script
+||vidible.tv/prod/player/js/$script
 ||delivery.vidible.tv/jsonp/$script
 @@||delivery.vidible.tv/jsonp/$script
 ! LinkedIn in embed

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -155,6 +155,8 @@
 ! https://community.brave.com/t/ad-not-bloked-properly/63628
 ||readthedocs.org/api/v2/sustainability/$script,domain=pyexcel.org
 ! Embedded vidible video's
+@@||vidible.tv/prod/$script
+||vidible.tv/prod/$script
 ||delivery.vidible.tv/jsonp/$script
 @@||delivery.vidible.tv/jsonp/$script
 ! LinkedIn in embed


### PR DESCRIPTION
Messed the last commit, re-up'd a new pull.  A few sites are broken due to vidible.tv being blocked via disconnect. This will modify our current filter to be generic to allow videos.

Sample videos: 
`https://popculture.com/tv-shows/2019/07/03/seinfeld-leaving-hulu-migrate-warnermedia-streaming-service/`
`https://comicbook.com/2019/07/04/mad-magazine-shutdown-details-revealed/`
`https://www.stuff.co.nz/entertainment/celebrities/114009167/joe-jonas-and-sophie-turner-share-their-first-wedding-photo`

This script loads the video, and needs to be allowed:
`https://delivery.vidible.tv/jsonp/pid=58d1e0f7f78ced6518eee162/vid=5d19ece5b8bad37cea19c3a3/58d1b4a95095491a900c189d.js?.embeded=cms_video_plugin_chromeExtension&m.sitesection=world&m.disableadspreloading=true`
