### PR TITLE
Fix vk/vkontakte issues on Russian sites

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -446,6 +446,12 @@
 /outbrain/base?
 /outbrain?
 ||outbrainimg.com^$third-party
+! Russian specific rules
+@@||vk.com/video_ext.php$subdocument
+@@||vk.com/js/api/openapi.js$script
+@@||vk.com/share.php$script,third-party
+@@||vkontakte.ru/js/api/openapi.js$script
+@@||vk.com/images/$image,third-party
 ! Chinese specific rules
 /^https?:\/\/asset.bixjf.com\/[0-9]{4}\/[a-z]{2,}\/[0-9].*(.jpg$)/$image,domain=imkan.tv
 /^https?:\/\/asset.bixjf.com\/[0-9]{4}\/ad\/[0-9].*/$domain=imkan.tv


### PR DESCRIPTION
vk/vkontakte is a popular Russian social site used for auth, comments and sharing videos (like Facebook). Given the popularity of the site, we should fix this.

**`https://vz.ru/news/2019/11/6/1007079.html`**
`https://vkontakte.ru/js/api/openapi.js?13`

**`https://chem-oge.sdamgia.ru/`**
`https://vk.com/images/icons/post_widget_2x.png`

**`http://sibkray.ru/news/8/928123/`**
`https://vk.com/video_ext.php?oid=-99099155&id=456252067&hash=852b92a4eeb68a30`
`http://vk.com/js/api/openapi.js?116`

**Regarding tracking. We're still blocking vk tracking: (see examples)**

**`https://riafan.ru/1225277-vyyavlennye-fznc-oskorbleniya-gossimvoliki-pokazali-neobkhodimost-izmeneniya-zakonodatelstva`**
**`https://rueconomics.ru/416376-burnyi-prirost-ipoteki-obuslovil-ozhivlenie-na-rossiiskom-stroitelnom-rynke`**

`https://vk.com/rtrg?p=VK-RTRG-42731-45BDN`
`https://vk.com/rtrg?p=VK-RTRG-25956-6X4Bd`
