### PR TITLE
Make gfycat.com block a little more specific

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -277,7 +277,7 @@
 ! stop wp.pl ads from generating (https://github.com/brave/brave-browser/issues/4914)
 ||wpcdn.pl/wpjslib/$script,third-party
 ! gifycat.com ads (https://community.brave.com/t/pages-loads-3rd-party-ads-after-page-loads/71472/10)
-||ga.gfycat.com^$script,domain=gfycat.com
+||daf77c42.ga.gfycat.com^$script,domain=gfycat.com
 ! Fix twitter images 
 ||twimg.com^$image,domain=drudgereport.com|batcommunity.org
 @@||twimg.com^$image,domain=drudgereport.com|batcommunity.org


### PR DESCRIPTION
||ga.gfycat.com^ might be too generic causing false positives.

Currently `https://gfycat.com/` is boken, this hopefully will help. if not I'll have another idea to fix this.

Blocks this script specifically, doesn't seem to change.
`https://daf77c42.ga.gfycat.com/3df94ccab771b057d2b03ff8c56ad826`