### PR TITLE
Allow twitter api readahead

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -86,6 +86,9 @@
 ! Allow sites to use reddit api
 ||reddit.com^*/.json?$script,third-party
 @@||reddit.com^*/.json?$script,third-party
+! Allow twitter.com readahead (using the twitter api)
+||twitter.com/i/search/typeahead.json$$third-party
+@@||twitter.com/i/search/typeahead.json$third-party
 ! DDG 1P analytics and optimization
 @@||improving.duckduckgo.com^$~third-party
 ! Disable PDFJS which we include by default's telemetry


### PR DESCRIPTION
We were notified on twitter by @HubertGAM, that `https://twitter.com/HubertGAM/status/1161776282587271175` we're breaking twitter user retreival api.

I haven't got a login to test, but going by the user screenshot it seems safe enough?