### PR TITLE
Adblock tracking on veedi.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -179,6 +179,8 @@
 @@||mediaite.com/adbaitplus/adsbygoogle.js$script,domain=mediaite.com
 ! Broken video playback on tn.com.ar (https://community.brave.com/t/the-blocker-does-not-allow-you-to-watch-the-video/76691)
 @@||googletagmanager.com/gtm.js$script,domain=tn.com.ar
+! Adblock-Tracking: silvergames.com
+@@||veedi.com^*/advert.js$script,domain=veedi.com
 ! Adblock-Tracking: thedailybeast.com
 @@||thedailybeast.com/static/advert.js$script
 ! Adblock-Tracking: vice.com


### PR DESCRIPTION
Adblock Tracking seen on `https://www.silvergames.com/en/stickman-fighter`

`https://www.veedi.com/v2/js/ads/advert.js`

Source:
`adBlocker = false;`