### PR TITLE
Fix anti-adblock tracking on https://www.snapdeal.com/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -179,6 +179,8 @@
 @@||veedi.com^*/advert.js$script,domain=veedi.com
 ! Adblock-Tracking: thedailybeast.com
 @@||thedailybeast.com/static/advert.js$script,domain=thedailybeast.com
+! Adblock-Tracking: snapdeal.com
+@@||sdlcdn.com^*/ads.js$script,domain=snapdeal.com
 ! Anti-adblock: realclear
 @@/doubleclick.js$xmlhttprequest,domain=realclearpolitics.com|realclearpolitics.com|realclearhealth.com|realclearreligion.org|realclearenergy.org|realclearhistory.com|realclearpolicy.com|realclearworld.com|realclearmarkets.com|realclearbooks.com|realcleareducation.com|realclearscience.com|realcleardefense.com
 ! Adblock-Tracking: vice.com


### PR DESCRIPTION
Ad-block tracking on `https://www.snapdeal.com/`

**Script:**
`https://i1.sdlcdn.com/js/helpcenter1564134737098/snap/ads/ads.js`

**Source:**
`var adBlocker=(function(){var A=document.createElement("div");A.id="adblocker";A.style.display="none";document.body.appendChild(A)})();`