### PR TITLE
Anti-adblock on cellmapper.net

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -208,6 +208,8 @@
 ! Fix Playback on http://v6.player.abacast.net/6508 (https://community.brave.com/t/problem-loading-http-v6-player-abacast-net-6508/71822)
 @@||imasdk.googleapis.com/js/core/$subdocument,domain=player.abacast.net
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=player.abacast.net
+! Anti-adblock: cellmapper.net
+@@||cellmapper.net/js/ads.js$script,domain=cellmapper.net
 ! Anti-adblock: cyberciti.biz
 @@||cyberciti.biz/js/ads.js$script,domain=cyberciti.biz
 ! Anti-adblock: mediaite.com


### PR DESCRIPTION
If you visit `https://www.cellmapper.net/` an Anti-adblock message will show because of blocking this script.

`https://www.cellmapper.net/js/ads.js`

**Source:**

`var adTestPass = true;`