### PR TITLE
Fix anti-adblock on https://www.xiaomitoday.com/xiaomi-redmi-note-8-pro/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -280,6 +280,8 @@
 @@||api.ebay.com^$xmlhttprequest,subdocument
 ! Adblock Tracking: thetimes.co.uk
 @@||thetimes.co.uk/d/js/ads-$script,domain=thetimes.co.uk
+! Anti-adblock: xiaomitoday.com
+@@||xiaomitoday.com/wp-content/themes/jannah/assets/js/advertisement.js$script,domain=xiaomitoday.com
 ! Anti-adblock ign.com
 ||g01.ign.com^$script,domain=ign.com
 ! fix first-party items on maxmind.com (https://community.brave.com/t/stop-blocking-the-website-for-maxmind-com/68326)


### PR DESCRIPTION
Was reported here; https://community.brave.com/t/adblock-warning-removal/83288

Visiting `https://www.xiaomitoday.com/xiaomi-redmi-note-8-pro/` will cause an Anti-adblock message.

**Source:**
`/* Used by the AdBlocker Detector */`
`var $tieE3 = true;`