### PR TITLE
Fix video playback on tomshardware

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -248,6 +248,8 @@
 ! Anti-adblock: washingtonpost.com
 ||pubads.g.doubleclick.net^$xmlhttprequest,domain=washingtonpost.com
 @@||pubads.g.doubleclick.net^$xmlhttprequest,domain=washingtonpost.com
+! Fix tomshardware.com/tomshardware.co.uk video playback
+@@||content.jwplatform.com^$xmlhttprequest,domain=tomshardware.com|tomshardware.co.uk
 ! Fix abcnews.go.com video playback
 @@||akamaihd.net/player/2.106.5/akamai/amp/chartbeatanalytics/Chartbeatanalytics.min.js$domain=abcnews.go.com
 ! Allow ads on DDG: brave-browser/issues#4533


### PR DESCRIPTION
The 2 urls being blocked:

`https://content.jwplatform.com/v2/media/zYBgfFoA?recommendations_playlist_id=NIsweH9n`
`https://content.jwplatform.com/v2/media/zYBgfFoA`

**Test tomshardware.co.uk url: (Near bottom)**
`https://www.tomshardware.co.uk/pc-case-atx-rgb-deal-sale,news-61088.html`

**Test tomshardware.com url: (Near bottom)**
`https://www.tomshardware.com/reviews/amd-radeon-rx_5700-rx_5700_xt,6216.html`