### PR TITLE
Fix Adblock on brave/brave-browser#5456

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -296,8 +296,9 @@
 @@||assets.adobedtm.com^$script,domain=ssrn.com
 ! thehindu.com (https://github.com/brave/brave-browser/issues/4808)
 @@||thgim.com/static/js/ads.min.js$script,domain=thehindu.com
-! stop wp.pl ads from generating (https://github.com/brave/brave-browser/issues/4914)
-||wpcdn.pl/wpjslib/$script,third-party
+! wp.pl / dobreprogramy.pl (fix) 
+@@||wp.pl/mtgx$script,domain=dobreprogramy.pl
+||wp.pl^$script,domain=dobreprogramy.pl
 ! gifycat.com ads (https://community.brave.com/t/pages-loads-3rd-party-ads-after-page-loads/71472/10)
 ||ga.gfycat.com^$script,domain=gfycat.com
 ! Fix twitter images 

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -297,8 +297,8 @@
 ! thehindu.com (https://github.com/brave/brave-browser/issues/4808)
 @@||thgim.com/static/js/ads.min.js$script,domain=thehindu.com
 ! wp.pl / dobreprogramy.pl (https://github.com/brave/brave-browser/issues/5456)
+||wp.pl/mtgx$script,domain=dobreprogramy.pl
 @@||wp.pl/mtgx$script,domain=dobreprogramy.pl
-||wp.pl^$script,domain=dobreprogramy.pl
 ! gifycat.com ads (https://community.brave.com/t/pages-loads-3rd-party-ads-after-page-loads/71472/10)
 ||ga.gfycat.com^$script,domain=gfycat.com
 ! Fix twitter images 

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -296,7 +296,7 @@
 @@||assets.adobedtm.com^$script,domain=ssrn.com
 ! thehindu.com (https://github.com/brave/brave-browser/issues/4808)
 @@||thgim.com/static/js/ads.min.js$script,domain=thehindu.com
-! wp.pl / dobreprogramy.pl (fix) 
+! wp.pl / dobreprogramy.pl (https://github.com/brave/brave-browser/issues/5456)
 @@||wp.pl/mtgx$script,domain=dobreprogramy.pl
 ||wp.pl^$script,domain=dobreprogramy.pl
 ! gifycat.com ads (https://community.brave.com/t/pages-loads-3rd-party-ads-after-page-loads/71472/10)


### PR DESCRIPTION
This reverts a previous commit https://github.com/brave/brave-browser/issues/4914, seems they now want the script to load or the site won't render.

So another stab at this, seems if we block one script, and only whitelist a non-ad script. It'll render correctly.

Test urls: `https://www.dobreprogramy.pl/Razer-Viper-esportowa-mysz-z-przelacznikami-optycznymi,News,103064.html`
`https://www.dobreprogramy.pl/Instalujemy-Ferro-Backup-System.-Archiwizacja-danych-w-kilku-krokach,Wideo,102811.html`
`https://www.dobreprogramy.pl/AMD-tlumaczy-Procesory-Zen-2-sa-odporne-na-wszystkie-znane-luki-sprzetowe,News,102339.html`