### PR TITLE
Fix Anti-adblock, forced ads on gfycat.com (reported https://community.brave.com/t/pages-loads-3rd-party-ads-after-page-loads/71472/10)

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -264,6 +264,8 @@
 @@||thgim.com/static/js/ads.min.js$script,domain=thehindu.com
 ! stop wp.pl ads from generating (https://github.com/brave/brave-browser/issues/4914)
 ||wpcdn.pl/wpjslib/$script,third-party
+! gifycat.com ads (https://community.brave.com/t/pages-loads-3rd-party-ads-after-page-loads/71472/10)
+||ga.gfycat.com^$script,domain=gfycat.com
 ! Fix twitter images 
 ||twimg.com^$image,domain=drudgereport.com|batcommunity.org
 @@||twimg.com^$image,domain=drudgereport.com|batcommunity.org


### PR DESCRIPTION
As a user reported an issue with force ads due to use of 'Instart Logic', this can be reviewed once Ubo filter fixes land. but this commit should help mitigate most of it.