### PR TITLE
Adblock tracking on gamesradar.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -156,8 +156,8 @@
 ! Adblock-Tracking: cbs sites
 @@||cbsistatic.com^*/advertisement*.js$script,domain=zdnet.com|techrepublic.com
 ! Fix https://github.com/brave/brave-browser/issues/4507 (mirrors uBO fix, rewritten so that brave/ad-block supports)
-! Adblock-Tracking: techradar.com
-@@||videoadex.com/jw/advertisement.js$domain=techradar.com
+! Adblock-Tracking: videoadex.com
+@@||videoadex.com/jw/advertisement.js$domain=techradar.com|gamesradar.com
 ||washingtonpost.com/pb/api/*/adblocker-feature$xmlhttprequest,first-party
 ! Fix blankpage issue https://github.com/brave/brave-browser/issues/4049
 ||dianomi.com/cgi-bin/smartads.pl$xmlhttprequest,domain=inc.com


### PR DESCRIPTION
Adblock tracking on `https://www.techradar.com/best/best-linux-server-distro`

**Same script, source:**

`_um_ads_allowed = 1;`