### PR TITLE
Anti-adblock on https://geoguessr.com/world/play

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -331,6 +331,8 @@
 @@||javaworld.com/www/js/ads/ads.js$script,domain=javaworld.com
 ! adziff ad tracking
 @@||adziff.com/ab/ads.js$xmlhttprequest,domain=pcmag.com|geek.com|extremetech.com
+! Anti-adblock: geoguessr.com
+@@||geoguessr.com/_ads/$script,domain=geoguessr.com
 ! ssrn.com login fix
 ||assets.adobedtm.com^$script,domain=ssrn.com
 @@||assets.adobedtm.com^$script,domain=ssrn.com

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -332,7 +332,7 @@
 ! adziff ad tracking
 @@||adziff.com/ab/ads.js$xmlhttprequest,domain=pcmag.com|geek.com|extremetech.com
 ! Anti-adblock: geoguessr.com
-@@||geoguessr.com/_ads/$script,domain=geoguessr.com
+@@||geoguessr.com/_ads/$script,xmlhttprequest,domain=geoguessr.com
 ! ssrn.com login fix
 ||assets.adobedtm.com^$script,domain=ssrn.com
 @@||assets.adobedtm.com^$script,domain=ssrn.com


### PR DESCRIPTION
Will detect adblock on `https://geoguessr.com/world/play` Will prevent user from accessing the site.

`It looks like you are using an ad blocker`
`The internet is full of ads these days, and we totally understand that you are using an ad blocker.`

`Unfortunately, running a website with millions of users costs a lot of money, and running GeoGuessr would not be possible without it.`

`We kindly ask you to disable the ad blocker while playing GeoGuessr so we all can continue exploring the world!`

