### PR TITLE
Fix twitter image on https://www.citizenfreepress.com/column-2/amy-klobuchar-is-not-presidential-my-prom-date-was-gay/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -478,6 +478,7 @@
 ! Fix twitter images 
 @@||pbs.twimg.com/media/$image,third-party
 @@||pbs.twimg.com/ext_tw_video_thumb/$image,third-party
+@@||abs.twimg.com/emoji/$image,third-party
 @@||pbs.twimg.com/profile_images/$image,third-party
 @@||pbs.twimg.com/amplify_video_thumb/$image,third-party
 ! Anti-adblock tracking Prometheus Global Media


### PR DESCRIPTION
Visiting `https://www.citizenfreepress.com/column-2/amy-klobuchar-is-not-presidential-my-prom-date-was-gay/` a partial twitter widget is blocked

Minor fix, but we're blocking this image om shields:

`https://abs.twimg.com/emoji/v2/72x72/1f418.png`

