### PR TITLE
Fix Anti-adblock on https://www.gazzetta.it/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -449,6 +449,8 @@
 @@||adziff.com/ab/ads.js$xmlhttprequest,domain=pcmag.com|geek.com|extremetech.com
 ! Fix nudatasecurity.com (captcha)
 @@||nudatasecurity.com^*/captcha?$image,third-party
+! Anti-adblock: gazzetta.it
+@@||rcsobjects.it^*/openx/$script,domain=gazzetta.it
 ! Anti-adblock: geoguessr.com
 @@||geoguessr.com/_ads/$script,xmlhttprequest,domain=geoguessr.com
 ! ssrn.com login fix


### PR DESCRIPTION
Visiting `https://www.gazzetta.it/` will invoke an anti-adblock message.


The following script is checking for adblock filters:
`https://components2.rcsobjects.it/rcs_data-tracking/v1/distro/openx/gazzetta/openx_async.js`

Just a whitelist to get around this check.