### PR TITLE
Fix video playback on https://www.ctv.ca/The-Rookie

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -131,7 +131,7 @@
 ! Fix addthis.com issues on rhmodern.com  https://github.com/brave/brave-browser/issues/3653
 @@||s7.addthis.com^$script,domain=rhmodern.com
 ! Fix video playback on ctv.ca
-@@||9c9media.ca^$script,domain=ctv.ca
+@@||9c9media.ca^$script,xmlhttprequest,domain=ctv.ca
 ! 2mdn video playback script
 @@||2mdn.net/instream/html5/ima3.js$script,domain=zdnet.com|techrepublic.com
 ! Adblock-Tracking: theintercept.com

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -131,7 +131,8 @@
 ! Fix addthis.com issues on rhmodern.com  https://github.com/brave/brave-browser/issues/3653
 @@||s7.addthis.com^$script,domain=rhmodern.com
 ! Fix video playback on ctv.ca
-@@||9c9media.ca^$script,xmlhttprequest,domain=ctv.ca
+@@||license.9c9media.ca^$xmlhttprequest,domain=ctv.ca
+@@||auth.9c9media.ca^$script,domain=ctv.ca
 ! 2mdn video playback script
 @@||2mdn.net/instream/html5/ima3.js$script,domain=zdnet.com|techrepublic.com
 ! Adblock-Tracking: theintercept.com

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -130,6 +130,8 @@
 @@||static.licdn.com/sc/p$tag=linked-in-embeds
 ! Fix addthis.com issues on rhmodern.com  https://github.com/brave/brave-browser/issues/3653
 @@||s7.addthis.com^$script,domain=rhmodern.com
+! Fix video playback on ctv.ca
+@@||9c9media.ca^$script,domain=ctv.ca
 ! 2mdn video playback script
 @@||2mdn.net/instream/html5/ima3.js$script,domain=zdnet.com|techrepublic.com
 ! Adblock-Tracking: theintercept.com


### PR DESCRIPTION
Blocking the following 9c9media.ca is breaking the site (from the disconnect list); as seen on `https://www.ctv.ca/The-Rookie`

`https://license.9c9media.ca/widevine`
`https://auth.9c9media.ca/auth/main.js`

Maybe affecting other Canadian sites, without the whitelists video playback is broken. I didn't see any tracking from this 9c9media.ca domain. Seems to be used for licensing ?