### PR TITLE
Fix oauth.reddit.com use on reddit.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -64,7 +64,7 @@
 ! Allow sites to use reddit api
 @@||reddit.com^*/.json?$script,third-party
 @@||reddit.com^*/access_token$xmlhttprequest,third-party
-@@||oauth.reddit.com^$xmlhttprequest,third-party
+@@||oauth.reddit.com^$xmlhttprequest
 ! reddit share buttons
 @@||reddit.com/static/button/$subdocument,third-party
 ! Adblock Tracking


### PR DESCRIPTION
Visiting the following `https://www.reddit.com/r/DIY/comments/e5k6nu/3d_printed_and_diy_490wh_14s2p_32700_lifepo4/`

Shows we're blocking in shields `https://oauth.reddit.com/api/jail/asknicely?feature=&app_name=web2x&raw_json=1&gilding_detail=1` in error. This could cause issues for reddit. 

