### PR TITLE
Adblock tracking on MediaNews Group (News websites)

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -384,9 +384,8 @@
 ! Adblock-Tracking: (News corp AU sites)
 @@||tags.news.com.au/prod/adblock/adblock.js$script,domain=cairnspost.com.au|ntnews.com.au|goldcoastbulletin.com.au|townsvillebulletin.com.au|themercury.com.au|news.com.au|taste.com.au|heraldsun.com.au|dailytelegraph.com.au|adelaidenow.com.au|bodyandsoul.com.au|bestrecipes.com.au|whimn.com.au|vogue.com.au|delicious.com.au|escape.com.au|weeklytimesnow.com.au|geelongadvertiser.com.au
 ! Adblock-Tracking: MediaNews Group
-@@||ocregister.com/wp-content/themes/wp-mason/static/js/ads.js$script,domain=ocregister.com
-@@||bostonherald.com/wp-content/themes/wp-mason/static/js/ads.js$script,domain=bostonherald.com
-@@||denverpost.com/wp-content/themes/wp-mason/static/js/ads.js$script,domain=bostonherald.com
+@@||townnews.com^*/flex/components/ads/$script,domain=southernchestercountyweeklies.com|dailylocal.com|delcotimes.com|morningjournal.com|delconewsnetwork.com|montgomerynews.com|mainlinemedianews.com|news-herald.com|cnweekly.com|troyrecord.com|southjerseylocalnews.com|saratogian.com|oneidadispatch.com|dailyfreeman.com|trentonian.com|berksmontnews.com|thenewsherald.com|dailytribune.com|theoaklandpress.com|voicenews.com|themorningsun.com|pottsmerc.com|phoenixvillenews.com|timesherald.com|thereporteronline.com|pvnews.com|tbrnews.com|pressandguide.com|gazettes.com|macombdaily.com
+@@/static/js/ads.js$script,domain=redlandsdailyfacts.com|pasadenastarnews.com|dailybulletin.com|marinij.com|montereyherald.com|presstelegram.com|times-standard.com|chicoer.com|whittierdailynews.com|dailydemocrat.com|dailynews.com|ocregister.com|pe.com|buffzone.com|orovillemr.com|journal-advocate.com|reporterherald.com|broomfieldenterprise.com|record-bee.com|sentinelandenterprise.com|bostonherald.com|nashobavalleyvoice.com|eptrail.com|akronnewsreporter.com|willitsnews.com|redbluffdailynews.com|thevalleydispatch.com|twincities.com|burlington-record.com|fortmorgantimes.com|coloradodaily.com|lamarledger.com|timescall.com|canoncitydailyrecord.com|excelsiorcalifornia.com|advocate-news.com|paradisepost.com|redwoodtimes.com|denverpost.com|mendocinobeacon.com
 ! Fix nfl.com video playback
 @@||googletagservices.com/tag/js/gpt.js$script,domain=nfl.com
 ! Fix twitter images 

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -383,8 +383,10 @@
 @@||computerbase.de/js/ads.$script,xmlhttprequest,domain=computerbase.de
 ! Adblock-Tracking: (News corp AU sites)
 @@||tags.news.com.au/prod/adblock/adblock.js$script,domain=cairnspost.com.au|ntnews.com.au|goldcoastbulletin.com.au|townsvillebulletin.com.au|themercury.com.au|news.com.au|taste.com.au|heraldsun.com.au|dailytelegraph.com.au|adelaidenow.com.au|bodyandsoul.com.au|bestrecipes.com.au|whimn.com.au|vogue.com.au|delicious.com.au|escape.com.au|weeklytimesnow.com.au|geelongadvertiser.com.au
-! Adblock-Tracking: ocregister.com
+! Adblock-Tracking: MediaNews Group
 @@||ocregister.com/wp-content/themes/wp-mason/static/js/ads.js$script,domain=ocregister.com
+@@||bostonherald.com/wp-content/themes/wp-mason/static/js/ads.js$script,domain=bostonherald.com
+@@||denverpost.com/wp-content/themes/wp-mason/static/js/ads.js$script,domain=bostonherald.com
 ! Fix nfl.com video playback
 @@||googletagservices.com/tag/js/gpt.js$script,domain=nfl.com
 ! Fix twitter images 

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -383,6 +383,8 @@
 @@||computerbase.de/js/ads.$script,xmlhttprequest,domain=computerbase.de
 ! Adblock-Tracking: (News corp AU sites)
 @@||tags.news.com.au/prod/adblock/adblock.js$script,domain=cairnspost.com.au|ntnews.com.au|goldcoastbulletin.com.au|townsvillebulletin.com.au|themercury.com.au|news.com.au|taste.com.au|heraldsun.com.au|dailytelegraph.com.au|adelaidenow.com.au|bodyandsoul.com.au|bestrecipes.com.au|whimn.com.au|vogue.com.au|delicious.com.au|escape.com.au|weeklytimesnow.com.au|geelongadvertiser.com.au
+! Adblock-Tracking: ocregister.com
+@@||ocregister.com/wp-content/themes/wp-mason/static/js/ads.js$script,domain=ocregister.com
 ! Fix nfl.com video playback
 @@||googletagservices.com/tag/js/gpt.js$script,domain=nfl.com
 ! Fix twitter images 


### PR DESCRIPTION
Adblock tracking, as seen on `https://www.ocregister.com/2019/08/30/tyler-skaggs-died-of-fentanyl-oxycodone-alcohol-mixture-coroner-says/`

`https://www.ocregister.com/wp-content/themes/wp-mason/static/js/ads.js?ver=1.0`

**Source:**

`/* exported dfmCanRunAds */`

`// Determine if user can run ads`
`var dfmCanRunAds = true;`