### PR TITLE
Adblock Tracking on Amazon sites

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -282,6 +282,8 @@
 @@||list-manage.com/subscribe/$script,third-party
 ! Adblock-Tracking:indiatoday.in
 @@||indiatoday.in/sites/all/modules/custom/itg_ads_blocker/js/ads.js$script,domain=indiatoday.in
+! Adblock-Tracking: amazon.com + amazon regional
+@@||media-amazon.com^*/showads.$script,third-party
 ! Adblock-Tracking: salon.com
 @@||salon.com/design/assets/ads.js$script,domain=salon.com
 ! Adblock-Tracking: infowars.com


### PR DESCRIPTION
When buying items, came across an anti-adblock check, and seems to be on both `amazon.co.uk` and `amazon.com`. Made generic given the amount of amazon domains

`https://m.media-amazon.com/images/G/01/csm/showads.v2.js`

**source:**

`window.ue_adb_chk = 1;`