### PR TITLE
Fix https://www.yac.chat/pricing

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -464,6 +464,8 @@
 @@||plus.google.com/js/$script,domain=shapeways.com
 ! Anti-adblock tracking: abc.com
 @@||edgedatg.com^*/ads.min.js$script,domain=abc.com
+! Fix yac.chat (Disconnect block on viral-loops.com)
+@@||app.viral-loops.com^$domain=yac.chat
 ! Fix abcnews.go.com video playback
 @@||akamaihd.net/player/2.106.5/akamai/amp/chartbeatanalytics/Chartbeatanalytics.min.js$domain=abcnews.go.com
 ! Fix blank page on flipp.com


### PR DESCRIPTION
Due to the block on `viral-loops.com` in the Disconnect list (possibly a bit overreaching by the Disconnect guys). This whitelist this will allow the user click on 'Request Access` from https://www.yac.chat/pricing  

Did try to make the filter more specific, seems viral-loops.com needs `app.viral-loops.com` items whitelisted to make this work. Made it specific for `yac.chat `, but if we get more reports might be easier to make this generic.

We're whitelisting the following:

`https://app.viral-loops.com/popup_assets/js/vl_load_v2.min.js`
`https://app.viral-loops.com/static/vl-loader.css`
`https://app.viral-loops.com/popup_assets/css/vl_popup.min.css`
`https://app.viral-loops.com/popup_assets/css/style.min.css`
`https://app.viral-loops.com/popup_assets/js/vl_bundle.min.js`
`https://app.viral-loops.com/popup_assets/templates/waitlist.min.js`
`https://app.viral-loops.com/popup_assets/templates/waitlist.min.html?from=https://www.yac.chat`
`https://app.viral-loops.com/api/v2/data?publicToken=jU0rK7aFeDNwisjBE6n4EgV8xl0&params%5Breferrer%5D%5BreferralCode%5D=&params%5Breferrer%5D%5BrefSource%5D=&params%5Baccessors%5D=campaignInfo` 