### PR TITLE
Fix test push notifications on https://onesignal.com/webpush

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -191,8 +191,8 @@
 ! Fix blankpage issue https://github.com/brave/brave-browser/issues/4049
 ||dianomi.com/cgi-bin/smartads.pl$xmlhttprequest,domain=inc.com
 ! Fix onesignal.com example push notifications
-||www.googletagmanager.com/gtm.js$script,domain=onesignal.com
-@@||www.googletagmanager.com/gtm.js$script,domain=onesignal.com
+||googletagmanager.com/gtm.js$script,domain=onesignal.com
+@@||googletagmanager.com/gtm.js$script,domain=onesignal.com
 ! Anti-adblock: newsmax.com
 @@||newsmax.com/js/ads.adblock.js$script,domain=newsmax.com
 ! Adblock-Tracking: healthline.com

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -190,6 +190,9 @@
 ||washingtonpost.com/pb/api/*/adblocker-feature$xmlhttprequest,first-party
 ! Fix blankpage issue https://github.com/brave/brave-browser/issues/4049
 ||dianomi.com/cgi-bin/smartads.pl$xmlhttprequest,domain=inc.com
+! Fix onesignal.com example push notifications
+||www.googletagmanager.com/gtm.js$script,domain=onesignal.com
+@@||www.googletagmanager.com/gtm.js$script,domain=onesignal.com
 ! Anti-adblock: newsmax.com
 @@||newsmax.com/js/ads.adblock.js$script,domain=newsmax.com
 ! Adblock-Tracking: healthline.com


### PR DESCRIPTION
From `https://onesignal.com/webpush` Under see Example 1/2 down the page. the example will won't launch the push notifications correctly because googletagmanager is tied to it.  

Whitelisting the script will show the onesignal push notification.  Only applicable to the site onesignal.com and not other 3rd-party sites.

#edit
Was reported also: `https://community.brave.com/t/onesignal-notifications-are-not-received/76252`

Was also added to EP.