### PR TITLE
Update Notifications servers

### DIFF
--- a/brave-notifications.txt
+++ b/brave-notifications.txt
@@ -15,6 +15,7 @@
 ||alertme.news^$third-party
 ||aswpsdkus.com^$third-party
 ||basepush.com^$third-party
+||bildirt.com^$third-party
 ||bosspush.com^$third-party
 ||braze.com^$third-party
 ||browserpusher.com^$third-party
@@ -25,13 +26,18 @@
 ||cleverpush.com^$third-party
 ||contentsitesrv.com/js/push/$third-party
 ||copush.com^$third-party
+||cracataum.com^$third-party
 ||d2r1yp2w7bby2u.cloudfront.net^
+||easyfeeed.com^$third-party
 ||edrone.me^$third-party
+||farteniuson.com^$third-party
+||fernomius.com^$third-party
 ||fortpush.com^$third-party
 ||foxpush.com^$third-party
 ||foxpush.net^$third-party
 ||getback.ch^$third-party
 ||getpushmonkey.com^$third-party
+||heroesdom.com^$third-party
 ||hitplus.net^$third-party
 ||iopushtech.com^$third-party
 ||irpush.com^$third-party
@@ -40,9 +46,11 @@
 ||master-push.com^$third-party
 ||master-push.net^$third-party
 ||moengage.com^$third-party
+||nativesubscribe.pro^$third-party
 ||news2day.me^$third-party
 ||notification-time.com^$third-party
 ||notification.tubecup.net^
+||olgtex.com^$third-party
 ||onesignal.com^$third-party
 ||partishion.com^$third-party
 ||pathlime.com^$third-party
@@ -59,6 +67,7 @@
 ||push-pro.net^$third-party
 ||push.connect.digital^$third-party
 ||push.daksham.in^$third-party
+||push.esputnik.com^
 ||push.rent^$third-party
 ||push.world^$third-party
 ||push4site.com^$third-party
@@ -71,8 +80,10 @@
 ||pushbox.info^$third-party
 ||pushbullet.com^$third-party
 ||pushcentr.com^$third-party
+||pushchev.info^$third-party
 ||pushcrew.com^$third-party
 ||pushengage.com^$third-party
+||pusherapp.com^$third-party
 ||pushex.io^$third-party
 ||pushify.com^$third-party
 ||pushiki.ru^$third-party
@@ -100,6 +111,7 @@
 ||signaly.co^$third-party
 ||snrcdn.net^$third-party
 ||subscribers.com^$third-party
+||topswp.com^$third-party
 ||truepush.com^$third-party
 ||ucfeed.ru^$third-party
 ||viapush.com^$third-party
@@ -108,6 +120,6 @@
 ||whitepush.biz^$third-party
 ||wonderpush.com^$third-party
 ||worldpush.co^$third-party
-||wpu.sh^$third-party
 ||wpush.biz^$third-party
+||wwclicknews.club^$third-party
 ||xtremepush.com^$third-party


### PR DESCRIPTION
Just an update from Fanboy Annoyances list. A number of new notifications 3rd-party servers. (mostly of Russian origin)

`||wpu.sh^$third-party` has been removed, filter was moved to Easylist.