### PR TITLE
Fix Anti-adblock on bild.de

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -426,6 +426,8 @@
 @@||nflcdn.com^*/ad.js$script,domain=nfl.com
 ! Adblock-Tracking: cbc.ca
 @@||cbc.ca/g/stats/js/ads.js$script,domain=cbc.ca
+! Anti-Adblock: bild.de
+@@||asadcdn.com/adlib/$script,stylesheet,domain=bild.de
 ! Adblock-Tracking: computerbase.de
 @@||computerbase.de/js/ads.$script,xmlhttprequest,domain=computerbase.de
 ! Adblock-Tracking: (News corp AU sites)


### PR DESCRIPTION
Was reported on https://old.reddit.com/r/brave_browser/comments/ef7qhc/some_website_dosent_work_with_brave/

This is the script being checked for Anti-adblock visiting `https://www.bild.de/` will cause the browser to force an Anti-adblock message

`https://www.asadcdn.com/adlib/adlib_seq.js`
`https://www.asadcdn.com/adlib/extensions/adplayer.css`