### PR TITLE
Fix CSS issues with wp.pl as seen on https://prawo.money.pl/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -339,6 +339,9 @@
 ! wp.pl / dobreprogramy.pl (https://github.com/brave/brave-browser/issues/5456)
 ||wp.pl/mtgx$script,domain=dobreprogramy.pl
 @@||wp.pl/mtgx$script,domain=dobreprogramy.pl
+! wp.pl stylesheet issues on https://prawo.money.pl/
+||wp.pl^$stylesheet,third-party
+@@||wp.pl^$stylesheet,third-party
 ! gifycat.com ads (https://community.brave.com/t/pages-loads-3rd-party-ads-after-page-loads/71472/10)
 ||ga.gfycat.com^$script,domain=gfycat.com
 ! Fix twitter images 


### PR DESCRIPTION
wp.pl is also hosting stylesheets. As seen on `https://prawo.money.pl/`

Should be safe to allow, scripts still remain blocked. Given the high use of wp.pl on Polish sites , I made it generic.