### PR TITLE
Allow twitter images to be viewed on https://blog.batcommunity.org/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -242,9 +242,9 @@
 @@||reddit.com/r/$script,domain=deora.dev
 ! thehindu.com (https://github.com/brave/brave-browser/issues/4808)
 @@||thgim.com/static/js/ads.min.js$script,domain=thehindu.com
-! drudgereport.com (images not shown)
-||twimg.com^$image,domain=drudgereport.com
-@@||twimg.com^$image,domain=drudgereport.com
+! Fix twitter images 
+||twimg.com^$image,domain=drudgereport.com|batcommunity.org
+@@||twimg.com^$image,domain=drudgereport.com|batcommunity.org
 ! Anti-adblock: washingtonpost.com
 ||pubads.g.doubleclick.net^$xmlhttprequest,domain=washingtonpost.com
 @@||pubads.g.doubleclick.net^$xmlhttprequest,domain=washingtonpost.com


### PR DESCRIPTION
We're blocking twitter images on https://blog.batcommunity.org/2019/07/weeklyupdate-jun28-jul04/   

Lets allow twitter images to be viewed :)