### PR TITLE
Fix stripe.com (payment platform) on kickstarter.com (WIP)

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -115,6 +115,8 @@
 @@||video.twimg.com^$tag=twitter-embeds
 ! Fix sign in icon on https://app.mysms.com/#login
 @@||developers.google.com/identity/$image,domain=mysms.com
+! Fix incorrectly blocked stripe.com on kickstarter.com
+@@||stripe.com^*/outer.html$subdocument,domain=kickstarter.com
 ! Adblock-Tracking: speedtest.com
 @@||speedtest.net/javascript/ads.js$script,domain=speedtest.net
 ! vresp.com (https://community.brave.com/t/cant-see-captcha-on-form/67187)


### PR DESCRIPTION
We are blocking on `https://www.kickstarter.com/projects/tiltfive/holographic-tabletop-gaming`

`https://js.stripe.com/v2/m/outer.html#url=https%3A%2F%2Fwww.kickstarter.com%2Fprojects%2Ftiltfive%2Fholographic-tabletop-gaming&title=Tilt%20Five%3A%20Holographic%20Tabletop%20Gaming%20by%20Tilt%20Five%20%E2%80%94%20Kickstarter&referrer=&muid=45fb4a6f-41d7-4c96-9113-f9edbae56cef&sid=fd7a8fe1-2b07-4171-b8ab-1ca064377db3&preview=false`

We shouldn't be blocking this script, has been reported issues regarding backing project's because of this subdoc being blocked.

