### PR TITLE
Fix signup issues on https://qri.io/beta/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -271,6 +271,8 @@
 ! mailchi.mp form fix (https://github.com/brave/brave-browser/issues/5522)
 @@||list-manage.com/signup-form/subscribe?$domain=mailchi.mp
 @@||list-manage.com/signup-form/settings?$domain=mailchi.mp
+! Allow sites to use signup forms from list-manage
+@@||list-manage.com/subscribe/$script,third-party
 ! Adblock-Tracking:indiatoday.in
 @@||indiatoday.in/sites/all/modules/custom/itg_ads_blocker/js/ads.js$script,domain=indiatoday.in
 ! Adblock-Tracking: salon.com


### PR DESCRIPTION
Signing up to Beta test is broken on `https://qri.io/beta/`

Due to the block on list-manage.com, the following script is being blocked
`https://qri.us19.list-manage.com/subscribe/post-json?u=54a6a8c1171101850b8576277&id=9fc5ce3233&c=jQuery19003258859970468757_1569012354602&EMAIL=c2147997%40urhen.com&FNAME=dfgdfgdfg&LNAME=dfgdfgdfg&b_54a6a8c1171101850b8576277_9fc5ce3233=&subscribe=Sign+Up&_=1569012354603`

The tracking filter for this domain is still blocked; ||list-manage.com/track/ in EP.