### PR TITLE
Fix Anti-adblock detection script used by fundingchoicesmessages.google.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -325,7 +325,8 @@
 ||fncstatic.com^*/google-funding-choices.js$script,domain=foxbusiness.com|foxnews.com
 @@||fncstatic.com/static/v/all/js/ads.js$script,domain=foxbusiness.com|foxnews.com
 ! Anti-adblock message (fundingchoices)
-@@||fundingchoicesmessages.google.com^$script,domain=marca.com
+||fundingchoicesmessages.google.com^$3p,badfilter
+||fundingchoicesmessages.google.com^$xmlhttprequest
 ! redditcommentsearch.com (https://community.brave.com/t/redditcommentsearch-doesnt-work-with-shields-on/66496)
 @@||pay.reddit.com/user/$script,domain=redditcommentsearch.com
 ! Adblock-Tracking: vg247.com


### PR DESCRIPTION
Blocking the $script used on `fundingchoicesmessages.google.com` will cause Anti-adblock messages for any site using it. (Foxnews/Foxbusiness as another example) It is a problematic filter.

ubO initially fixed [this](https://forums.lanik.us/viewtopic.php?f=62&t=44195&p=152501). Then changed by another author [unfortunately](https://github.com/uBlockOrigin/uAssets/commit/08958cacab69ae2682248dee8c6df063b6a707a7
).

Was reported in the forums: https://community.brave.com/t/message-blockers-on-websites-how-to-remove-it/102494/8 

