### PR TITLE
Fix playback on https://thothub.tv/ (NSFW)

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -151,6 +151,8 @@
 @@||theintercept.com/ads.js$script,domain=theintercept.com
 ! Adblock-Tracking: imgbox.com
 @@||imgbox.com/site_ads.js$script,domain=imgbox.com
+! thothub.tv (NSFW)
+@@||awemwh.com^$media,domain=thothub.tv
 ! Adblock-Tracking: cbs sites
 @@||cbsistatic.com^*/advertisement*.js$script,domain=zdnet.com|techrepublic.com
 ! Fix https://github.com/brave/brave-browser/issues/4507 (mirrors uBO fix, rewritten so that brave/ad-block supports)


### PR DESCRIPTION
Open any video on `https://thothub.tv/` (NSFW). We're blocking a pre-roll mp4, and if not allowed to run will prevent the videos not to play.

What we're whitelisting (NSFW):
`https://galleryn0.awemwh.com/f8d2e11bd6c43618af00d6f28c91232a17/1fa447358bebbf4c300af673a917991b.mp4`

Not blocked in EL/EP or the Disconnect list from what I can see, Before landing this patch, would be interested how `awemwh.com` is being blocked in the first place