### PR TITLE
spiegel.de filters no longer used

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -280,14 +280,6 @@
 @@||notebookcheck-ru.com/ads.js$script,domain=notebookcheck.net|notebookcheck.com
 @@||static.h-bid.com/prebid/$script,domain=notebookcheck.net|notebookcheck.com
 @@||static.h-bid.com/notebookcheck.net/$script,domain=notebookcheck.net|notebookcheck.com
-! spiegel.de (https://github.com/brave/brave-browser/issues/4201)
-||imagesrv.adition.com/banners/$image,domain=spiegel.de
-||googletagservices.com/tag/js/gpt.js$script,domain=spiegel.de
-||doubleclick.net/ddm/$image,domain=spiegel.de
-@@||doubleclick.net/ddm/$image,domain=spiegel.de
-@@||googletagservices.com/tag/js/gpt.js$script,domain=spiegel.de
-@@||mxcdn.net/bb-mx/$script,domain=spiegel.de
-@@||imagesrv.adition.com/banners/$image,domain=spiegel.de
 ! Video playback on maxpreps.com (script source on cbssports.com)
 ||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=cbssports.com
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=cbssports.com


### PR DESCRIPTION
Given the filters aren't effective, lets just remove them.  Related ticket: https://github.com/brave/brave-browser/issues/4201