### PR TITLE
Anti-adblock on https://www.formel1.de/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -176,7 +176,7 @@
 ! Adblock-Tracking: vice.com
 @@||web-scripts.vice.com/ad.vice.com/$script
 ! Anti-adblock: dianomi-anti-adblock
-@@/ad-time/*$image,domain=golem.de|pcwelt.de|reuters.com
+@@/ad-time/*$image,domain=golem.de|pcwelt.de|reuters.com|formel1.de
 @@||golem.de/*&adserv$script,domain=golem.de
 @@||pcwelt.de/js/advert.js$script,domain=pcwelt.de
 ! Anti-adblock: neowin.net


### PR DESCRIPTION
Visiting `https://www.formel1.de/`  Another /ad-time/* Anti-adblock check;

`https://www.formel1.de/public/video/ready/small/ad-time/1rng8o72-dom-akte-yack-sailor-zombie.jpg`
`https://www.formel1.de/public/video/ready/teaser_big/ad-time/1rng8o72-garage-gabe.png`

User reported;

https://community.brave.com/t/no-ads-blocked-on-www-formel1-de/83797

$generichide will be needed when we roll out cosmetic filtering.