### PR TITLE
Anti-adblock tracking on sourceforge.net / slashdot.org

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -203,6 +203,9 @@
 ||mdn.neowin.net^$domain=neowin.net
 ! Anti-adblock: stream2watch.ws
 @@||stream2watch.ws/js/advertisement.js$script
+! Adblock-Tracking: sourceforge.net / slashdot.org 
+@@||fsdn.com/con/js/adframe.js$script,domain=sourceforge.net
+@@||fsdn.com/sd/js/scripts/ad.js$script,domain=slashdot.org
 ! Fix facebook logins on messenger.com https://github.com/brave/brave-browser/issues/4173
 ||facebook.com/login/$domain=messenger.com
 ||connect.facebook.net^$domain=messenger.com


### PR DESCRIPTION
On: `https://sourceforge.net/`


`https://a.fsdn.com/con/js/adframe.js`
`/*global SF */`
`SF.adblock = false;`

On `https://slashdot.org/`

`https://a.fsdn.com/sd/js/scripts/ad.js`
`isAdBlockActive = false;`