### PR TITLE
Fix anti-adblock for https://www.shush.se/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -220,6 +220,8 @@
 ||pcgamer-gb.pcgamer.com^$domain=pcgamer.com
 ! Anti-adblock: concert.io (vox sites)
 @@||vox-cdn.com/packs/concert_ads-$script,domain=theverge.com|eater.com|polygon.com|vox.com|sbnation.com|curbed.com|theringer.com|mmafighting.com|racked.com|mmamania.com|funnyordie.com|riftherald.com
+! Anti-adblock: shush.se
+@@||shush.se/_ads.js$script,domain=shush.se
 ! Adblock-Tracking: tweakers.net
 ||tweakimg.net/x/scripts/min/banners.js$script,domain=tweakers.net
 ! Adblock-Tracking: dailystar.co.uk


### PR DESCRIPTION
Anti-adblock on visiting `https://www.shush.se/index.php?l=406c6b696d467461577835494564312130617a534254404b694c57467a6232346740704f546767406c6b695842706332396b404b694c5321774f4b33&id=s&mirror=MIRROR#loaded1`

**Script:**
`https://www.shush.se/_ads.js?`

**Source:**
`var check=true;`