### PR TITLE
Anti-adblock on hardwareluxx.de

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -178,7 +178,7 @@
 ! Adblock-Tracking: vice.com
 @@||web-scripts.vice.com/ad.vice.com/$script,domain=vice.com
 ! Anti-adblock: dianomi-anti-adblock
-@@/ad-time/*$image,domain=golem.de|pcwelt.de|reuters.com|formel1.de
+@@/ad-time/*$image,domain=golem.de|pcwelt.de|reuters.com|formel1.de|hardwareluxx.de
 @@||golem.de/*&adserv$script,domain=golem.de
 @@||pcwelt.de/js/advert.js$script,domain=pcwelt.de
 ! Anti-adblock: neowin.net


### PR DESCRIPTION
Visiting `https://www.hardwareluxx.de/` will invoke ads.

Whitelisting the /ad-time/ will fix this.

`https://www.hardwareluxx.de/images/stories/2017/ad-time/bc07645362581DE5E26CB2F0FEE9DC5892.jpg`
`https://www.hardwareluxx.de/images/stories/2017/ad-time/bc0764536258C9D251D3694284E2ECF471.png`

Notified by @Brave-Matt 