### PR TITLE
Adblock Tracking on cbc.ca

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -326,6 +326,8 @@
 ||ga.gfycat.com^$script,domain=gfycat.com
 ! Anti-adblock tracking: nfl.com
 @@||nflcdn.com^*/ad.js$script,domain=nfl.com
+! Adblock-Tracking: cbc.ca
+@@||cbc.ca/g/stats/js/ads.js
 ! Adblock-Tracking: computerbase.de
 @@||computerbase.de/js/ads.$script,xmlhttprequest,domain=computerbase.de
 ! Adblock-Tracking: (News corp AU sites)

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -327,7 +327,7 @@
 ! Anti-adblock tracking: nfl.com
 @@||nflcdn.com^*/ad.js$script,domain=nfl.com
 ! Adblock-Tracking: cbc.ca
-@@||cbc.ca/g/stats/js/ads.js
+@@||cbc.ca/g/stats/js/ads.js$script,domain=cbc.ca
 ! Adblock-Tracking: computerbase.de
 @@||computerbase.de/js/ads.$script,xmlhttprequest,domain=computerbase.de
 ! Adblock-Tracking: (News corp AU sites)


### PR DESCRIPTION
Adblock tracking on `https://www.cbc.ca/news/canada/london/vehicle-crash-london-explosions-dundas-woodman-1.5247707`

`https://www.cbc.ca/g/stats/js/ads.js`

**Source:**
`"use strict";window.CBC||(window.CBC={}),CBC.APP||(CBC.APP={}),CBC.APP.SC||(CBC.APP.SC={}),CBC.APP.SC.ads=!0;`