### PR TITLE
Anti-adblock on https://www.investing.com/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -463,6 +463,8 @@ stats.brave.com#@#adsContent
 @@||nudatasecurity.com^*/captcha?$image,third-party
 ! Anti-adblock: gazzetta.it
 @@||rcsobjects.it^*/openx/$script,domain=gazzetta.it
+! Anti-adblock: investing.com
+@@||akamaized.net/js/ads.js$script,domain=investing.com
 ! Anti-adblock: geoguessr.com
 @@||geoguessr.com/_ads/$script,xmlhttprequest,domain=geoguessr.com
 ! ssrn.com login fix


### PR DESCRIPTION
From `https://www.investing.com/`

This is fixed in Nightly, but this is helping a user from `https://community.brave.com/t/shield-down-but-still-ad-block-warning/110300/`

We can remove this when cosmetics/ubo snippets land in Brave release. I can revisit this later.

This whitelists this anti-adblock check:
`http://i-invdn-com.akamaized.net/js/ads.js`
`document.write('<div id="adsense" style="visibility: hidden;">ad</div>');`