### PR TITLE
Adblock-Tracking on thenextweb.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -250,6 +250,8 @@
 ! Fix foxnews video playback
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=foxbusiness.com|foxnews.com
 @@||fncstatic.com/static/isa/app/lib/VisitorAPI.js$script,domain=foxbusiness.com|foxnews.com
+! Adblock-Tracking: thenextweb.com
+@@||thenextweb.com/wp-content/advertisement.js$script,domain=thenextweb.com
 ! Adblock-Tracking: tumblr
 @@/assets/scripts/tumblr/dashboard/showads.js$script,~third-party
 ! Adblock-Tracking: ieee.org


### PR DESCRIPTION
Adblock Tracking as seen on `https://thenextweb.com/`

`https://thenextweb.com/wp-content/advertisement.js`

**Source**

`window['noBlocker'] = true;`