### PR TITLE
fixes brave/brave-browser/5406 (WIP)

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -34,6 +34,8 @@
 ! theatlantic.com anti-blocker filters
 ||theatlantic.blueconic.net$domain=theatlantic.com
 ||theatlantic.com/please-support-us^
+! Fix browser lockup on skepticalscience.com (https://github.com/brave/brave-browser/issues/5406)
+||skepticalscience.net/widgets/heat_widget/js/heat_content.js$script,domain=skepticalscience.com
 ! adops.com unusable without this
 @@||adops.com^$~third-party
 @@||www.scrumpoker.online^$~third-party


### PR DESCRIPTION
This a quick fix on an outstanding issue on https://github.com/brave/brave-browser/issues/5406 for `skepticalscience.com`

Blocking this script will prevent the browser from a lock up. This solution is a temp fix, and could be re-tested/removed in future.

Was re-reported here: https://community.brave.com/t/why-does-this-website-lockup-the-browser/102074/2