### PR TITLE
Block ad-tracking script /gpt.js

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -20,6 +20,8 @@
 ||csp.screen9.com^$script,image,domain=expressen.se|aftonbladet.se
 ||glimr.io^$script,image,domain=expressen.se|aftonbladet.se
 ||aka-cdn-ns.adtech.de^$script,image,domain=aftonbladet.se|expressen.se
+! gpt-ad tracking
+/gpt.js$script
 ! Hearst anti-ad blocking fix
 ||aps.hearstnp.com^$script,image
 ! Sailthru native ad aggregator fix


### PR DESCRIPTION
As seen on `https://www.tribunnews.com/`

Used by googletagservices and doubleclick.net