### PR TITLE
Anti-adblock Tracking on buzzfeed.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -341,6 +341,8 @@
 ||reddit.com/comments/$domain=batcommunity.org
 @@||reddit.com/r/$script,domain=deora.dev
 @@||reddit.com/comments/$domain=batcommunity.org
+! Adblock-Tracking: buzzfeed.com / buzzfeednews.com
+@@||buzzfeed.com/static/js/advertiser/ads.js$script,domain=buzzfeednews.com|buzzfeed.com
 ! Adblock-Tracking: idg sites 
 @@||networkworld.com/www/js/ads/ads.js$script,domain=networkworld.com
 @@||cio.com/www/js/ads/ads.js$script,domain=cio.com


### PR DESCRIPTION
Anti-adblock tracking on `https://www.buzzfeed.com/` and `https://www.buzzfeednews.com/`


`https://www.buzzfeed.com/static/js/advertiser/ads.js`

**Source:**

`if (typeof(window.BF_Scout) !== 'object') {`
  `window.BF_Scout = {};`
`}`
`window.BF_Scout.adBlocked = false;`