### PR TITLE
Fix for dailymotion.com filter not required

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -131,8 +131,6 @@
 @@||developers.google.com/identity/$image,domain=mysms.com
 ! Adblock-Tracking: speedtest.com
 @@||speedtest.net/javascript/ads.js
-! Fix page rendering due to issues with scorecardresaerch.com https://github.com/brave/brave-browser/issues/1580
-||scorecardresearch.com^$domain=dailymotion.com
 ! vresp.com (https://community.brave.com/t/cant-see-captcha-on-form/67187)
 @@||captcha.vresp.com^$domain=lawfirmkpi.com
 ! https://community.brave.com/t/ad-not-bloked-properly/63628


### PR DESCRIPTION
Looking at review, and was reported it was still an issue. Seems scorecardresearch.com was causing the issue, but in opposite. a white-list was needed.

https://github.com/easylist/easylist/commit/c8677d3b3db75b83a0e43fe2206eca47fa1942fa