### PR TITLE
Anti-adblock on laptopmedia.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -315,6 +315,8 @@
 @@||geoip-js.maxmind.com/geoip/$xmlhttprequest,domain=bandai-hobby.net
 ! ABP Japanese blocking Aliexpress (https://github.com/k2jp/abp-japanese-filters/issues?utf8=✓&q=is%3Aissue+aliexpress)
 @@||aliexpress.com^$~third-party
+! Anti-adblock: laptopmedia.com
+@@||laptopmedia.com/ads.js$script,domain=laptopmedia.com
 ! Anti-adblock: nbc.com
 @@||nbc.com/generetic/scripts/ads.js$script,domain=nbc.com
 ! Anti-adblock: cnbc.com


### PR DESCRIPTION
From; `https://laptopmedia.com/comparisons/amd-radeon-rx-vega-10-vs-nvidia-geforce-mx150-benchmarks-and-performance-comparison/`

**Script:** 

`https://laptopmedia.com/ads.js`

**Source:**

`var e=document.createElement('div'); e.id='prATkIlvdfEx'; e.style.display='none'; document.body.appendChild(e);`