### PR TITLE
Fix captcha on https://kyc.fedex.com/#/app-login

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -395,6 +395,8 @@
 @@||esportsheaven.com/wp-content/themes/esportsheaven/js/advertisement.js$script,domain=esportsheaven.com
 ! adziff ad tracking
 @@||adziff.com/ab/ads.js$xmlhttprequest,domain=pcmag.com|geek.com|extremetech.com
+! Fix nudatasecurity.com (captcha)
+@@||nudatasecurity.com^*/captcha?$image,third-party
 ! Anti-adblock: geoguessr.com
 @@||geoguessr.com/_ads/$script,xmlhttprequest,domain=geoguessr.com
 ! ssrn.com login fix


### PR DESCRIPTION
Was reported here: https://community.brave.com/t/bug-captcha-not-showing-on-fedex-kyc-page/94885

Visiting `https://kyc.fedex.com/#/app-login` and `Submission of KYC Documents`. The disconnect list is blocking the following image file holding the captcha. 

`https://api-us-east-1.nd.nudatasecurity.com/1.0/w/3.74.119619/w-809838/captcha?type=VIDEO&lang=eng&index=0&token=1.w-809838.1.2.C7ADVFNO25d6lWC6JeIezA,,.7e-_MCoWB4oZIjOe9o898pyBmZ_4xVcbaA7R12zXDQ7GAHsOQapHsnUQa4FSOOoNWwjoUSuqjGZx5woYoem5OqqyGLWnNYGWdb5jmCTC17sgCNPh0mDedV6VC7IaUsQ0Bn21j13ChhhfWTov6KD0IgYbk8tBzD4qgqhiygaaAjxDLJnSengws2SEgCOQs_MhghsgbUYAeUb1gCa954ON2uEU73ClNhWnuSgPVSce3bMzjYVL-w8sMAKQ7NgoT-2cNDW1FBEOZCKL4_iQMD6p3ODHZfsvbCHBUehH_Gq4lIXaqhLdb0CpTT7CscgHqfus6l_2lHyL-8KYTJG12SIWsNV07nZW-tjDQi8qN8UDoTl4TzVBWeXHeE4tNmTwqnpFcPRg9ol0Y6mv2h1b1XVeRp76CxWWKOSzHBvipJ8cYPQCRwhB7iTiMOrbJ73lNCM-&r=rs-LHq3cEp667qgDwMlIqi6Ywxx&ptype=SCRIPT`

Will affect other sites using this captcha. No other nudatasecurity scripts or tracking seen on this site.