### PR TITLE
Anti-adblock Tracking on reddit.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -87,7 +87,7 @@
 ||reddit.com^*/.json?$script,third-party
 @@||reddit.com^*/.json?$script,third-party
 ! Adblock Tracking
-@@||redditstatic.com/desktop2x/js/ads.js$script,domain=reddit.com
+@@/^https?:\/\/www.redditstatic.com\/[a-z0-9]{4,}\/.*\/ads.js/$script,domain=reddit.com
 ! Allow twitter.com readahead (using the twitter api)
 ||twitter.com/i/search/typeahead.json$$third-party
 @@||twitter.com/i/search/typeahead.json$third-party

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -86,6 +86,8 @@
 ! Allow sites to use reddit api
 ||reddit.com^*/.json?$script,third-party
 @@||reddit.com^*/.json?$script,third-party
+! Adblock Tracking
+@@||redditstatic.com/desktop2x/js/ads.js$script,domain=reddit.com
 ! Allow twitter.com readahead (using the twitter api)
 ||twitter.com/i/search/typeahead.json$$third-party
 @@||twitter.com/i/search/typeahead.json$third-party


### PR DESCRIPTION
Applicable and only seen on `www.reddit.com` and `old.reddit.com`. Desktop only, mobile reddit seems to be not applicable

`https://www.redditstatic.com/desktop2x/js/ads.js`

**Source:**

`var e=document.createElement('div');`
`e.id='a2ba06a4-a2ec-4182-b295-c15ffe5f1181';`
`e.style.display='none';`
`document.body.appendChild(e);`