### PR TITLE
Allow Twitter images on websites

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -449,6 +449,7 @@
 ! Fix twitter images 
 @@||pbs.twimg.com/media/$image,third-party
 @@||pbs.twimg.com/profile_images/$image,third-party
+@@||pbs.twimg.com/amplify_video_thumb/$image,third-party
 ! Anti-adblock tracking Prometheus Global Media
 @@||pgmcdn.com/advertisement.js$script,domain=billboard.com|hollywoodreporter.com|vibe.com
 ! Adblock tradcking: defenseone.com

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -448,6 +448,7 @@
 @@||googletagservices.com/tag/js/gpt.js$script,domain=nfl.com
 ! Fix twitter images 
 @@||pbs.twimg.com/media/$image,third-party
+@@||pbs.twimg.com/ext_tw_video_thumb/$image,third-party
 @@||pbs.twimg.com/profile_images/$image,third-party
 @@||pbs.twimg.com/amplify_video_thumb/$image,third-party
 ! Anti-adblock tracking Prometheus Global Media

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -447,7 +447,8 @@
 ! Fix nfl.com video playback
 @@||googletagservices.com/tag/js/gpt.js$script,domain=nfl.com
 ! Fix twitter images 
-@@||twimg.com^$image,domain=drudgereport.com|batcommunity.org
+@@||pbs.twimg.com/media/$image,third-party
+@@||pbs.twimg.com/profile_images/$image,third-party
 ! Anti-adblock tracking Prometheus Global Media
 @@||pgmcdn.com/advertisement.js$script,domain=billboard.com|hollywoodreporter.com|vibe.com
 ! Adblock tradcking: defenseone.com


### PR DESCRIPTION
While adding filters from one site, came across twitter.com (twimg) images broken on this site `https://www.youradio.cz/`. We have existing filters for 2 sites, making a generic filter for just the  Twitter images hosted by external sites would unbreak a quite few sites.

Seems to affecting a few other sites: `https://publicwww.com/websites/%22pbs.twimg.com%22/`

More sample sites: `https://www.cuny.edu/` `https://www.fanfiction.net/` `https://umich.edu/`