### PR TITLE
Anti-adblock tracking: dslreports.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -222,6 +222,8 @@
 @@||nyt.com/ads/google/adsbygoogle.js$script,domain=nytimes.com
 ! Anti-adblock: dreamdth.com
 @@||dreamdth.com/js/wutime_adblock/ads.js$script
+! Adblock-Tracking: dslreports.com
+@@||dslr.net/css/ads.js$script,domain=dslreports.com
 ! Adblock-Tracking: wired.co.uk
 @@||wired.co.uk/static/js/ads.js
 ! Anti-adblock: 9anime


### PR DESCRIPTION
Anti-adblock tracking script

Seen on homepaghe `https://www.dslreports.com/` `https://www.dslreports.com/forums/all`

Source:
`https://i.dslr.net/css/ads.js`
`document.write('<div id="adsense" style="visibility: hidden;">yipee! an advertisement</div>');`