### PR TITLE
Anti-adblock tracking on https://abc.com/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -431,6 +431,8 @@
 ! Anti-adblock: washingtonpost.com
 @@||d2ty8gaf6rmowa.cloudfront.net/ad/$domain=washingtonpost.com
 @@||pubads.g.doubleclick.net^$xmlhttprequest,domain=washingtonpost.com
+! Anti-adblock tracking: abc.com
+@@||edgedatg.com^*/ads.min.js$script,domain=abc.com
 ! Fix abcnews.go.com video playback
 @@||akamaihd.net/player/2.106.5/akamai/amp/chartbeatanalytics/Chartbeatanalytics.min.js$domain=abcnews.go.com
 ! Fix blank page on flipp.com


### PR DESCRIPTION
Anti-adblock tracking from; `https://abc.com/shows/jimmy-kimmel-live/video/featured/vdka14524148`

**Script:**
`https://cdn1.edgedatg.com/aws/apps/datg/web-player-unity/1.1.8.15/js/ads.min.js`

**Source:**
`var e=document.createElement("div");e.id="LkFtUuy",e.style.cssText="display:block; width: 0px !important; height: 0px !important",e.className="ads-container",document.body.appendChild(e);`