### PR TITLE
Fix https://amd1.com/contact-us.html

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -151,6 +151,8 @@
 @@||imgbox.com/site_ads.js$script,domain=imgbox.com
 ! thothub.tv (NSFW)
 @@||awemwh.com^$media,domain=thothub.tv
+! Allow godaddy signup forums
+@@||godaddy.com/signups/$subdocument
 ! Adblock-Tracking: cbs sites
 @@||cbsistatic.com^*/advertisement*.js$script,domain=zdnet.com|techrepublic.com
 ! Fix https://github.com/brave/brave-browser/issues/4507 (mirrors uBO fix, rewritten so that brave/ad-block supports)


### PR DESCRIPTION
Was reported here https://community.brave.com/t/why-dis-my-iframe-form-invisible-when-trying-to-view-with-brave-browser/109059

Over zealous blocking from the Disconnect list. this will allow sites to use the godday signup forms

Full url we're fixing: `https://gem.godaddy.com/signups/1acd552f54ac4ba4953cf941b09d56dc/iframe`