### PR TITLE
Anti-adblock Tracking on idg sites

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -280,6 +280,13 @@
 ||reddit.com/comments/$domain=batcommunity.org
 @@||reddit.com/r/$script,domain=deora.dev
 @@||reddit.com/comments/$domain=batcommunity.org
+! Adblock-Tracking: idg sites 
+@@||networkworld.com/www/js/ads/ads.js$script,domain=networkworld.com
+@@||cio.com/www/js/ads/ads.js$script,domain=cio.com
+@@||csoonline.com/www/js/ads/ads.js$script,domain=csoonline.com
+@@||infoworld.com/www/js/ads/ads.js$script,domain=infoworld.com
+@@||itwhitepapers.com/www/js/ads/ads.js$script,domain=itwhitepapers.com
+@@||javaworld.com/www/js/ads/ads.js$script,domain=javaworld.com
 ! ssrn.com login fix
 ||assets.adobedtm.com^$script,domain=ssrn.com
 @@||assets.adobedtm.com^$script,domain=ssrn.com


### PR DESCRIPTION
Same script used on many idg sites.

`https://www.networkworld.com/www/js/ads/ads.js`

`var canRunAds=true;`

`https://www.computerworld.com/www/js/ads/ads.js`

`var canRunAds=true;`

**Sources:**

`https://www.networkworld.com/`
`https://www.javaworld.com/`
`https://resourcelibrary.itwhitepapers.com/`
`https://www.infoworld.com/`
`https://www.computerworld.com/`
`https://www.cio.com/`