### PR TITLE
Anti-adblock on timesofindia.indiatimes.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -300,6 +300,8 @@
 ! Anti-adblock: indiatimes.com
 @@||indiatimes.com/ads.cms$script,domain=indiatimes.com
 @@/ad-banner-zedo/*$image,domain=indiatimes.com
+@@||timesofindia.indiatimes.com/acms/$xmlhttprequest,domain=indiatimes.com
+@@||timesofindia.indiatimes.com/manageads/$xmlhttprequest,domain=indiatimes.com
 ! Adblock-Tracking:indiatoday.in
 @@||indiatoday.in/sites/all/modules/custom/itg_ads_blocker/js/ads.js$script,domain=indiatoday.in
 ! Adblock-Tracking: amazon.com + amazon regional

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -301,7 +301,6 @@
 @@||indiatimes.com/ads.cms$script,domain=indiatimes.com
 @@/ad-banner-zedo/*$image,domain=indiatimes.com
 @@||timesofindia.indiatimes.com/acms/$xmlhttprequest,domain=indiatimes.com
-@@||timesofindia.indiatimes.com/manageads/$xmlhttprequest,domain=indiatimes.com
 ! Adblock-Tracking:indiatoday.in
 @@||indiatoday.in/sites/all/modules/custom/itg_ads_blocker/js/ads.js$script,domain=indiatoday.in
 ! Adblock-Tracking: amazon.com + amazon regional


### PR DESCRIPTION
Got another report of more Anti-adblock checks on `indiatimes.com` as seen on `https://timesofindia.indiatimes.com/spotlight/capture-diwali-moments-like-never-before-with-oppo-reno2-z/articleshow/71751883.cms`

`https://timesofindia.indiatimes.com/acms/jsAds/getContent?ad_classid=-1380871877&admid=675451890&RMPn=-1178857300`

**Source:**
(Empty)
