### PR TITLE
Anti-adblock Tracking on various newscorp sites

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -381,6 +381,8 @@
 @@||nflcdn.com^*/ad.js$script,domain=nfl.com
 ! Adblock-Tracking: computerbase.de
 @@||computerbase.de/js/ads.$script,xmlhttprequest,domain=computerbase.de
+! Adblock-Tracking: (News corp AU sites)
+@@||tags.news.com.au/prod/adblock/adblock.js$script,domain=cairnspost.com.au|ntnews.com.au|goldcoastbulletin.com.au|townsvillebulletin.com.au|themercury.com.au|news.com.au|taste.com.au|heraldsun.com.au|dailytelegraph.com.au|adelaidenow.com.au|bodyandsoul.com.au|bestrecipes.com.au|whimn.com.au|vogue.com.au|delicious.com.au|escape.com.au
 ! Fix nfl.com video playback
 @@||googletagservices.com/tag/js/gpt.js$script,domain=nfl.com
 ! Fix twitter images 

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -382,7 +382,7 @@
 ! Adblock-Tracking: computerbase.de
 @@||computerbase.de/js/ads.$script,xmlhttprequest,domain=computerbase.de
 ! Adblock-Tracking: (News corp AU sites)
-@@||tags.news.com.au/prod/adblock/adblock.js$script,domain=cairnspost.com.au|ntnews.com.au|goldcoastbulletin.com.au|townsvillebulletin.com.au|themercury.com.au|news.com.au|taste.com.au|heraldsun.com.au|dailytelegraph.com.au|adelaidenow.com.au|bodyandsoul.com.au|bestrecipes.com.au|whimn.com.au|vogue.com.au|delicious.com.au|escape.com.au
+@@||tags.news.com.au/prod/adblock/adblock.js$script,domain=cairnspost.com.au|ntnews.com.au|goldcoastbulletin.com.au|townsvillebulletin.com.au|themercury.com.au|news.com.au|taste.com.au|heraldsun.com.au|dailytelegraph.com.au|adelaidenow.com.au|bodyandsoul.com.au|bestrecipes.com.au|whimn.com.au|vogue.com.au|delicious.com.au|escape.com.au|weeklytimesnow.com.au|geelongadvertiser.com.au
 ! Fix nfl.com video playback
 @@||googletagservices.com/tag/js/gpt.js$script,domain=nfl.com
 ! Fix twitter images 


### PR DESCRIPTION
Newscorp in Australia own quite a few a few newspaper sites, they're checking on Adblock users. Using the same script on all the sites.

`https://publicwww.com/websites/%22tags.news.com.au%22/`

**Few Examples:** 
`https://www.cairnspost.com.au/`
`https://www.news.com.au/`
`https://www.ntnews.com.au/`
`https://www.townsvillebulletin.com.au/`

**Source:**
`window.utag_data=window.utag_data||`
`{},window.utag_data.no_adblocker=window.utag_data.no_adblocker||!0;`