### PR TITLE
Anti-adblock for nbc.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -310,6 +310,8 @@
 @@||geoip-js.maxmind.com/geoip/$xmlhttprequest,domain=bandai-hobby.net
 ! ABP Japanese blocking Aliexpress (https://github.com/k2jp/abp-japanese-filters/issues?utf8=✓&q=is%3Aissue+aliexpress)
 @@||aliexpress.com^$~third-party
+! Anti-adblock: nbc.com
+@@||nbc.com/generetic/scripts/ads.js$script,domain=nbc.com
 ! Anti-adblock: cnbc.com
 @@||cnbc.com/staticContent/showads.js$script,domain=cnbc.com
 ! Allow reddit extensions to be used


### PR DESCRIPTION
As seen on `https://www.nbc.com/bluff-city-law/video/next-secret-love-child/4035584`

`Sorry, we can't play this video in its intended experience because we're unable to load the accompanying message from our sponsors.`

`If you are using ad-blocking software, please disable it and try loading the page again.`

Tested in Brave-beta (Brave Release is having some video playback issues atm).

`https://www.nbc.com/generetic/scripts/ads.js`

**Source:**
`var canRunAds = true;`

