### PR TITLE
Fix playback issue on http://v6.player.abacast.net/6508

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -206,6 +206,11 @@
 @@||wallpapershome.com/scripts/ads.js$script
 ! Anti-adblock: haaretz.com
 @@||haaretz.com/htz/js/advertisement.js
+! Fix Playback on http://v6.player.abacast.net/6508 (https://community.brave.com/t/problem-loading-http-v6-player-abacast-net-6508/71822)
+||imasdk.googleapis.com/js/core/$subdocument,domain=player.abacast.net
+@@||imasdk.googleapis.com/js/core/$subdocument,domain=player.abacast.net
+||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=player.abacast.net
+@@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=player.abacast.net
 ! Anti-adblock: mediaite.com
 @@||mediaite.com/adbait/adsbygoogle.js
 ! rambler.ru css issues (https://community.brave.com/t/broken-formatting-on-specific-websites-when-using-brave-or-firefox/68023)


### PR DESCRIPTION
Testing this needed a bit of work on `http://v6.player.abacast.net/6508` since it'd work once the site/google saved its cookies, so using private mode and clearing cookies. A single cookie check for "GoogleAdServingTest" If the site doesn't see this cookie, it'll stop the site loading correctly. Seems to simple Anti-adblock cookie check.

We could fix this properly via ubo filters.

This involves 2 google scripts, Needed 2 fixes. one fix needed in Easylist:

`||imasdk.googleapis.com/js/sdkloader/ima3.js`

https://github.com/easylist/easylist/commit/cd8acfd312c999f0c4ccde11ef46b3ee34b43045

ima3.js, loads an additional script that we have a generic filter (because it caused many issues, and only is applicable when loaded from another whitelist)

In Easylist already;
`@@||imasdk.googleapis.com/js/core/bridge*.html$subdocument,domain=~spotify.com`

Reported here:
https://community.brave.com/t/problem-loading-http-v6-player-abacast-net-6508/71822

