### PR TITLE
Adblock Tracking Script on https://www.healthline.com/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -179,6 +179,8 @@
 ||washingtonpost.com/pb/api/*/adblocker-feature$xmlhttprequest,first-party
 ! Fix blankpage issue https://github.com/brave/brave-browser/issues/4049
 ||dianomi.com/cgi-bin/smartads.pl$xmlhttprequest,domain=inc.com
+! Adblock-Tracking: healthline.com
+@@||healthline.com/scripts/advertising.js
 ! Adblock-Tracking: jpost.com
 @@||bitsngo.net/widget-scripts/extra_content/ads.js$script,domain=jpost.com
 ! Adblock-Tracking: thedailybeast.com


### PR DESCRIPTION
Just Adblock tracking script;

`https://www.healthline.com/scripts/advertising.js`

Script /advertising.js is blank.