### PR TITLE
Fix blank page on https://bandai-hobby.net/sw/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -298,6 +298,11 @@
 ||static.maxmind.com^$~third-party
 @@||blog.maxmind.com^$~third-party
 @@||static.maxmind.com^$~third-party
+! bandai-hobby.net (maxmind check causing blank pages)
+||js.maxmind.com/js/apis/geoip2/v2.1/geoip2.js$script,domain=bandai-hobby.net
+||geoip-js.maxmind.com/geoip/$xmlhttprequest,domain=bandai-hobby.net
+@@||js.maxmind.com/js/apis/geoip2/v2.1/geoip2.js$script,domain=bandai-hobby.net
+@@||geoip-js.maxmind.com/geoip/$xmlhttprequest,domain=bandai-hobby.net
 ! ABP Japanese blocking Aliexpress (https://github.com/k2jp/abp-japanese-filters/issues?utf8=✓&q=is%3Aissue+aliexpress)
 @@||aliexpress.com^$~third-party
 ! Allow reddit extensions to be used


### PR DESCRIPTION
Blank page caused by maxmind on `https://bandai-hobby.net/sw/`

Fixed in EP: https://github.com/easylist/easylist/commit/86fe778758d8ee8f4814e23b2d1d1ab18c6ef736