### PR TITLE
Fix rendering, comments and anti-adblock on https://www.gazeta.ru/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -211,6 +211,12 @@
 @@||mediaite.com/adbait/adsbygoogle.js
 ! rambler.ru css issues (https://community.brave.com/t/broken-formatting-on-specific-websites-when-using-brave-or-firefox/68023)
 @@||rambler.ru^$stylesheet,xmlhttprequest,domain=lenta.ru
+! rambler.ru issues on gazeta.ru
+@@||myqualification.rambler.ru^$domain=gazeta.ru
+@@||subscriptions.rambler.ru^$subdocument,domain=gazeta.ru
+@@||rambler.ru/widget.js$script,domain=gazeta.ru
+! Adblock-Tracking: gazeta.ru
+@@||gazeta.ru^*/advertising.js$script,domain=gazeta.ru
 ! Adblock-Tracking: nytimes.com
 @@||nyt.com/ads/google/adsbygoogle.js$script,domain=nytimes.com
 ! Fix digitalriver.com content on various shoping sites.

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -213,6 +213,7 @@
 @@||rambler.ru^$stylesheet,xmlhttprequest,domain=lenta.ru
 ! rambler.ru issues on gazeta.ru
 @@||myqualification.rambler.ru^$domain=gazeta.ru
+@@||rambler.ru/api/$xmlhttprequest,domain=gazeta.ru
 @@||subscriptions.rambler.ru^$subdocument,domain=gazeta.ru
 @@||rambler.ru/widget.js$script,domain=gazeta.ru
 ! Adblock-Tracking: gazeta.ru


### PR DESCRIPTION
**1. Fix site rendering and comments api used by the site:**

Visiting `https://www.gazeta.ru` will cause the site not to render correct. Specifically caused by the block on `myqualification.rambler.ru`.

Following scripts are being blocked:
`https://cdn-comments.rambler.ru/widget.js`
`https://subscriptions.rambler.ru/subscribe_form/gazeta:header/`
`https://c.rambler.ru/api/app/3/comments-count?xid=12660673&xid=12660337&xid=12657883&xid=12641047`
`https://myqualification.rambler.ru/dvwegmyv/YWxpZTcuaHVoem12QHsiZGF0YSI6ey..`
`https://myqualification.rambler.ru/lnmmhspf/YnNiejAuZHcxNWNqQHsiZGF0YSI6eyJBY3Rpb24iOiJTdGF0QmxvY2tlcnMiLCJzdGF0Ijp7ImVsIjoxLCJyZSI6MSwic2l0ZSI6?juirzbcl=Ind3dy5nYXpldGEucnUifSwidXNlciI6e&mcehw=yJydWlkIjpudWxsLCJscnVpZCI6InBROE&qbzg=FBTE5GZzEzSUU3akFBY3QzY3dBPSJ9fX0&yayv=%3D`

The following domains `myqualification.rambler.ru`, `subscriptions.rambler.ru` and `cdn-comments.rambler.ru` and `c.rambler.ru/api/app/3/comments-count` seems to be legit content. (Comments by rambler.ru). This an overreach by the disconnect blocking rambler.ru.

We're still blocking the rambler.ru trackers in EP: (which are blocked on this site)
`||sync.rambler.ru^`
`||ssp.rambler.ru^`

**2. Fix Anti-adblock tracker:**

Anti adblock Tracking also see:
`https://static.gazeta.ru/nm2015/js/advertising.js`

**Source:**
`(function (){`
`	window.ADBLOCK_DETECTED = false;`
`})();`