### PR TITLE
Fix embedded vidible.tv video on politicalflare.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -122,7 +122,7 @@
 ! Embedded vidible video's
 @@||vidible.tv/prod/$xmlhttprequest,media,image
 @@||vidible.tv/prod/player/js/$script
-@@||delivery.vidible.tv/placement/$xhr
+@@||delivery.vidible.tv/placement/$xmlhttprequest
 @@||delivery.vidible.tv/jsonp/$script
 ! LinkedIn in embed
 @@||platform.linkedin.com/$tag=linked-in-embeds

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -122,6 +122,7 @@
 ! Embedded vidible video's
 @@||vidible.tv/prod/$xmlhttprequest,media,image
 @@||vidible.tv/prod/player/js/$script
+@@||delivery.vidible.tv/placement/$xhr
 @@||delivery.vidible.tv/jsonp/$script
 ! LinkedIn in embed
 @@||platform.linkedin.com/$tag=linked-in-embeds


### PR DESCRIPTION
Embedded video playback is broken on this site; (and probably other vidible sites)

`https://www.politicalflare.com/2019/11/republicans-furious-that-sarah-huckabee-sanders-is-being-blacklisted-from-getting-a-job/`

Just need to whitelist the following script:

`https://delivery.vidible.tv/placement/5ce3314e27f25f5968dd980b?bcid=562e7cfeff690a1238314ac1&sid=b8d4d914-dc68-435e-93b5-513cbc77ca9a&s=true&pv=21.1.168&r=https%3A%2F%2Fwww.politicalflare.com%2F2019%2F11%2Frepublicans-furious-that-sarah-huckabee-sanders-is-being-blacklisted-from-getting-a-job%2F&vvuid=D6E84C61-DECE-4E6C-A040-1B80A286BDA6&pt=scriptapi&m.api=dynamic`
