### PR TITLE
Anti-adblock on ratemyteachers.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -332,6 +332,8 @@
 @@||aliexpress.com^$~third-party
 ! Anti-adblock: laptopmedia.com
 @@||laptopmedia.com/ads.js$script,domain=laptopmedia.com
+! Anti-adblock: ratemyteachers.com
+@@||ratemyteachers.com/ads.js$script,domain=ratemyteachers.com
 ! Anti-adblock: nbc.com
 @@||nbc.com/generetic/scripts/ads.js$script,domain=nbc.com
 ! Anti-adblock: cnbc.com


### PR DESCRIPTION
Unable to view `https://ratemyteachers.com/` . Instant adblock detection.

**Script:**
`https://ratemyteachers.com/ads.js`

**Source:**
`var e=document.createElement('div');e.id='VayUHZiAvJyoCZccsrjoL9mG';e.style.display='none';document.body.appendChild(e);`