### PR TITLE
Anti-adblock tracking on Prometheus Global Media sites

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -344,6 +344,8 @@
 ! Fix twitter images 
 ||twimg.com^$image,domain=drudgereport.com|batcommunity.org
 @@||twimg.com^$image,domain=drudgereport.com|batcommunity.org
+! Anti-adblock tracking Prometheus Global Media
+@@||pgmcdn.com/advertisement.js$script,domain=billboard.com|hollywoodreporter.com|vibe.com
 ! Anti-adblock: washingtonpost.com
 ||pubads.g.doubleclick.net^$xmlhttprequest,domain=washingtonpost.com
 @@||pubads.g.doubleclick.net^$xmlhttprequest,domain=washingtonpost.com


### PR DESCRIPTION
Anti-adblock tracking from these domains;

`https://www.billboard.com/articles/columns/pop/8527595/first-stream-normani-taylor-swift-young-thug-miley-cyrus`

`https://www.hollywoodreporter.com/features/why-hollywood-studio-film-producer-deals-are-disappearing-1231089`

`https://www.vibe.com/2019/08/new-music-friday-snoop-dogg-young-thug-quality-control-aap-ferg-and-more`

Only covers these domains, and not their other domains `spin.com` and `stereogum.com` which don't seem to use it. 

**Source:**
`window['noBlocker'] = true;`