### PR TITLE
Fix Anti-adblock on https://www.dagbladet.no/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -389,6 +389,8 @@
 @@||digitalartsonline.co.uk/scripts/ads.js$script,domain=digitalartsonline.co.uk
 @@||cio.co.uk/scripts/ads.js$script,domain=cio.co.uk
 @@||techworld.com/scripts/ads.js$script,domain=techworld.com
+! Anti-adblock: dagbladet.no
+@@||dagbladet.no^*/prebid.js$script,domain=dagbladet.no
 ! Adblock-Tracking: hanime.tv
 @@||hanime.tv/exoclick.ads.$script,domain=hanime.tv
 ! Adblock-Tracking: esportsheaven.com


### PR DESCRIPTION
Was reported here https://community.brave.com/t/videoes-not-working-when-adblocker-is-enabled/94168

Visiting `https://www.dagbladet.no/video/fant-kidnappet-8-aring-i-skittentoyskurv/oV1LFErb` (With Adblock/Ubo not enabled) Will cause a black video screen

We fix this in Easylist with a cosmetic element `##div[itemtype="http://schema.org/WPAdBlock"]`

Until we get cosmetic filtering, the quick fix for this site is to whitelist this specific script:
`https://www.dagbladet.no/_next/static/prebid-2.6.0/prebid.js` Should be safe to remove once cosmetic filtering has landed (once tested).