### PR TITLE
Adblock-Tracking on imgur.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -167,6 +167,8 @@
 @@||neustar.biz^$domain=home.neustar
 ! Anti-adblock: newsmax.com
 @@||newsmax.com/js/ads.adblock.js$script,domain=newsmax.com
+! Adblock-Tracking: imgur.com
+@@||imgur.com/min/advertising.js$script,domain=imgur.com
 ! Anti-adblock: thehindu.com
 @@||thgim.com/static/js/ads.min.js$script,domain=thehindu.com
 ! Adblock-Tracking: healthline.com


### PR DESCRIPTION
Adblock Tracking on `https://imgur.com/gallery/hi1oFpX`

`https://s.imgur.com/min/advertising.js?1568999642`

**Source:**
`window.ADBLOCKED=!1;`
`//# sourceMappingURL=advertising.js.map`