### PR TITLE
Anti-adblock tracking on pagesix.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -188,6 +188,8 @@
 ! Fix use of salesforce 
 @@||my.salesforce.com^$subdocument,third-party
 @@||salesforce.com/jslibrary/$script,third-party
+! Adblock-Tracking: pagesix.com
+@@||wp.com^*/show-ads.js$script,domain=pagesix.com
 ! Adblock-Tracking: sourceforge.net / slashdot.org 
 @@||fsdn.com/con/js/adframe.js$script,domain=sourceforge.net
 @@||fsdn.com/sd/js/scripts/ad.js$script,domain=slashdot.org


### PR DESCRIPTION
From: `https://pagesix.com/2019/10/23/celebrity-chef-rocco-dispirito-out-at-standard-grill/`

**Script:**
`https://s2.wp.com/wp-content/themes/vip/nypost-2016/static/js/show-ads.js`

**Source:**
`var dimension21 = 'no';`