### PR TITLE
Adblock Tracking on https://www.computerbase.de/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -375,6 +375,8 @@
 ||ga.gfycat.com^$script,domain=gfycat.com
 ! Anti-adblock tracking: nfl.com
 @@||nflcdn.com^*/ad.js$script,domain=nfl.com
+! Adblock-Tracking: computerbase.de
+@@||computerbase.de/js/ads.$script,xmlhttprequest,domain=computerbase.de
 ! Fix nfl.com video playback
 @@||googletagservices.com/tag/js/gpt.js$script,domain=nfl.com
 ! Fix twitter images 


### PR DESCRIPTION
Anti-adblock tracking on `https://www.computerbase.de/2019-08/control-benchmark-raytracing-test/`


Script isn't actually viewable, seems they're trying to prevent people from viewing it directly.

Covers both requests; a script, and xmlhttp request.
`https://www.computerbase.de/js/ads.c28ef33a.js`