### PR TITLE
Fix reddit.com share buttons on http://johngaltfla.com/wordpress/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -65,6 +65,8 @@
 @@||reddit.com^*/.json?$script,third-party
 @@||reddit.com^*/access_token$xmlhttprequest,third-party
 @@||oauth.reddit.com^$xmlhttprequest,third-party
+! reddit share buttons
+@@||reddit.com/static/button/$subdocument,third-party
 ! Adblock Tracking
 @@||redditstatic.com^*/ads.js$script,domain=reddit.com
 ! Allow twitter.com readahead (using the twitter api)


### PR DESCRIPTION
Visiting `http://johngaltfla.com/wordpress/`

Has various share/social buttons, however the reddit button is blocked in error? Would be applicable for any site using reddit share buttons.

`http://www.reddit.com/static/button/button1.html?newwindow=true&width=120&url=http%3A%2F%2Fjohngaltfla.com%2Fwordpress%2F2019%2F08%2F05%2F08-05-breaking-news-u-s-treasury-designates-china-as-a-currency-manipulator%2F&title=08.05%20BREAKING%20NEWS%3A%20U.S.%20Treasury%20Designates%20China%20as%20a%20Currency%20Manipulator`
`http://www.reddit.com/static/button/button1.html?newwindow=true&width=120&url=http%3A%2F%2Fjohngaltfla.com%2Fwordpress%2F2019%2F08%2F05%2Fthe-deadly-fork-in-the-road-in-12-terrifying-outcomes%2F&title=The%20Deadly%20Fork%20in%20the%20Road%20in%2012%20Terrifying%20Outcomes`

Seems to just link to reddit rather than track (at the most maybe a referrer track?).  Will send the user to reddit.com to make a post (example); 

`https://www.reddit.com/submit?url=http%3A%2F%2Fjohngaltfla.com%2Fwordpress%2F2019%2F10%2F15%2Fin-memoriam-of-bobby-black%2F&title=In%20Memoriam%20of%20Bobby%20Black`

![reddit-post](https://user-images.githubusercontent.com/1659004/69229719-dd396380-0bea-11ea-84c3-861ef94a4f5d.png)
