### PR TITLE
Disable ABP Japanese potential problematic filters

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -376,6 +376,16 @@
 ! bandai-hobby.net (maxmind check causing blank pages)
 @@||js.maxmind.com/js/apis/geoip2/v2.1/geoip2.js$script,domain=bandai-hobby.net
 @@||geoip-js.maxmind.com/geoip/$xmlhttprequest,domain=bandai-hobby.net
+! ABP Japanese problematic filters
+|http:*^ad-$badfilter
+|https:*^ad-$badfilter
+|http:*^ad.$badfilter
+|https:*^ad.$badfilter
+|http:*^ad^$badfilter
+|https:*^ad^$badfilter
+|http:*^ad_$badfilter
+|https:*^ad_$badfilter
+|https:*_ad_$badfilter
 ! ABP Japanese blocking: Google
 @@||googleusercontent.com/videoplayback?$domain=google.com
 @@||googlevideo.com/videoplayback?$xmlhttprequest,domain=youtube.com


### PR DESCRIPTION
While having the ABP Japanese filter I noticed a potential issue with these overally generic filters;

While testing from a UK IP, This filter specific `|https:*_ad_` broke the video playback on `https://www.vice.com/en_us/article/j5yngp/the-universe-is-made-of-tiny-bubbles-containing-mini-universes-scientists-say`.

It would a safe to disable these filters, just too generic and no doubt will cause more false positives.