### PR TITLE
Fix anti-adblock ads on https://www.reuters.com/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -175,8 +175,8 @@
 @@||thedailybeast.com/static/advert.js$script
 ! Adblock-Tracking: vice.com
 @@||web-scripts.vice.com/ad.vice.com/$script
-! Anti-adblock: golem.de / pcwelt.de
-@@/ad-time/*$image,domain=golem.de|pcwelt.de
+! Anti-adblock: dianomi-anti-adblock
+@@/ad-time/*$image,domain=golem.de|pcwelt.de|reuters.com
 @@||golem.de/*&adserv$script,domain=golem.de
 @@||pcwelt.de/js/advert.js$script,domain=pcwelt.de
 ! Anti-adblock: neowin.net


### PR DESCRIPTION
Visiting `https://www.reuters.com/`

Using a similar style anti-adblock check on: `https://utoumine.net/s/ad-time/?e=17&m=15&d=20170706&t=3&i=4002312587&w=001&r=CNINEf4LjrSqt.jpg`

Simply whitelisting this image check will avoid the ads. A $generichide will be needed when cosmetic filtering is deployed.