### PR TITLE
Anti-adblock tracking on rocket-league.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -296,6 +296,8 @@
 @@||media-amazon.com^*/showads.$script,third-party
 ! Adblock-Tracking: salon.com
 @@||salon.com/design/assets/ads.js$script,domain=salon.com
+! Adblock-Tracking: rocket-league.com
+@@||rocket-league.com/scripts/advert.js$script,domain=rocket-league.com
 ! Adblock-Tracking: infowars.com
 @@||infowars.com/ads.js$script,domain=infowars.com
 ! ebay.co.uk + ebay.com and other ebay regions (https://github.com/brave/brave-browser/issues/5019)


### PR DESCRIPTION
Anti-adblock tracking on `https://rocket-league.com/news/g2s-chicago-rolls-everyone-while-turbopolsa-and-ayyjayy-fail-to-produce` Seems to track rather than nag.

**Script:**
`https://rocket-league.com/scripts/advert.js`

**Source:**
`showshalthis=false;`