### PR TITLE
Anti-adblock Tracking on theintercept.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -175,6 +175,8 @@
 ! 2mdn video playback script
 ||2mdn.net/instream/html5/ima3.js$script,domain=zdnet.com|techrepublic.com
 @@||2mdn.net/instream/html5/ima3.js$script,domain=zdnet.com|techrepublic.com
+! Adblock-Tracking: theintercept.com
+@@||theintercept.com/ads.js$script,domain=theintercept.com
 ! Adblock-Tracking: cbs sites
 @@||cbsistatic.com^*/advertisement*.js$script,domain=zdnet.com|techrepublic.com
 ! Fix https://github.com/brave/brave-browser/issues/4507 (mirrors uBO fix, rewritten so that brave/ad-block supports)


### PR DESCRIPTION
Just a Adblock tracking script: `https://theintercept.com/ads.js`

source;

`(function() {`
 ` var element = document.getElementById('ad-block-test');`
`  if (element) {`
 `   element.setAttribute('data-blocked', 'false');`
`  }`
`})();`