### PR TITLE
Fix Blocking on stats.brave.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -22,6 +22,9 @@
 ||aka-cdn-ns.adtech.de^$script,image,domain=aftonbladet.se|expressen.se
 ! Hearst anti-ad blocking fix
 ||aps.hearstnp.com^$script,image
+! stats.brave.com
+stats.brave.com#@#adsContent
+@@||stats.brave.com/local/img/publisher-icons/$domain=stats.brave.com
 ! Sailthru native ad aggregator fix
 ||ak.sail-horizon.com^$script,image
 @@||ak.sail-horizon.com/spm/$script,domain=wwe.com


### PR DESCRIPTION
Just an internal cosmetic fix for stats.brave.com if using Cosmetic filtering, and/or using uBO and Fanboy Social/Annoyances.

