### PR TITLE
Remove wp.pl no longer needed since https://github.com/brave/adblock-lists/commit/80a338c0c461

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -420,10 +420,6 @@
 @@||assets.adobedtm.com^$script,domain=ssrn.com
 ! thehindu.com (https://github.com/brave/brave-browser/issues/4808)
 @@||thgim.com/static/js/ads.min.js$script,domain=thehindu.com
-! wp.pl / dobreprogramy.pl (https://github.com/brave/brave-browser/issues/5456)
-@@||wp.pl/mtgx$script,domain=dobreprogramy.pl
-! wp.pl stylesheet issues on https://prawo.money.pl/
-@@||wp.pl^$stylesheet,third-party
 ! gifycat.com ads (https://community.brave.com/t/pages-loads-3rd-party-ads-after-page-loads/71472/10)
 ||ga.gfycat.com^$script,domain=gfycat.com
 ! Anti-adblock tracking: nfl.com


### PR DESCRIPTION
`wp.pl` was removed from the disconnect list. This just reverts the whtelists filters we no longer need.

https://github.com/brave/adblock-lists/commit/80a338c0c4619f3040e2fc1073da419233839a3d