### PR TITLE
Fix use of Salesforce for internal use by third-party sites.

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -179,6 +179,7 @@
 @@||tellerium.com/showads.js$script,domain=telerium.tv
 ! Fix use of salesforce 
 @@||my.salesforce.com^$subdocument,third-party
+@@||salesforce.com/jslibrary/$script,third-party
 ! Adblock-Tracking: sourceforge.net / slashdot.org 
 @@||fsdn.com/con/js/adframe.js$script,domain=sourceforge.net
 @@||fsdn.com/sd/js/scripts/ad.js$script,domain=slashdot.org

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -178,7 +178,7 @@
 ! Anti-adblock: stream2watch.ws
 @@||tellerium.com/showads.js$script,domain=telerium.tv
 ! Fix use of salesforce 
-@@||my.salesforce.com^$third-party
+@@||my.salesforce.com^$subdocument,third-party
 ! Adblock-Tracking: sourceforge.net / slashdot.org 
 @@||fsdn.com/con/js/adframe.js$script,domain=sourceforge.net
 @@||fsdn.com/sd/js/scripts/ad.js$script,domain=slashdot.org

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -177,6 +177,8 @@
 ||mdn.neowin.net^$domain=neowin.net
 ! Anti-adblock: stream2watch.ws
 @@||tellerium.com/showads.js$script,domain=telerium.tv
+! Fix use of salesforce 
+@@||my.salesforce.com^$third-party
 ! Adblock-Tracking: sourceforge.net / slashdot.org 
 @@||fsdn.com/con/js/adframe.js$script,domain=sourceforge.net
 @@||fsdn.com/sd/js/scripts/ad.js$script,domain=slashdot.org


### PR DESCRIPTION
The overzealous blocking of salesforce.com from the disconnect list is causing issues with sites deploying SF.

The domain "*.my.salesforce.com" mainly used for internal sites, since we're blocking salesforce.com it is causing issues for any sites hosting salesforce.com content.

Was supplied some private details via email on which domain was causing issues. To confirm what is being blocked.

We block the following in Easyprivacy:
`easyprivacy/easyprivacy_thirdparty.txt:||lct.salesforce.com^$third-party`
`easyprivacy/easyprivacy_thirdparty.txt:||salesforce.com/sfga.js`

https://community.brave.com/t/cannot-use-brave-with-salesforce-lightning-experience/83638/17


