### PR TITLE
Fix uBo list addition block on tags.tiqcdn.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -57,6 +57,8 @@
 ||npttech.com/advertising.js$important,script,redirect=fuckadblock.js-3.2.0,badfilter
 ! crypto ad network
 ||ctnetload.com^$third-party
+! Fix UBO addition (https://github.com/uBlockOrigin/uAssets/commit/dc12acd80d1d64be596272c66ceb0b7925828347)
+||tags.tiqcdn.com^$3p,badfilter
 ! Internal reddit API that breaks reddit for many users
 @@||gateway.reddit.com^
 ! https://github.com/brave/adblock-lists/issues/39


### PR DESCRIPTION
Have previously experimented blocking this script before, and it'll cause many false positives. 

Initial False positive:
`https://community.brave.com/t/hyperlink-does-not-work/98608` 

Only recently committed 2 days ago. Have requested a revert: https://github.com/uBlockOrigin/uAssets/commit/dc12acd80d1d64be596272c66ceb0b7925828347 

But not sure how long this will take for uBO authors, or if they'll revert this. 