### PR TITLE
Fix blank page on flipp.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -395,6 +395,9 @@
 @@||pubads.g.doubleclick.net^$xmlhttprequest,domain=washingtonpost.com
 ! Fix abcnews.go.com video playback
 @@||akamaihd.net/player/2.106.5/akamai/amp/chartbeatanalytics/Chartbeatanalytics.min.js$domain=abcnews.go.com
+! Fix blank page on flipp.com
+||wishabi.net^$image,domain=flipp.com
+@@||wishabi.net^$image,domain=flipp.com
 ! Allow ads on DDG: brave-browser/issues#4533
 @@||duckduckgo.com/m.js
 @@||duckduckgo.com/share/spice/amazon/


### PR DESCRIPTION
As reported here: `https://community.brave.com/t/https-flipp-com-does-not-load-the-content-in-brave-browser/79164` Blocking of wishabi.net caused `flipp.com` not to render correctly.

Caused by blocking on the tracking protection.