### PR TITLE
Fixes for  https://blog.batcommunity.org/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -237,9 +237,11 @@
 ||static.maxmind.com^$~third-party
 @@||blog.maxmind.com^$~third-party
 @@||static.maxmind.com^$~third-party
-! Allow reddit on https://deora.dev/corgi/
+! Allow reddit extensions to be used
 ||reddit.com/r/$script,domain=deora.dev
+||reddit.com/comments/$domain=batcommunity.org
 @@||reddit.com/r/$script,domain=deora.dev
+@@||reddit.com/comments/$domain=batcommunity.org
 ! thehindu.com (https://github.com/brave/brave-browser/issues/4808)
 @@||thgim.com/static/js/ads.min.js$script,domain=thehindu.com
 ! Fix twitter images 

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -242,9 +242,9 @@
 @@||reddit.com/r/$script,domain=deora.dev
 ! thehindu.com (https://github.com/brave/brave-browser/issues/4808)
 @@||thgim.com/static/js/ads.min.js$script,domain=thehindu.com
-! drudgereport.com (images not shown)
-||twimg.com^$image,domain=drudgereport.com
-@@||twimg.com^$image,domain=drudgereport.com
+! Fix twitter images 
+||twimg.com^$image,domain=drudgereport.com|batcommunity.org
+@@||twimg.com^$image,domain=drudgereport.com|batcommunity.org
 ! Anti-adblock: washingtonpost.com
 ||pubads.g.doubleclick.net^$xmlhttprequest,domain=washingtonpost.com
 @@||pubads.g.doubleclick.net^$xmlhttprequest,domain=washingtonpost.com


### PR DESCRIPTION
Looks a little broken due to blocking of reddit.  https://blog.batcommunity.org/2019/07/weeklyupdate-jun28-jul04/

This will be removed once adblock-rust lands. (similar vain to https://github.com/brave/adblock-lists/pull/99)
