### PR TITLE
Fix anti-adblock on https://www.zdnet.de/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -186,6 +186,8 @@
 @@||pcwelt.de/js/advert.js$script,domain=pcwelt.de
 ! Anti-adblock: neowin.net
 ||mdn.neowin.net^$domain=neowin.net
+! Anti-adblock: zdnet.de
+@@||zdnet.de^*/advertising.js$script,domain=zdnet.de
 ! Anti-adblock: stream2watch.ws
 @@||tellerium.com/showads.js$script,domain=telerium.tv
 ! Fix use of salesforce 


### PR DESCRIPTION
Anti-adblock reported by https://community.brave.com/t/adblocker-warning-on-www-zdnet-de/92173

On site: `https://www.zdnet.de/`

**Script:**
`https://www.zdnet.de/wp-content/themes/korasa-zdnet-de/assets/js/advertising.js`

**Source:**
`// Used to detect adblockers`
`var can_i_run_ads = true;`