### PR TITLE
Fix google signin on https://www.shapeways.com/login

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -445,6 +445,8 @@
 ! Anti-adblock: washingtonpost.com
 @@||d2ty8gaf6rmowa.cloudfront.net/ad/$domain=washingtonpost.com
 @@||pubads.g.doubleclick.net^$xmlhttprequest,domain=washingtonpost.com
+! shapeways.com (google-sign)
+@@||plus.google.com/js/$script,domain=shapeways.com
 ! Anti-adblock tracking: abc.com
 @@||edgedatg.com^*/ads.min.js$script,domain=abc.com
 ! Fix abcnews.go.com video playback


### PR DESCRIPTION
Blocking this script prevents the google sign-in popup on `https://www.shapeways.com/login`

Whitelist this script: `https://plus.google.com/js/client:plusone.js?onload=start` will allow the signin to work correctly.

Was reported here; https://community.brave.com/t/brave-x3dom-support/95609