### PR TITLE
Fixes https://github.com/brave/brave-browser/issues/8453

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -311,6 +311,9 @@ stats.brave.com#@#adsContent
 @@||sftcdn.net/statics/ads.min.js$xmlhttprequest,domain=softonic.com
 ! Anti-adblock: thehindu.com
 @@||thgim.com/static/js/ads.min.js$script,domain=thehindu.com
+! Anti-adblock: lapresse.ca
+||lapresse-ca.lapresse.ca^$domain=lapresse.ca
+@@||static.lpcdn.ca/lpweb/common/scripts/advertisement.js$script,domain=lapresse.ca
 ! Anti-adblock: brainyquote.com
 @@||brainyquote.com/st/js/3425190/displayad.js$script,domain=brainyquote.com
 ! Anti-adblock: notebookcheck.net / notebookcheck.com


### PR DESCRIPTION
This fixes Anti-adblock checks as reported reported by user: https://github.com/brave/brave-browser/issues/8453

Fixes 2 issues, 

**Blocking the Sourcepoint warning:**
`||lapresse-ca.lapresse.ca^`
**Another adblock check script**
`@@||static.lpcdn.ca/lpweb/common/scripts/advertisement.js$script,domain=lapresse.ca`
**Source:**
`window['noBlocker'] = true;`

Was tested in Brave Nightly, Anti-adblock still showed.

Can be re-visited if my PR is accepted: https://github.com/uBlockOrigin/uAssets/pull/7022
