### PR TITLE
Adblock Tracking Script on https://www.wired.co.uk/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -205,6 +205,8 @@
 @@||nyt.com/ads/google/adsbygoogle.js$script,domain=nytimes.com
 ! Anti-adblock: dreamdth.com
 @@||dreamdth.com/js/wutime_adblock/ads.js$script
+! Adblock-Tracking: wired.co.uk
+@@||wired.co.uk/static/js/ads.js
 ! Anti-adblock: notebookcheck.net / notebookcheck.com
 @@||notebook-check.com/ads.min.js$script,domain=notebookcheck.net|notebookcheck.com
 @@||static.h-bid.com/prebid/$script,domain=notebookcheck.net|notebookcheck.com


### PR DESCRIPTION
Just Adblock tracking script;

As seen on;

`https://www.wired.co.uk/article/best-privacy-browsers-and-chrome-alternatives`

source:
`var ads_not_blocked = true;`