### PR TITLE
Adblock Tracking Script on https://www.vice.com/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -189,6 +189,8 @@
 @@||bitsngo.net/widget-scripts/extra_content/ads.js$script,domain=jpost.com
 ! Adblock-Tracking: thedailybeast.com
 @@||thedailybeast.com/static/advert.js$script
+! Adblock-Tracking: vice.com
+@@||web-scripts.vice.com/ad.vice.com/$script
 ! Anti-adblock: stream2watch.ws
 @@||stream2watch.ws/js/advertisement.js$script
 ! Fix facebook logins on messenger.com https://github.com/brave/brave-browser/issues/4173


### PR DESCRIPTION
Just Adblock tracking script;

As seen on;

`https://www.vice.com/en_asia/article/xwn9yw/this-japanese-magazine-celebrates-creative-collaborators-rockstar-couples-and-ex-yakuza-love-stories`

Specific script, and its Adblock tracking payload:

`​https://web-scripts.vice.com/ad.vice.com/v1.0.4/ads.js`

`"use strict";window.adsloading=!0;`