### PR TITLE
Fix usps.com whitelist on IOS

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -137,6 +137,8 @@
 @@||auth.9c9media.ca^$script,domain=ctv.ca
 ! 2mdn video playback script
 @@||2mdn.net/instream/html5/ima3.js$script,domain=zdnet.com|techrepublic.com
+! ups.com fix (ios)
+@@||usps.com/go/scripts/tracking.js$script,domain=usps.com
 ! Adblock-Tracking: theintercept.com
 @@||theintercept.com/ads.js$script,domain=theintercept.com
 ! Adblock-Tracking: irishmirror.ie


### PR DESCRIPTION
Visiting `https://tools.usps.com/go/TrackConfirmAction_input?origTrackNum=9274890234839909034667` on IOS will break dropdown menus due to a lack of a whitelist in Easyprivacy.

`easyprivacy/easyprivacy_whitelist.txt:@@||tools.usps.com/go/scripts/tracking.js`

The whitelist will allow the dropdown menus to work correctly.

Was reported here: https://community.brave.com/t/usps-tracking-links/97455