### PR TITLE
Fix anti-adblock on other realclear websites from previous request adblock-lists/pull/285

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -180,9 +180,7 @@
 ! Adblock-Tracking: thedailybeast.com
 @@||thedailybeast.com/static/advert.js$script,domain=thedailybeast.com
 ! Anti-adblock: realclear
-@@||realclearpolitics.com/asset/section/doubleclick.js$xmlhttprequest,domain=realclearpolitics.com
-@@||realclearscience.com/asset/section/doubleclick.js$xmlhttprequest,domain=realclearscience.com
-@@||realcleardefense.com/asset/section/doubleclick.js$xmlhttprequest,domain=realcleardefense.com
+@@/doubleclick.js$xmlhttprequest,domain=realclearpolitics.com|realclearpolitics.com|realclearhealth.com|realclearreligion.org|realclearenergy.org|realclearhistory.com|realclearpolicy.com|realclearworld.com|realclearmarkets.com|realclearbooks.com|realcleareducation.com|realclearscience.com|realcleardefense.com
 ! Adblock-Tracking: vice.com
 @@||web-scripts.vice.com/ad.vice.com/$script,domain=vice.com
 ! Anti-adblock: dianomi-anti-adblock


### PR DESCRIPTION
Just addition websites from https://github.com/brave/adblock-lists/pull/285

From the sites on `http://www.realclearmediagroup.com/brands/` They're using the same cms among all the sites.

**Source:**

`/**`
`* New add block test made by David 06/09/2017`
`*/`
`var e = document.createElement('div');`
`e.id = 'AEVBvthGXnCs';`
`e.style.display = 'none';`
`document.body.appendChild(e);`