### PR TITLE
Stop wp pl ads from being generated

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -254,6 +254,8 @@
 @@||reddit.com/comments/$domain=batcommunity.org
 ! thehindu.com (https://github.com/brave/brave-browser/issues/4808)
 @@||thgim.com/static/js/ads.min.js$script,domain=thehindu.com
+! stop wp.pl ads from generating (https://github.com/brave/brave-browser/issues/4914)
+||wpcdn.pl/wpjslib/$script,third-party
 ! Fix twitter images 
 ||twimg.com^$image,domain=drudgereport.com|batcommunity.org
 @@||twimg.com^$image,domain=drudgereport.com|batcommunity.org


### PR DESCRIPTION
Intentionally didn't link directly to the github ticket due to potential referrer tracking to the site (trying to avoid any unwanted attention / arms-race)

Blocking this one script, stops ads and trackers from being generated and possibly making that site (and other wp.pl related sites) less buggy and quicker to load.

Tagged as regional (Polish sites only)

![wps](https://user-images.githubusercontent.com/1659004/61040720-40d5a800-a425-11e9-927d-c1fbb33e0f4d.png)

