### PR TITLE
Fix Non-clickable links on https://www.elconfidencial.com/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -72,6 +72,8 @@
 @@||reddit.com/static/button/$subdocument,third-party
 ! Adblock Tracking
 @@||redditstatic.com^*/ads.js$script,domain=reddit.com
+! Non-clickable links due to uBo/unbreak
+@@||elconfidencial.com/*/EventTracker.js$script,1p,badfilter
 ! Allow twitter.com readahead (using the twitter api)
 @@||twitter.com/i/search/typeahead.json$third-party
 ! DDG 1P analytics and optimization

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -72,8 +72,8 @@
 @@||reddit.com/static/button/$subdocument,third-party
 ! Adblock Tracking
 @@||redditstatic.com^*/ads.js$script,domain=reddit.com
-! Non-clickable links due to uBo/unbreak
-@@||elconfidencial.com/*/EventTracker.js$script,1p,badfilter
+! Non-clickable links due to cookie consent 
+||elconfidencial.com^*/cookieConsent/$script
 ! Allow twitter.com readahead (using the twitter api)
 @@||twitter.com/i/search/typeahead.json$third-party
 ! DDG 1P analytics and optimization


### PR DESCRIPTION
This affected Brave specifically than ubo by itself. White listing EventTracker.js by ubo is causing links to be non-clickable

Visit: `https://www.elconfidencial.com/` 
With shields enabled, no links will be clickable.

Letting Easyprivacy blocking `/EventTracker.js` should fix this site.

I was going to land a PR removal on uBO but I couldn't reproduce the same issue with uBO lists enabled.

Closing this. causing another issue with comments.