### PR TITLE
Anti-adblock on few more idg sites

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -328,6 +328,9 @@
 @@||phandroid.com/ads.js$script,domain=phandroid.com
 ! Adblock-Tracking: idg sites 
 @@||networkworld.com/www/js/ads/ads.js$script,domain=networkworld.com
+@@||techadvisor.fr/scripts/ads.js$script,domain=techadvisor.fr
+@@||pcworld.com/www/js/ads/ads.js$script,domain=pcworld.com
+@@||techconnect.com/www/js/ads/ads.js$script,domain=techconnect.com
 @@||cio.com/www/js/ads/ads.js$script,domain=cio.com
 @@||csoonline.com/www/js/ads/ads.js$script,domain=csoonline.com
 @@||infoworld.com/www/js/ads/ads.js$script,domain=infoworld.com


### PR DESCRIPTION
From; `https://www.techconnect.com/article/3441800/grab-a-kitchenaid-cold-brew-maker-for-80-on-amazon-today.html`
From: `https://www.pcworld.com/article/3432512/nvidia-gamescom-game-ready-driver-improves-performance-latency-and-sharpness.html`
From; `https://www.techadvisor.fr/long-format/gadgets/bon-plan-audio-3695492/`

**Scripts:**

`https://www.techconnect.com/www/js/ads/ads.js`
`https://www.techadvisor.fr/scripts/ads.js`
`https://www.pcworld.com/www/js/ads/ads.js`

**Source:**
`var canRunAds=true;`
