### PR TITLE
Fix blank screen on https://watch.wwe.com/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -24,6 +24,7 @@
 ||aps.hearstnp.com^$script,image
 ! Sailthru native ad aggregator fix
 ||ak.sail-horizon.com^$script,image
+@@||ak.sail-horizon.com/spm/$script,domain=wwe.com
 ! vendors serving video ads and tracking via proxied requests
 ||vidazoo.com/aggregate^$third-party
 ||vidazoo.com/proxy^$third-party


### PR DESCRIPTION
User reported in https://community.brave.com/t/wwe-network-no-longer-works-on-brave-browser/104651/2 of blank screens occasionally being shown on `https://watch.wwe.com/`

Blocking this script `||ak.sail-horizon.com^$script,image` prevents other elements of the site from loading. (required a bit of testing of clearing cookies to be sure)

Exact script being whitelisted is `https://ak.sail-horizon.com/spm/spm.v1.min.js`