### PR TITLE
Update Anti-ad tracking on healthline.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -160,7 +160,7 @@
 ! Anti-adblock: thehindu.com
 @@||thgim.com/static/js/ads.min.js$script,domain=thehindu.com
 ! Adblock-Tracking: healthline.com
-@@||healthline.com/scripts/advertising.js
+@@||healthline.com^*/advertising.js
 ! Adblock-Tracking: jpost.com
 @@||bitsngo.net/widget-scripts/extra_content/ads.js$script,domain=jpost.com
 ! Adblock-Tracking: rateyourmusic.com

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -160,7 +160,7 @@
 ! Anti-adblock: thehindu.com
 @@||thgim.com/static/js/ads.min.js$script,domain=thehindu.com
 ! Adblock-Tracking: healthline.com
-@@||healthline.com^*/advertising.js
+@@||healthline.com^*/advertising.js$script,domain=healthline.com
 ! Adblock-Tracking: jpost.com
 @@||bitsngo.net/widget-scripts/extra_content/ads.js$script,domain=jpost.com
 ! Adblock-Tracking: rateyourmusic.com


### PR DESCRIPTION
Just a minor adjustment. Script folder was changed. Visiting `https://www.healthline.com/` will show the updated check.

`https://assets.healthline.com/content/advertising.js`

Blank file check, no source.