### PR TITLE
Anti-adblock for https://transparentcalifornia.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -229,6 +229,8 @@
 @@||nyt.com/ads/google/adsbygoogle.js$script,domain=nytimes.com
 ! Anti-adblock: dreamdth.com
 @@||dreamdth.com/js/wutime_adblock/ads.js$script
+! Anti-adblock: transparentcalifornia.com
+@@||transparentcalifornia.com/static/js/ads.js$script,domain=transparentcalifornia.com
 ! Adblock-Tracking: dslreports.com
 @@||dslr.net/css/ads.js$script,domain=dslreports.com
 ! Adblock-Tracking: wired.co.uk


### PR DESCRIPTION
Source: 
`https://transparentcalifornia.com/`

Prevents Anti-adblock popup from showing, Can show screenshot if need be.

`https://transparentcalifornia.com/static/js/ads.js`

`// Technique via http://www.detectadblock.com/`
`var e=document.createElement('div');`
`e.id='BF33E649-230F-4CA6-A5A8-AC1A7D6A2CA1';`
`e.style.display='none';`
`document.body.appendChild(e);`