### PR TITLE
Merge outbrain scripts from Fanboy Annoyances List

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -272,6 +272,13 @@
 ! Allow ads on DDG: brave-browser/issues#4533
 @@||duckduckgo.com/m.js
 @@||duckduckgo.com/share/spice/amazon/
+! Outbrain scripts
+/cdn-cgi/pe/bag2?*odb.outbrain.com
+/outbrain-load-
+/outbrain.js
+/outbrain/base?
+/outbrain?
+||outbrainimg.com^$third-party
 ! Japanese specific rules below (temporarily)
 /ad/alliance_
 /loadPopIn.


### PR DESCRIPTION
Disconnect already blocks outbrain.com, this just covers the scripts the load or check on outbrain. And one domain not covered by disconnect