### PR TITLE
Fix Antiadblock on https://www.thehindu.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -195,6 +195,8 @@
 @@||googletagmanager.com/gtm.js$script,domain=onesignal.com
 ! Anti-adblock: newsmax.com
 @@||newsmax.com/js/ads.adblock.js$script,domain=newsmax.com
+! Anti-adblock: thehindu.com
+@@||thgim.com/static/js/ads.min.js$script,domain=thehindu.com
 ! Adblock-Tracking: healthline.com
 @@||healthline.com/scripts/advertising.js
 ! Adblock-Tracking: jpost.com


### PR DESCRIPTION
Anti-adblock on `https://www.thehindu.com/`

`https://th.thgim.com/static/js/ads.min.js`
Source: 
`Adblock=false;`