### PR TITLE
Fix anti-adblock on cnbc.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -299,6 +299,8 @@
 @@||geoip-js.maxmind.com/geoip/$xmlhttprequest,domain=bandai-hobby.net
 ! ABP Japanese blocking Aliexpress (https://github.com/k2jp/abp-japanese-filters/issues?utf8=✓&q=is%3Aissue+aliexpress)
 @@||aliexpress.com^$~third-party
+! Anti-adblock: cnbc.com
+@@||cnbc.com/staticContent/showads.js$script,domain=cnbc.com
 ! Allow reddit extensions to be used
 @@||reddit.com/r/$script,domain=deora.dev
 @@||reddit.com/comments/$domain=batcommunity.org


### PR DESCRIPTION
Visiting `https://www.cnbc.com/video/2019/09/20/apple-introduces-arcade-its-new-subscription-gaming-service.html`.  Video is blocked due to Anti-adblock check.

Sciript being used: `https://www.cnbc.com/staticContent/showads.js`

**Source:**

`// to check whether the file was loaded`
`// if (cnbc && cnbc.canShowAds) {  }`

`var cnbc = cnbc || {};`
`cnbc.canShowAds = true;`