### PR TITLE
Fix and Update ads on dianomi sites

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -199,9 +199,10 @@
 @@||finanzen.net^$generichide
 @@||hardwareluxx.de^$generichide
 @@||golem.de^$generichide
-@@/ad*.$image,domain=hardwareluxx.de|formel1.de|reuters.com|golem.de|finanzen.net
+@@/ad*.$image,domain=hardwareluxx.de|formel1.de|reuters.com|golem.de|finanzen.net|autobild.de
 @@||reuters.com/ads.js$script,domain=reuters.com
 @@||golem.de/*&adserv$script,domain=golem.de
+@@||autobild.de/*&adserv$script,domain=autobild.de
 @@||golem.de^*/showAds.js$script,domain=golem.de
 @@||pcwelt.de/js/advert.js$script,domain=pcwelt.de
 ! Anti-adblock: neowin.net

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -194,11 +194,13 @@
 ! Adblock-Tracking: vice.com
 @@||web-scripts.vice.com/ad.vice.com/$script,domain=vice.com
 ! Anti-adblock: dianomi-anti-adblock
+@@||pcwelt.de^$generichide
+@@||formel1.de^$generichide
+@@||finanzen.net^$generichide
+@@||hardwareluxx.de^$generichide
+@@||golem.de^$generichide
+@@/ad*.$image,domain=hardwareluxx.de|formel1.de|reuters.com|golem.de|finanzen.net
 @@||reuters.com/ads.js$script,domain=reuters.com
-@@||hardwareluxx.de/images/$image,domain=hardwareluxx.de
-@@||formel1.de/public/$image,domain=formel1.de
-@@||reutersmedia.net/resources/$image,domain=reuters.com
-@@||isondled.net^$image,domain=pcwelt.de
 @@||golem.de/*&adserv$script,domain=golem.de
 @@||golem.de^*/showAds.js$script,domain=golem.de
 @@||pcwelt.de/js/advert.js$script,domain=pcwelt.de


### PR DESCRIPTION
Cosmetic checks by dianomi, will cause Ads. 

Tested these filters in Brave Nightly Version 1.6.35 when committing this. 

Including new dianomi domain `finanzen.net` due to a user request here: https://community.brave.com/t/unblocked-ads-on-webpage/108251

