### PR TITLE
Fixes brave/brave-browser#6112 (Anti-adblock on rarbg)

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -244,6 +244,8 @@
 ! Fix foxnews video playback
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=foxbusiness.com|foxnews.com
 @@||fncstatic.com/static/isa/app/lib/VisitorAPI.js$script,domain=foxbusiness.com|foxnews.com
+! Anti-adblock: rarbg
+@@||dyncdn.me^*/showads.js$script,domain=rarbg2019.org|rarbgaccess.org|rarbgmirror.com|rarbgproxied.org|rarbgmirrored.org|rarbgproxied.org|rarbgproxy.org|rarbgprx.org|rarbgto.org|rarbg.to|rarbgunblock.com
 ! Adblock-Tracking: thenextweb.com
 @@||thenextweb.com/wp-content/advertisement.js$script,domain=thenextweb.com
 ! Adblock-Tracking: tumblr


### PR DESCRIPTION
Fixes brave/brave-browser#6112

Visiting `https://rarbg.to/` will create a div overlay (causing popups). Whitelisting this anti-adblock script will prevent happening:

`https://dyncdn.me/static/20/js/showads.js`

**Source:**
`var abbz = true;`