### PR TITLE
Fix anti-adblock adblock on realclearpolitics.com and other realclear sites

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -179,6 +179,10 @@
 @@||veedi.com^*/advert.js$script,domain=veedi.com
 ! Adblock-Tracking: thedailybeast.com
 @@||thedailybeast.com/static/advert.js$script,domain=thedailybeast.com
+! Anti-adblock: realclear
+@@||realclearpolitics.com/asset/section/doubleclick.js$xmlhttprequest,domain=realclearpolitics.com
+@@||realclearscience.com/asset/section/doubleclick.js$xmlhttprequest,domain=realclearscience.com
+@@||realcleardefense.com/asset/section/doubleclick.js$xmlhttprequest,domain=realcleardefense.com
 ! Adblock-Tracking: vice.com
 @@||web-scripts.vice.com/ad.vice.com/$script,domain=vice.com
 ! Anti-adblock: dianomi-anti-adblock


### PR DESCRIPTION
Visiting: `https://www.realclearpolitics.com/` `https://www.realclearscience.com/` and `https://www.realclearscience.com/`

**Scripts:**

`https://www.realclearscience.com/asset/section/doubleclick.js`
`https://www.realclearpolitics.com/asset/section/doubleclick.js`
`https://www.realcleardefense.com/asset/section/doubleclick.js`

**Source:**

`/**`
 `* New add block test made by David 06/09/2017`
 `*/`
`var e = document.createElement('div');`
`e.id = 'AEVBvthGXnCs';`
`e.style.display = 'none';`
`document.body.appendChild(e);`

