### PR TITLE
Fix anti-adblock on reuters.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -177,6 +177,7 @@
 @@||web-scripts.vice.com/ad.vice.com/$script
 ! Anti-adblock: dianomi-anti-adblock
 @@/ad-time/*$image,domain=golem.de|pcwelt.de|reuters.com
+@@||reuters.com/ads.js$script,domain=reuters.com
 @@||golem.de/*&adserv$script,domain=golem.de
 @@||pcwelt.de/js/advert.js$script,domain=pcwelt.de
 ! Anti-adblock: neowin.net


### PR DESCRIPTION
`reuters.com` added a new check on the site. This will stop the dianomi ads from being loaded.

As seen on  `https://www.reuters.com/article/us-usa-election/democrats-claim-victory-over-trump-backed-kentucky-governor-seize-virginia-legislature-idUSKBN1XF1EU`

`https://www.reuters.com/ads.js`

Source:

`var e=document.createElement('div');`
`e.id='ApoHvDqryePk';`
`e.style.display='none';`
`document.body.appendChild(e);`