### PR TITLE
Adblock tracking on tumblr-related sites

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -295,6 +295,8 @@
 ||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=foxbusiness.com|foxnews.com
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=foxbusiness.com|foxnews.com
 @@||fncstatic.com/static/isa/app/lib/VisitorAPI.js$script,domain=foxbusiness.com|foxnews.com
+! Adblock-Tracking: tumblr
+@@/assets/scripts/tumblr/dashboard/showads.js$script,~third-party
 ! Adblock-Tracking: ieee.org
 @@||ieee.org/assets/dist/js/ads.js$script,domain=ieee.org
 ! Adblock-Tracking: motherjones.com


### PR DESCRIPTION
Seen on both tumblr and tumblr custom domains.

`https://thanksforthemameries.tumblr.com/assets/scripts/tumblr/dashboard/showads.js`
`https://onegianthand.com/assets/scripts/tumblr/dashboard/showads.js`

`https://thanksforthemameries.tumblr.com/post/182938073496/this-is-the-lucky-test-post-in-a-text-post`

`https://onegianthand.com/`

Source /showads.js is blank.