### PR TITLE
Fix Anti-adblock checks on foxnews.com and foxbusiness.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -315,6 +315,7 @@
 ! Adblock-Tracking: motherjones.com
 @@||motherjones.com/wp-content/themes/motherjones/js/ads.min.js$script,domain=motherjones.com
 ! Adblock-Tracking: foxnews.com / foxbusiness.com
+||fncstatic.com^*/google-funding-choices.js$script,domain=foxbusiness.com|foxnews.com
 @@||fncstatic.com/static/v/all/js/ads.js$script,domain=foxbusiness.com|foxnews.com
 ! redditcommentsearch.com (https://community.brave.com/t/redditcommentsearch-doesnt-work-with-shields-on/66496)
 @@||pay.reddit.com/user/$script,domain=redditcommentsearch.com


### PR DESCRIPTION
Visiting: `https://video.foxnews.com/v/6113967935001#sp=show-clips`

Blocking the following script `https://global.fncstatic.com/static/isa/app/lib/google-funding-choices.js` will prevent Anti-adblock Warning from loading from `https://fundingchoicesmessages.google.com/` 