### PR TITLE
Fix npttech.com blocking filter used by uBo

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -75,6 +75,8 @@
 ! content blocking
 ||seattletimes.com/wp-content/plugins/st-user-messaging^$script
 ||theatlantic.com/packages/adsjs^$script
+! Temp filter, uBO is overriding the whitelist, which Brave is blocking by default until we implement redirect
+||npttech.com/advertising.js$important,script,redirect=fuckadblock.js-3.2.0,badfilter
 ! tracking
 ||optimizely.com^$third-party
 ! crypto ad network


### PR DESCRIPTION
Because of our implementation of redirect isn't ready, it'll block ||npttech.com/advertising.js and override the Easylist whitelist `@@||npttech.com/advertising.js`

So we're just overriding this filter: `||npttech.com/advertising.js$important,script,redirect=fuckadblock.js-3.2.0`

