### PR TITLE
Allow xmlhttp to work on lenta.ru

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -209,8 +209,8 @@
 ! Anti-adblock: mediaite.com
 @@||mediaite.com/adbait/adsbygoogle.js
 ! rambler.ru css issues (https://community.brave.com/t/broken-formatting-on-specific-websites-when-using-brave-or-firefox/68023)
-||rambler.ru^$stylesheet,domain=lenta.ru
-@@||rambler.ru^$stylesheet,domain=lenta.ru
+||rambler.ru^$stylesheet,xmlhttprequest,domain=lenta.ru
+@@||rambler.ru^$stylesheet,xmlhttprequest,domain=lenta.ru
 ! Adblock-Tracking: nytimes.com
 @@||nyt.com/ads/google/adsbygoogle.js$script,domain=nytimes.com
 ! Anti-adblock: dreamdth.com


### PR DESCRIPTION
We need to allow the following script to work; and fix rendering of other elements
`​https://keenwilling.rambler.ru/bywnzzbbzi/MWdoaTJrLjlsMXVwQHsiZG..` (xmlhttp)

Tested on `https://lenta.ru/news/2019/07/22/fsin/`