### PR TITLE
Fix syndication.twitter.com whitelist to allow Easyprivacy block the Twitter tracker

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -121,14 +121,16 @@
 @@||www.facebook.com/rsrc.php$tag=fb-embeds
 @@||www.facebook.com/ajax/bz$tag=fb-embeds
 ! Twitter embeds
-@@||platform.twitter.com/$tag=twitter-embeds
-@@||syndication.twitter.com/$xmlhttprequest,tag=twitter-embeds
-@@||pbs.twimg.com/$tag=twitter-embeds
-@@||cdn.syndication.twimg.com/$tag=twitter-embeds
-@@||twitter.com/i/videos/tweet/$tag=twitter-embeds
+@@||twitter.com/sw.js$tag=twitter-embeds
+@@||ton.twimg.com^$tag=twitter-embeds
+@@||platform.twitter.com^$tag=twitter-embeds
+@@||syndication.twitter.com^$xmlhttprequest,tag=twitter-embeds 
+@@||pbs.twimg.com^$tag=twitter-embeds
+@@||cdn.syndication.twimg.com^$tag=twitter-embeds
+@@||twitter.com/i/videos/tweet/$tag=twitter-embeds 
 @@||abs.twimg.com/web-video-player/$tag=twitter-embeds
-@@||api.twitter.com/1.1/$tag=twitter-embeds
-@@||video.twimg.com/$tag=twitter-embeds
+@@||api.twitter.com^$tag=twitter-embeds
+@@||video.twimg.com^$tag=twitter-embeds
 ! Fix sign in icon on https://app.mysms.com/#login
 @@||developers.google.com/identity/$image,domain=mysms.com
 ! Adblock-Tracking: speedtest.com

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -122,7 +122,7 @@
 @@||www.facebook.com/ajax/bz$tag=fb-embeds
 ! Twitter embeds
 @@||platform.twitter.com/$tag=twitter-embeds
-@@||syndication.twitter.com/$tag=twitter-embeds
+@@||syndication.twitter.com/$xmlhttprequest,tag=twitter-embeds
 @@||pbs.twimg.com/$tag=twitter-embeds
 @@||cdn.syndication.twimg.com/$tag=twitter-embeds
 @@||twitter.com/i/videos/tweet/$tag=twitter-embeds


### PR DESCRIPTION
Tested on the following sites;

   `https://wet-boew.github.io/v4.0-ci/demos/twitter/twitter-en.html`
   `http://twitframe.com/`
   `https://buffer.com/library/twitter-moments`

Our current whitelist `@@||syndication.twitter.com/$tag=twitter-embeds` Allows the following tracking scripts through:

`https://syndication.twitter.com/i/jot`
`https://syndication.twitter.com/i/jot?l=%7B%22widget_origin%22%3A%22https%3A%2F%2Fwet-boew.github.io%2Fv4.0-ci%2Fdemos%2Ftwitter%2Ftwitter-en.html%22%2C%22widget_frame%22%3Afalse%2C%22widget_data_source%22%3A%22profile%3AWebExpToolkit%22%2C%22query%22%3Anull%2C%22profile_id%22%3Anull%2C%22_category_%22%3A%22tfw_client_event%22%2C%22triggered_on%22%3A1570093351729%2C%22dnt%22%3Afalse%2C%22client_version%22%3A%22708eecd%3A1570046592825%22%2C%22format_version%22%3A%22708eecd%3A1570046592825%22%2C%22event_namespace%22%3A%7B%22client%22%3A%22tfw%22%2C%22page%22%3A%22timeline%22%2C%22element%22%3A%22notice%22%2C%22section%22%3A%22header%22%2C%22action%22%3A%22seen%22%7D%7D&notice_seen=true`
`​https://syndication.twitter.com/i/jot/syndication?l=%7B%22_category_%22%3A%22syndicated_impression%22%2C%22triggered_on%22%3A1570093351087%2C%22dnt%22%3Afalse%2C%22event_namespace%22%3A%7B%22client%22%3A%22tfw%22%2C%22page%22%3A%22timeline%22%2C%22action%22%3A%22impression%22%7D%7D`

We have an existing filter in Easyprivacy `||twitter.com/i/jot` blocking these twitter trackers.

Whitelisting this (xmlhttprequest request) seems fine: `https://syndication.twitter.com/settings` would be more specific and avoid letting the tracking in.

The other option is @@||syndication.twitter.com/settings$tag=twitter-embeds  But kept it generic for safety-sake. 