### PR TITLE
Allow reddit api use on external sites (https://snew.notabug.io/r/all/)

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -65,6 +65,8 @@
 @@||alb.reddit.com^
 ! Allow sites to use reddit api
 @@||reddit.com^*/.json?$script,third-party
+@@||reddit.com^*/access_token$xmlhttprequest,third-party
+@@||oauth.reddit.com^$xmlhttprequest,third-party
 ! Adblock Tracking
 @@||redditstatic.com^*/ads.js$script,domain=reddit.com
 ! Allow twitter.com readahead (using the twitter api)


### PR DESCRIPTION
When visiting `https://snew.notabug.io/r/all/` the site makes use of the reddit api, which would also affect other sites doing the same.

`https://www.reddit.com/api/v1/access_token`
​`https://oauth.reddit.com/r/all/?limit=100&api_type=json`
`​https://oauth.reddit.com/r/undelete/new?limit=100&api_type=json`
`https://oauth.reddit.com/api/info?limit=100&id=t3_dgjbs4%2Ct3_dghvrf%2Ct3_...`

The whitelist would allow these scripts to be used, for websites wanting to use the reddit api (outside of reddit itself).

We're blocking `https://www.reddit.com/api/v1/access_token`, but I can see issues with `https://oauth.reddit.com/` So whitelisted this url also.

Was reported in `https://www.reddit.com/r/brave_browser/comments/dg9lb9/snewnotabugio_site_broken_by_brave_shields/`
