### PR TITLE
Fix stylesheet issues on https://www.fallingsquirrel.com/post/the-demo-is-here

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -283,6 +283,8 @@
 ! fix first-party items on maxmind.com (https://community.brave.com/t/stop-blocking-the-website-for-maxmind-com/68326)
 @@||blog.maxmind.com^$~third-party
 @@||static.maxmind.com^$~third-party
+! Fix Mailchimp stylesheet issued (https://www.fallingsquirrel.com/post/the-demo-is-here)
+@@||mailchimp.com/embedcode/$stylesheet
 ! bandai-hobby.net (maxmind check causing blank pages)
 @@||js.maxmind.com/js/apis/geoip2/v2.1/geoip2.js$script,domain=bandai-hobby.net
 @@||geoip-js.maxmind.com/geoip/$xmlhttprequest,domain=bandai-hobby.net


### PR DESCRIPTION
Generic fix for any site using Mailchimp on their site. this should allow the style sheet to be used.

As seen on `https://www.fallingsquirrel.com/post/the-demo-is-here`

Element blocked;
`https://cdn-images.mailchimp.com/embedcode/classic-10_7.css`
