### PR TITLE
Fix https://github.com/brave/adblock-lists/issues/43 (not being blocked)

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -236,6 +236,8 @@
 @@||cyberciti.biz/js/ads.js$script,domain=cyberciti.biz
 ! Anti-adblock: mediaite.com
 @@||mediaite.com/adbait/adsbygoogle.js$script,domain=mediaite.com
+! Fix yandex.ru blocking on 3dnews.ru
+||aflt.market.yandex.ru^$script,third-party
 ! rambler.ru issues
 @@||myqualification.rambler.ru^$xmlhttprequest,image,stylesheet,domain=gazeta.ru|lenta.ru
 @@||rambler.ru/api/$xmlhttprequest,domain=gazeta.ru


### PR DESCRIPTION
Visiting `https://3dnews.ru/982615` is show the market.yandex widget. With any of the Russian lists enabled in brave://adblock doesn't seem to work when blocking this. I mainly tested Adguard Russian list, but enabling the other Russian lists didn't remove it.

In Adguard; `https://filters.adtidy.org/extension/chromium/filters/1.txt`  (spectiically on https://github.com/AdguardTeam/AdguardFilters/blob/master/RussianFilter/sections/specific.txt#L5635)

`||aflt.market.yandex.$domain=3dnews.ru`

The script we're blocking is `https://aflt.market.yandex.ru/widget/script/api`

Doesn't seem to work well in Brave as its not treating everything after the "." as a wildcard. This is a temp fix, but its a bug on our end