### PR TITLE
Fix missing CSS/images on gazeta.ru

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -223,9 +223,9 @@
 ! Anti-adblock: mediaite.com
 @@||mediaite.com/adbait/adsbygoogle.js
 ! rambler.ru issues
-@@||myqualification.rambler.ru^$xmlhttprequest,domain=gazeta.ru|lenta.ru
+@@||myqualification.rambler.ru^$xmlhttprequest,image,stylesheet,domain=gazeta.ru|lenta.ru
 @@||rambler.ru/api/$xmlhttprequest,domain=gazeta.ru
-@@||subscriptions.rambler.ru^$subdocument,domain=gazeta.ru
+@@||subscriptions.rambler.ru^$subdocument,script,domain=gazeta.ru
 @@||rambler.ru/widget.js$script,domain=gazeta.ru
 ! Adblock-Tracking: gazeta.ru
 @@||gazeta.ru^*/advertising.js$script,domain=gazeta.ru


### PR DESCRIPTION
Looks like I missed the stylesheet/images on the orginal pull request https://github.com/brave/adblock-lists/pull/206  Only applicable from the domain 'myqualification.rambler.ru`

This should finally fix the rendering on `https://www.gazeta.ru/` and also `https://lenta.ru/`

