### PR TITLE
Fix anti-adblock on cpubenchmark.net & videocardbenchmark.net

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -234,7 +234,8 @@
 @@||gazeta.ru^*/advertising.js$script,domain=gazeta.ru
 ! Adblock-Tracking: nytimes.com
 @@||nytimes.com/ads/google/adsbygoogle.js$script,domain=nytimes.com
-! Adblock-Tracking: cpubenchmark.net
+! Adblock-Tracking: cpubenchmark.net / videocardbenchmark.net
+@@||videocardbenchmark.net/js/ads.js$script,domain=videocardbenchmark.net
 @@||cpubenchmark.net/js/ads.js$script,domain=cpubenchmark.net
 ! Fix digitalriver.com content on various shoping sites.
 @@||api.digitalriver.com^$script,third-party

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -234,6 +234,8 @@
 @@||gazeta.ru^*/advertising.js$script,domain=gazeta.ru
 ! Adblock-Tracking: nytimes.com
 @@||nytimes.com/ads/google/adsbygoogle.js$script,domain=nytimes.com
+! Adblock-Tracking: cpubenchmark.net
+@@||cpubenchmark.net/js/ads.js$script,domain=cpubenchmark.net
 ! Fix digitalriver.com content on various shoping sites.
 @@||api.digitalriver.com^$script,third-party
 @@||img.digitalriver.com/store?$script,image,stylesheet,third-party


### PR DESCRIPTION
As seen on `https://www.cpubenchmark.net/cpu.php?cpu=Intel+Core2+Duo+T9300+%40+2.50GHz&id=1008` and `https://www.videocardbenchmark.net/gpu.php?gpu=Quadro+FX+3000&id=1572`

`https://www.cpubenchmark.net/js/ads.js`
`https://www.videocardbenchmark.net/js/ads.js`

**Source:**
`var canRunAds = true;`
