### PR TITLE
Merge taboola scripts from Fanboy Annoyances List

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -272,6 +272,21 @@
 ! Allow ads on DDG: brave-browser/issues#4533
 @@||duckduckgo.com/m.js
 @@||duckduckgo.com/share/spice/amazon/
+! Taboola scripts
+-taboola-article.
+-taboola-loader.
+/components/taboola/*
+/modulo/taboola/*
+/taboola-iframe/*
+/taboola.js
+/taboola/footer.
+/taboola/head.
+/taboola_header.
+/taboolaArticleFooter.
+/taboolaArticleHead.
+/taboolaBottomBody.
+/taboolaHead.
+||taboolasyndication.com^$third-party
 ! Outbrain scripts
 /cdn-cgi/pe/bag2?*odb.outbrain.com
 /outbrain-load-


### PR DESCRIPTION
Like Outbrain, we don't block taboola scripts. We block taboola domain via disconnect list. These are the scripts that will either check or load taboola.