### PR TITLE
Fix ip-approval: https://community.brave.com/t/cannot-log-on-to-mufon-com-with-brave/74565/2

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -235,6 +235,8 @@
 @@||dslr.net/css/ads.js$script,domain=dslreports.com
 ! Adblock-Tracking: wired.co.uk
 @@||wired.co.uk/static/js/ads.js
+! ip-approval bug
+||ip-approval.com^$third-party,domain=mufon.com
 ! Anti-adblock: 9anime
 @@||9anime.vip/assets/js/ads.js$script,domain=9anime.vip
 @@||animecdn.xyz/js/ads.js$script,domain=9animes.ru


### PR DESCRIPTION
Site uses a 3rd-party checker, which according to ip-approval we're invalid. We can push it out, and then revert this change when its fixed, or wait a few more days to see if they fix it.

`https://community.brave.com/t/cannot-log-on-to-mufon-com-with-brave/74565`

**Current message if you visit mufon.com without this filter:**

`Unauthorized Domain`
`The website you were trying to visit, was not authorized to use our code.`



`Please contact the website owner about this issue.`
`If you are the website owner, please login and edit your IP Approval - IP Editor settings.`