### PR TITLE
Anti-adblock Tracking for adziff.com-related sites

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -291,6 +291,8 @@
 @@||infoworld.com/www/js/ads/ads.js$script,domain=infoworld.com
 @@||itwhitepapers.com/www/js/ads/ads.js$script,domain=itwhitepapers.com
 @@||javaworld.com/www/js/ads/ads.js$script,domain=javaworld.com
+! adziff ad tracking
+@@||adziff.com/ab/ads.js$xmlhttprequest,domain=pcmag.com|geek.com|extremetech.com
 ! ssrn.com login fix
 ||assets.adobedtm.com^$script,domain=ssrn.com
 @@||assets.adobedtm.com^$script,domain=ssrn.com


### PR DESCRIPTION
`https://static.adziff.com/ab/ads.js`
`ad`

**Sources:**
`https://www.extremetech.com/extreme/296147-this-alien-planet-is-so-hot-it-bleeds-metal`
`https://www.pcmag.com/`
`https://www.geek.com/television/what-to-stream-on-netflix-this-weekend-1755701/`