### PR TITLE
Fix https://www.championat.com/ and other rambler sites

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -259,10 +259,11 @@
 ! Fix yandex.ru blocking on 3dnews.ru
 ||aflt.market.yandex.ru^$script,third-party
 ! rambler.ru issues
-@@||myqualification.rambler.ru^$xmlhttprequest,image,stylesheet,domain=gazeta.ru|lenta.ru
-@@||rambler.ru/api/$xmlhttprequest,domain=gazeta.ru
-@@||subscriptions.rambler.ru^$subdocument,script,domain=gazeta.ru
-@@||rambler.ru/widget.js$script,domain=gazeta.ru
+@@||myqualification.rambler.ru^$xmlhttprequest,image,stylesheet
+@@||rambler.ru/api/$xmlhttprequest
+@@||id.rambler.ru^$script,xmlhttprequest
+@@||subscriptions.rambler.ru^$subdocument,script
+@@||rambler.ru/widget.js$script
 ! Adblock-Tracking: gazeta.ru
 @@||gazeta.ru^*/advertising.js$script,domain=gazeta.ru
 ! Adblock-Tracking: nytimes.com


### PR DESCRIPTION
Rambler.ru is blocked outright by the disconnect lists (is a bad idea imo),  as its used for logins, comments. We're blocking the rambler tracking bits in Easyprivacy already. `||ssp.rambler.ru^` and `||sync.rambler.ru^` and other ramber scripts.

Since this will affect Russian sites using `rambler.ru`, we need to just whitelist the scripts needed to avoid breakage of the site.

- Fix css issues breaking on `https://www.championat.com/` caused by blocking of rambler.ru, specifially the domain: `myqualification.rambler.ru`.

- Fix rambler api calls/id/login/comments.

Tested on `https://www.gazeta.ru/` and `https://www.championat.com/`

Issue was reported by @iefremov 

