### PR TITLE
Anti-adblock tracking on dailystar.co.uk

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -209,6 +209,8 @@
 @@||vox-cdn.com/packs/concert_ads-$script,domain=theverge.com|eater.com|polygon.com|vox.com|sbnation.com|curbed.com|theringer.com|mmafighting.com|racked.com|mmamania.com|funnyordie.com|riftherald.com
 ! Adblock-Tracking: tweakers.net
 ||tweakimg.net/x/scripts/min/banners.js$script,domain=tweakers.net
+! Adblock-Tracking: dailystar.co.uk
+@@||dailystar.co.uk^*/ads.js$script,domain=dailystar.co.uk
 ! Adblock-Tracking: animeflv.net/animeflv.com
 @@||animeflv.net/js/adsbygoogle.js$script,domain=animeflv.net
 @@||animeflv.com/js/adsbygoogle.js$script,domain=animeflv.com


### PR DESCRIPTION
From: `https://www.dailystar.co.uk/news/latest-news/essex-lorry-victims-had-no-20711805`

**Script:**
`https://s2-prod.dailystar.co.uk/@trinitymirrordigital/withnail/lib/ads/ads.js`

**Source:**
`(function(){`
`  var el = document.createElement('DIV');`
`  el.id = 'tm-adblock';`
`  el.style.display = 'none';`
`  document.body.appendChild(el);`
`}());`