### PR TITLE
Anti-adblock on securenetsystems.net

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -234,6 +234,8 @@
 ! Anti-adblock: 9anime
 @@||9anime.vip/assets/js/ads.js$script,domain=9anime.vip
 @@||animecdn.xyz/js/ads.js$script,domain=9animes.ru
+! Anti-adblock: securenetsystems.net
+@@||securenetsystems.net/v5/scripts/ads/prebid.js$script,domain=securenetsystems.net
 ! Adblock-Tracking: softonic.com
 @@||sftcdn.net/statics/ads.min.js$xmlhttprequest,domain=softonic.com
 ! Anti-adblock: thehindu.com


### PR DESCRIPTION
Simple anti-adblock script; `https://streamdb3web.securenetsystems.net/v5/scripts/ads/prebid.js`

Test link: `https://streamdb3web.securenetsystems.net/v5/index.cfm?stationCallSign=WRJB&retry=true&playSessionID=C81B5FB9-93E8-9BCB-C0E2768583A49FF8`

Reported here: `https://community.brave.com/t/https-streamdb3web-securenetsystems-net-v5-wrjb/73011/4`

Is used to detect Adblock: (source)

`var iExist = true;`