### PR TITLE
Update Anti-adblock on nytimes.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -207,7 +207,7 @@
 ! Adblock-Tracking: gazeta.ru
 @@||gazeta.ru^*/advertising.js$script,domain=gazeta.ru
 ! Adblock-Tracking: nytimes.com
-@@||nyt.com/ads/google/adsbygoogle.js$script,domain=nytimes.com
+@@||nytimes.com/ads/google/adsbygoogle.js$script,domain=nytimes.com
 ! Fix digitalriver.com content on various shoping sites.
 @@||api.digitalriver.com^$script,third-party
 @@||img.digitalriver.com/store?$script,image,stylesheet,third-party


### PR DESCRIPTION
The Adblock-Tracking script domain changed for this site; 

`https://nytimes.com/ads/google/adsbygoogle.js`

**Source:**

`window._adBlockCheck = true;`