### PR TITLE
Anti-adblock on metacritic.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -281,7 +281,9 @@
 @@||thetimes.co.uk/d/js/ads-$script,domain=thetimes.co.uk
 ! Anti-adblock: xiaomitoday.com
 @@||xiaomitoday.com/wp-content/themes/jannah/assets/js/advertisement.js$script,domain=xiaomitoday.com
-! Anti-adblock ign.com
+! Anti-adblock metacritic.com  (instart ads)
+||c-9pruhskhx78v49x24vwdwlfx2ephwdfulwlfx2efrp.g00.metacritic.com^$script,domain=metacritic.com
+! Anti-adblock ign.com  (instart ads)
 ||b8n5kh.g02.ign.com^$script,xmlhttprequest,domain=ign.com
 ! fix first-party items on maxmind.com (https://community.brave.com/t/stop-blocking-the-website-for-maxmind-com/68326)
 @@||blog.maxmind.com^$~third-party


### PR DESCRIPTION
As seen on `https://www.metacritic.com/game/playstation-4/fifa-20/trailers/13567081`

(Testing on a US Vpn).

This specific url is launching other instart ad scripts, 
`https://c-9pruhskhx78v49x24vwdwlfx2ephwdfulwlfx2efrp.g00.metacritic.com/g00/3_c-9zzz.phwdfulwlf.frp_/c-9PRUHSKHXV49x24kwwsvx3ax2fx2fvwdwlf.phwdfulwlf.frpx2fvlwhqrwlfhx2f758x2fphwdfulwlfx2fvhwwlqjv.mvx3fl43f.pdunx3dvfulsw_$/$/$/$/$?i10c.ua=1&i10c.dv=21`

The block can't be generic, since it'll break the rendering of the site. Similar to the ign.com filter, https://github.com/brave/adblock-lists/pull/204

Submitted the same requested on anti-cv, https://github.com/abp-filters/abp-filters-anti-cv/pull/279