### PR TITLE
Update Anti-adblock on mediaite.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -168,7 +168,7 @@
 ! Adblock-Tracking: explosm.net
 @@||explosm.net/js/adsense.js$script,domain=explosm.net
 ! Adblock-Tracking:  mediaite.com
-@@||mediaite.com/adbaitplus/adsbygoogle.js$script,domain=mediaite.com
+@@||mediaite.com^*/adsbygoogle.js$script,domain=mediaite.com
 ! Broken video playback on tn.com.ar (https://community.brave.com/t/the-blocker-does-not-allow-you-to-watch-the-video/76691)
 @@||googletagmanager.com/gtm.js$script,domain=tn.com.ar
 ! Adblock-Tracking: silvergames.com


### PR DESCRIPTION
From `https://www.mediaite.com/`

Updated anti-adblock script;

`https://www.mediaite.com/dswo3w/adsbygoogle.js`

Empty js file, no source.