### PR TITLE
Fix ebay image upload brave/brave-browser#5190

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -242,6 +242,9 @@
 ! ebay.co.uk + ebay.com and other ebay regions (https://github.com/brave/brave-browser/issues/5019)
 ||ebay.com/experience/listing_auto_complete/$xmlhttprequest
 @@||ebay.com/experience/listing_auto_complete/$xmlhttprequest
+! ebay image upload issue (https://github.com/brave/brave-browser/issues/5190)
+||ebay.com/ws/$xmlhttprequest
+@@||ebay.com/ws/$xmlhttprequest
 ! fix first-party items on maxmind.com (https://community.brave.com/t/stop-blocking-the-website-for-maxmind-com/68326)
 ||blog.maxmind.com^$~third-party
 ||static.maxmind.com^$~third-party


### PR DESCRIPTION
Easy fix, specific for ebay, made it generic because it could be affecting a few scripts used by ebay

The specifc script:

`https://msa-b1.cgi5.ebay.com/ws/eBayISAPI.dll`