### PR TITLE
Fix issue on https://superpowered.com/js-wasm-sdk/example_timestretching/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -230,8 +230,6 @@
 ! Anti-adblock: 9anime
 @@||9anime.vip/assets/js/ads.js$script,domain=9anime.vip
 @@||animecdn.xyz/js/ads.js$script,domain=9animes.ru
-! Coin-miner Whitelist (Fixes https://superpowered.com/js-wasm-sdk/example_timestretching/)
-@@||superpowered.com^*/processor.js$script,domain=superpowered.com
 ! Anti-adblock: securenetsystems.net
 @@||securenetsystems.net/v5/scripts/ads/prebid.js$script,domain=securenetsystems.net
 ! Adblock-Tracking: softonic.com

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -230,6 +230,8 @@
 ! Anti-adblock: 9anime
 @@||9anime.vip/assets/js/ads.js$script,domain=9anime.vip
 @@||animecdn.xyz/js/ads.js$script,domain=9animes.ru
+! Coin-miner Whitelist (Fixes https://superpowered.com/js-wasm-sdk/example_timestretching/)
+@@||superpowered.com^*/processor.js$script,domain=superpowered.com
 ! Anti-adblock: securenetsystems.net
 @@||securenetsystems.net/v5/scripts/ads/prebid.js$script,domain=securenetsystems.net
 ! Adblock-Tracking: softonic.com

--- a/coin-miners.txt
+++ b/coin-miners.txt
@@ -222,7 +222,6 @@
 /nano.wasm
 /noblock.js
 /obfus.min.js
-/processor.js
 /projectpoi.min.js
 /safelinkconverter.js
 /streambeam-jw.js


### PR DESCRIPTION
From the test site `https://superpowered.com/js-wasm-sdk/example_timestretching/`

Affected by 2 lists; Easyprivacy is blocking /processor.js, was a common js file name for coin miner. But probably too generic to be honest. I've removed it in Easprivacy, but will still affect us because of our use of another coin-miner list.