### PR TITLE
Fix ads on https://rutracker.net/forum/index.php

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -434,6 +434,9 @@
 ! Adblock-Tracking: MediaNews Group
 @@||townnews.com^*/flex/components/ads/$script,domain=southernchestercountyweeklies.com|dailylocal.com|delcotimes.com|morningjournal.com|delconewsnetwork.com|montgomerynews.com|mainlinemedianews.com|news-herald.com|cnweekly.com|troyrecord.com|southjerseylocalnews.com|saratogian.com|oneidadispatch.com|dailyfreeman.com|trentonian.com|berksmontnews.com|thenewsherald.com|dailytribune.com|theoaklandpress.com|voicenews.com|themorningsun.com|pottsmerc.com|phoenixvillenews.com|timesherald.com|thereporteronline.com|pvnews.com|tbrnews.com|pressandguide.com|gazettes.com|macombdaily.com
 @@/static/js/ads.js$script,domain=redlandsdailyfacts.com|pasadenastarnews.com|dailybulletin.com|marinij.com|montereyherald.com|presstelegram.com|times-standard.com|chicoer.com|whittierdailynews.com|dailydemocrat.com|dailynews.com|ocregister.com|pe.com|buffzone.com|orovillemr.com|journal-advocate.com|reporterherald.com|broomfieldenterprise.com|record-bee.com|sentinelandenterprise.com|bostonherald.com|nashobavalleyvoice.com|eptrail.com|akronnewsreporter.com|willitsnews.com|redbluffdailynews.com|thevalleydispatch.com|twincities.com|burlington-record.com|fortmorgantimes.com|coloradodaily.com|lamarledger.com|timescall.com|canoncitydailyrecord.com|excelsiorcalifornia.com|advocate-news.com|paradisepost.com|redwoodtimes.com|denverpost.com|mendocinobeacon.com
+! rutracker.net (regional)
+||rutrk.org^$domain=rutracker.net
+||betsonsport.ru^$domain=rutracker.net
 ! Fix endless loading on epaper.timesgroup.com
 @@||googletagservices.com/tag/js/gpt.js$script,domain=epaper.timesgroup.com
 ! Fix nfl.com video playback


### PR DESCRIPTION
Possibly related to this bug; https://github.com/brave/brave-browser/issues/5440 a user reported ads showing up on the rutracker site (https://twitter.com/lukemulks/status/1203421141978644480)

Should limit some of the ads being loaded.

Same filters from https://easylist-downloads.adblockplus.org/advblock.txt
`||rutrk.org/`
`||betsonsport.ru^$third-party`

