### PR TITLE
Prevent Anti-adblock message on all vox sites

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -201,8 +201,9 @@
 ||ttauri.space.com^$script,domain=space.com
 ||ttauri.tomsguide.com^$script,domain=tomsguide.com
 ||pcgamer-gb.pcgamer.com^$domain=pcgamer.com
-! Anti-adblock: theverge.com (vox sites)
-@@||vox-cdn.com/packs/concert_ads-$script,domain=theverge.com|eater.com|polygon.com|vox.com|sbnation.com|curbed.com
+! Anti-adblock: concert.io (vox sites)
+@@||vox-cdn.com/packs/concert_ads-$script,third-party
+@@||concert.io^*/concert_ads.js$script,third-party
 ! Adblock-Tracking: tweakers.net
 ||tweakimg.net/x/scripts/min/banners.js$script,domain=tweakers.net
 ! Adblock-Tracking: animeflv.net/animeflv.com

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -203,7 +203,6 @@
 ||pcgamer-gb.pcgamer.com^$domain=pcgamer.com
 ! Anti-adblock: concert.io (vox sites)
 @@||vox-cdn.com/packs/concert_ads-$script,third-party
-@@||concert.io^*/concert_ads.js$script,third-party
 ! Adblock-Tracking: tweakers.net
 ||tweakimg.net/x/scripts/min/banners.js$script,domain=tweakers.net
 ! Adblock-Tracking: animeflv.net/animeflv.com

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -202,7 +202,7 @@
 ||ttauri.tomsguide.com^$script,domain=tomsguide.com
 ||pcgamer-gb.pcgamer.com^$domain=pcgamer.com
 ! Anti-adblock: concert.io (vox sites)
-@@||vox-cdn.com/packs/concert_ads-$script,third-party
+@@||vox-cdn.com/packs/concert_ads-$script,domain=theverge.com|eater.com|polygon.com|vox.com|sbnation.com|curbed.com|theringer.com|mmafighting.com|racked.com|mmamania.com|funnyordie.com|riftherald.com
 ! Adblock-Tracking: tweakers.net
 ||tweakimg.net/x/scripts/min/banners.js$script,domain=tweakers.net
 ! Adblock-Tracking: animeflv.net/animeflv.com


### PR DESCRIPTION
Example, visiting `https://www.theverge.com/` would check for 2 scripts (concert.io related). If either item is blocked it would show the Anti-adblock message at the top of the page. Its also applicable on all vox sites.

`https://publicwww.com/websites/%22vox-cdn.com%22/`

More samples; `https://www.polygon.com/` `https://www.sbnation.com/` And all the sbnation blog (300+  sites); `https://www.sbnation.com/blogs`