### PR TITLE
Fixes brave/brave-browser/#6317 (Anti-adblock on golem.de)

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -173,6 +173,9 @@
 @@||thedailybeast.com/static/advert.js$script
 ! Adblock-Tracking: vice.com
 @@||web-scripts.vice.com/ad.vice.com/$script
+! Anti-adblock: golem.de
+@@||golem.de^*/ad-time/$image,domain=golem.de
+@@||golem.de/*&adserv$script,domain=golem.de
 ! Anti-adblock: neowin.net
 ||mdn.neowin.net^$domain=neowin.net
 ! Anti-adblock: stream2watch.ws

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -173,9 +173,10 @@
 @@||thedailybeast.com/static/advert.js$script
 ! Adblock-Tracking: vice.com
 @@||web-scripts.vice.com/ad.vice.com/$script
-! Anti-adblock: golem.de
-@@||golem.de^*/ad-time/$image,domain=golem.de
+! Anti-adblock: golem.de / pcwelt.de
+@@/ad-time/*$image,domain=golem.de|pcwelt.de
 @@||golem.de/*&adserv$script,domain=golem.de
+@@||pcwelt.de/js/advert.js$script,domain=pcwelt.de
 ! Anti-adblock: neowin.net
 ||mdn.neowin.net^$domain=neowin.net
 ! Anti-adblock: stream2watch.ws


### PR DESCRIPTION
Fixes the forced ads on https://github.com/brave/brave-browser/issues/6317 

White lists 2 scripts being actively checked: 

`https://ssl.1.damoh.golem.de/hic_qos?ads&adserv=1&_werbebanner_&simple_ad_`
`https://www.golem.de/1198/ad-time/sp_ipPh-770792_rc.jpg`

$generichide will be needed when we implement cosmetic filtering.

Also related to other sites; https://github.com/brave/brave-browser/issues/4201
