### PR TITLE
Fix ads on 5ch.net (Japanese)

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -442,6 +442,11 @@
 ! Chinese specific rules
 /^https?:\/\/asset.bixjf.com\/[0-9]{4}\/[a-z]{2,}\/[0-9].*(.jpg$)/$image,domain=imkan.tv
 /^https?:\/\/asset.bixjf.com\/[0-9]{4}\/ad\/[0-9].*/$domain=imkan.tv
+! 5ch.net (Japanese) Desktop/Mobile IOS/Android-specific blocks
+||thench.net^$third-party
+||proparm.jp^$third-party
+||i2ad.jp^$third-party
+||socdm.com^$third-party
 ! Japanese specific rules below (temporarily)
 /ad/alliance_
 /loadPopIn.


### PR DESCRIPTION
The following adservers were detected on 5ch.net, which are safe to block outright (would also benefit other jpn sites). Helpful for ios/android users.

These adservers are used on 

**Page: (mobile UA)**
`http://itest.5ch.net/subback/hulu`

**Scripts:**
`http://i2ad.jp/i/iVCCp0kwKCl4/sync`

**Page: (mobile UA)**
`http://find.5ch.net/search?q=test`

**Scripts:**
`http://proparm.jp/ssp/p/js1?_aid=2962&_slot=3830`
`http://proparm.jp/ssp/p/js1?_aid=2962&_slot=3829`

**Page:**
`http://fate.5ch.net/hinatazaka46/`

**Scripts:**
`http://stab.thench.net/subback/bottom_728x90`
`http://stab.thench.net/subback/middle_300x250`

**Page:**
`http://itest.5ch.net/test/read.cgi/famicom/1542957405/ (mobile UA)`

**Scripts:**
`http://i.socdm.com/sdk/js/adg-script-loader.js?id=56783&targetID=adg_56783&displayid=1&adType=RECT&async=false&tagver=2.0.0`

A few fixes landed in EL;

**Landed 2 Cosmetic's:**
https://github.com/easylist/easylist/commit/f6d2735f02958425d373cec6a1bf7a9786331726
https://github.com/easylist/easylist/commit/cb68d43b64d47a3b06ce9501bc36ba5519de7ef3
**Landed 2 Generics**
https://github.com/easylist/easylist/commit/7ec33a196a00b954b5a1848735241e5e1f0d9383
https://github.com/easylist/easylist/commit/40c5f3af0713d7112bc3e034cab4db8f500b443f
