### PR TITLE
Merge lenta.ru into the recent rambler.ru Fixes

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -209,10 +209,8 @@
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=player.abacast.net
 ! Anti-adblock: mediaite.com
 @@||mediaite.com/adbait/adsbygoogle.js
-! rambler.ru css issues (https://community.brave.com/t/broken-formatting-on-specific-websites-when-using-brave-or-firefox/68023)
-@@||rambler.ru^$stylesheet,xmlhttprequest,domain=lenta.ru
-! rambler.ru issues on gazeta.ru
-@@||myqualification.rambler.ru^$domain=gazeta.ru
+! rambler.ru issues
+@@||myqualification.rambler.ru^$xmlhttprequest,domain=gazeta.ru|lenta.ru
 @@||rambler.ru/api/$xmlhttprequest,domain=gazeta.ru
 @@||subscriptions.rambler.ru^$subdocument,domain=gazeta.ru
 @@||rambler.ru/widget.js$script,domain=gazeta.ru


### PR DESCRIPTION
Too quick :)

Here is just a quick merge for lenta.ru domain. Since ramber.ru is widely used on russian sites we can clean it up.
Same domain `myqualification.rambler.ru` is used on `https://lenta.ru/`
