### PR TITLE
Anti-adblock tracking: salon.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -285,6 +285,8 @@
 @@||list-manage.com/signup-form/subscribe?$domain=mailchi.mp
 ||list-manage.com/signup-form/settings?$domain=mailchi.mp
 @@||list-manage.com/signup-form/settings?$domain=mailchi.mp
+! Adblock-Tracking: salon.com
+@@||salon.com/design/assets/ads.js$script,domain=salon.com
 ! ebay.co.uk + ebay.com and other ebay regions (https://github.com/brave/brave-browser/issues/5019)
 ||ebay.com/experience/listing_auto_complete/$xmlhttprequest
 @@||ebay.com/experience/listing_auto_complete/$xmlhttprequest


### PR DESCRIPTION
As seen on 

`https://www.salon.com/2019/08/05/what-8chan-is-and-why-far-right-terrorists-flock-to-it/`

`https://www.salon.com/design/assets/ads.js`
`var valid_user=true;`