### PR TITLE
Anti-adblock on https://www.washingtonpost.com/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -357,6 +357,7 @@
 ! Adblock tradcking: defenseone.com
 @@||defenseone.com/b/js/adframe.js$script,domain=defenseone.com
 ! Anti-adblock: washingtonpost.com
+@@||d2ty8gaf6rmowa.cloudfront.net/ad/$domain=washingtonpost.com
 @@||pubads.g.doubleclick.net^$xmlhttprequest,domain=washingtonpost.com
 ! Fix abcnews.go.com video playback
 @@||akamaihd.net/player/2.106.5/akamai/amp/chartbeatanalytics/Chartbeatanalytics.min.js$domain=abcnews.go.com


### PR DESCRIPTION
Anti-adblock script being loaded on `https://www.washingtonpost.com/`

Being checked with the following `https://d2ty8gaf6rmowa.cloudfront.net/ad/ads.js`

**Source:** 

`(function() {`
`  window.TWP &&`
`    window.TWP.abchecker == false;`
`})();`