### PR TITLE
Fix broken search on https://www.capitalone.com/search

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -246,6 +246,8 @@
 @@||dreamdth.com/js/wutime_adblock/ads.js$script
 ! Anti-adblock: transparentcalifornia.com
 @@||transparentcalifornia.com/static/js/ads.js$script,domain=transparentcalifornia.com
+! Broken search on https://www.capitalone.com/search
+@@||nexus.ensighten.com/capitalone/Bootstrap.js$script,domain=capitalone.com
 ! Adblock-Tracking: dslreports.com
 @@||dslr.net/css/ads.js$script,domain=dslreports.com
 ! Adblock-Tracking: wired.co.uk

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -247,6 +247,7 @@
 ! Anti-adblock: transparentcalifornia.com
 @@||transparentcalifornia.com/static/js/ads.js$script,domain=transparentcalifornia.com
 ! Broken search on https://www.capitalone.com/search
+||nexus.ensighten.com/capitalone/Bootstrap.js$script,domain=capitalone.com
 @@||nexus.ensighten.com/capitalone/Bootstrap.js$script,domain=capitalone.com
 ! Adblock-Tracking: dslreports.com
 @@||dslr.net/css/ads.js$script,domain=dslreports.com


### PR DESCRIPTION
Following script: `https://nexus.ensighten.com/capitalone/Bootstrap.js` causing issues when a user trys to search on `https://www.capitalone.com/search`

Was reported here; https://twitter.com/aJimHolmes/status/1164633821842513920