### PR TITLE
Fix video playback on nfl.com and Anti-adblock tracking

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -371,6 +371,10 @@
 @@||wp.pl^$stylesheet,third-party
 ! gifycat.com ads (https://community.brave.com/t/pages-loads-3rd-party-ads-after-page-loads/71472/10)
 ||ga.gfycat.com^$script,domain=gfycat.com
+! Anti-adblock tracking: nfl.com
+@@||nflcdn.com^*/ad.js$script,domain=nfl.com
+! Fix nfl.com video playback
+@@||googletagservices.com/tag/js/gpt.js$script,domain=nfl.com
 ! Fix twitter images 
 ||twimg.com^$image,domain=drudgereport.com|batcommunity.org
 @@||twimg.com^$image,domain=drudgereport.com|batcommunity.org


### PR DESCRIPTION
**2 fixes for nfl.com:**

**Anti-adblock tracking;**
`http://s.nflcdn.com/static/site/7.5/scripts/ad.js`

**Source:** 
`var isAdsDisplayed = true;`

**Also fixes playback back:  (caused by googletagservices): Will prevent the video from displaying.**

`http://www.nfl.com/videos/nfl-game-highlights/0ap3000001043816/Mayfield-puts-arm-strength-on-display-on-LASER-pass`
