### PR TITLE
Anti-adblock on tweakers.net

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -191,6 +191,8 @@
 ||ttauri.tomsguide.com^$script,domain=tomsguide.com
 ! Anti-adblock: theverge.com (vox sites)
 @@||vox-cdn.com/packs/concert_ads-$script,domain=theverge.com|eater.com|polygon.com|vox.com|sbnation.com|curbed.com
+! Adblock-Tracking: tweakers.net
+||tweakimg.net/x/scripts/min/banners.js$script,domain=tweakers.net
 ! Adblock-Tracking: animeflv.net/animeflv.com
 @@||animeflv.net/js/adsbygoogle.js$script,domain=animeflv.net
 @@||animeflv.com/js/adsbygoogle.js$script,domain=animeflv.com


### PR DESCRIPTION
Blocking this script prevents adblock checks, if you visit; `https://tweakers.net/`

`https://tweakimg.net/x/scripts/min/banners.js`

JS Cleaned up:
`https://pastebin.com/raw/ZsFqcQbH`