### PR TITLE
Fix digitalriver.com content https://community.brave.com/t/asus-japan-store-images-will-not-load-default-shields/81228

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -213,6 +213,8 @@
 @@||rambler.ru^$stylesheet,xmlhttprequest,domain=lenta.ru
 ! Adblock-Tracking: nytimes.com
 @@||nyt.com/ads/google/adsbygoogle.js$script,domain=nytimes.com
+! Fix content on asus.com (https://community.brave.com/t/asus-japan-store-images-will-not-load-default-shields/81228 )
+@@||digitalriver.com^$domain=asus.com
 ! Anti-adblock: dreamdth.com
 @@||dreamdth.com/js/wutime_adblock/ads.js$script
 ! Anti-adblock: transparentcalifornia.com

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -214,7 +214,7 @@
 ! Adblock-Tracking: nytimes.com
 @@||nyt.com/ads/google/adsbygoogle.js$script,domain=nytimes.com
 ! Fix content on asus.com (https://community.brave.com/t/asus-japan-store-images-will-not-load-default-shields/81228 )
-@@||digitalriver.com^$domain=asus.com
+@@||digitalriver.com^$domain=store.asus.com
 ! Anti-adblock: dreamdth.com
 @@||dreamdth.com/js/wutime_adblock/ads.js$script
 ! Anti-adblock: transparentcalifornia.com

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -213,8 +213,9 @@
 @@||rambler.ru^$stylesheet,xmlhttprequest,domain=lenta.ru
 ! Adblock-Tracking: nytimes.com
 @@||nyt.com/ads/google/adsbygoogle.js$script,domain=nytimes.com
-! Fix content on asus.com (https://community.brave.com/t/asus-japan-store-images-will-not-load-default-shields/81228 )
-@@||digitalriver.com^$domain=store.asus.com
+! Fix digitalriver.com content on various shoping sites.
+@@||api.digitalriver.com^$script,third-party
+@@||img.digitalriver.com^$script,image,stylesheet,third-party
 ! Anti-adblock: dreamdth.com
 @@||dreamdth.com/js/wutime_adblock/ads.js$script
 ! Anti-adblock: transparentcalifornia.com

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -215,7 +215,8 @@
 @@||nyt.com/ads/google/adsbygoogle.js$script,domain=nytimes.com
 ! Fix digitalriver.com content on various shoping sites.
 @@||api.digitalriver.com^$script,third-party
-@@||img.digitalriver.com^$script,image,stylesheet,third-party
+@@||img.digitalriver.com/store?$script,image,stylesheet,third-party
+@@||img.digitalriver.com/DRHM/$script,image,stylesheet,third-party
 ! Anti-adblock: dreamdth.com
 @@||dreamdth.com/js/wutime_adblock/ads.js$script
 ! Anti-adblock: transparentcalifornia.com


### PR DESCRIPTION
Our block on digitalriver.com is causing rendering issues on `https://jp.store.asus.com/`

Was reported; https://community.brave.com/t/asus-japan-store-images-will-not-load-default-shields/81228/2

Sample of what is being blocked for our records;

`https://drh.img.digitalriver.com/store?Action=DisplayContentManagerStyleSheet&SiteID=asusjp&StyleID=4868877700&StyleVersion=70&styleIncludeFile=style.css`
`https://drh1.img.digitalriver.com/DRHM/Storefront/Site/asusjp/images/promo/top/bnr_20190820_newproduct.jpg`
`https://drh1.img.digitalriver.com/DRHM/Storefront/Company/asusjp/images/product/thumbnail/ASUS_S330UA-8130GL/S330UA-8130GL-1.jpg`
`https://drh1.img.digitalriver.com/DRHM/Storefront/Company/asusjp/images/product/thumbnail/X512_Coral-Crush_01.jpg`