### PR TITLE
Anti-adblock on thesaurus.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -255,6 +255,8 @@
 ! Fix foxnews video playback
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=foxbusiness.com|foxnews.com
 @@||fncstatic.com/static/isa/app/lib/VisitorAPI.js$script,domain=foxbusiness.com|foxnews.com
+! Anti-adblock: thesaurus.com
+@@||thesaurus.com/assets/ads.js$xmlhttprequest,domain=thesaurus.com
 ! Anti-adblock: rarbg
 @@||dyncdn.me^*/showads.js$script,domain=rarbg2019.org|rarbgaccess.org|rarbgmirror.com|rarbgproxied.org|rarbgmirrored.org|rarbgproxied.org|rarbgproxy.org|rarbgprx.org|rarbgto.org|rarbg.to|rarbgunblock.com
 ! Adblock-Tracking: thenextweb.com


### PR DESCRIPTION
Visiting `https://www.thesaurus.com/browse/illustrate` will generate an Anti-adblock message. due to this script;

`https://www.thesaurus.com/assets/ads.js`

**Source:**

`'use strict';`
`window.console && console.log('detectAB: ads.js successfully loaded');`