### PR TITLE
Fix video playback on tn.com.ar (Reported on https://community.brave.com/t/the-blocker-does-not-allow-you-to-watch-the-video/76691)

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -203,6 +203,9 @@
 @@||explosm.net/js/adsense.js$script,domain=explosm.net
 ! Adblock-Tracking:  mediaite.com
 @@||mediaite.com/adbaitplus/adsbygoogle.js$script,domain=mediaite.com
+! Broken video playback on tn.com.ar (https://community.brave.com/t/the-blocker-does-not-allow-you-to-watch-the-video/76691)
+||googletagmanager.com/gtm.js$script,domain=tn.com.ar
+@@||googletagmanager.com/gtm.js$script,domain=tn.com.ar
 ! Adblock-Tracking: thedailybeast.com
 @@||thedailybeast.com/static/advert.js$script
 ! Adblock-Tracking: vice.com


### PR DESCRIPTION
was reported here: `https://community.brave.com/t/the-blocker-does-not-allow-you-to-watch-the-video/76691`

Video playback on this page is broken due to googletagmanager.com

`https://tn.com.ar/sociedad/el-video-que-muestra-como-grafitearon-los-vagones-del-subte_988278?fbclid=IwAR1jPvUGUmxBDEtUhpcw9NzfsNQ5IeYf3ubxQyWVD8XEXOwNwMcaiRpAql4`

Fixed in EP.
https://github.com/easylist/easylist/commit/cd30cfa995046ce5263d1b44b7aa06e76236bb02