### PR TITLE
Fix api.ebay.com issues (https://community.brave.com/t/ebay-vehicle-compatibility-windows-10-brave-browser-something-went-wrong-reload/76021)

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -303,6 +303,9 @@
 ! ebay image upload issue (https://github.com/brave/brave-browser/issues/5190)
 ||ebay.com/ws/$xmlhttprequest
 @@||ebay.com/ws/$xmlhttprequest
+! api.ebay.com (https://community.brave.com/t/referral-not-getting-download-and-comfirmed/75898)
+||api.ebay.com^$xmlhttprequest,subdocument
+@@||api.ebay.com^$xmlhttprequest,subdocument
 ! Anti-adblock ign.com
 ||g01.ign.com^$script,domain=ign.com
 ! fix first-party items on maxmind.com (https://community.brave.com/t/stop-blocking-the-website-for-maxmind-com/68326)


### PR DESCRIPTION
Was reported here; `https://community.brave.com/t/ebay-vehicle-compatibility-windows-10-brave-browser-something-went-wrong-reload/76021`

Affects the following ebay scripts (and probably all ebay regional domains)

`https://api.ebay.com/user/v1/personalized_vehicle?fields=garageProducts&vehicle_marketplaceId=EBAY-GB&categoryId=174087 (xmlhttprequest)`
`https://api.ebay.com/parts_compatibility/v1/compatible_products/listing/401850440298?fieldgroups=full&limit=20  (xmlhttprequest)`
`https://api.ebay.com/sifr.html (subdocument)`