### PR TITLE
Fix anti-adblock on heise.de

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -200,6 +200,8 @@ stats.brave.com#@#adsContent
 @@/doubleclick.js$xmlhttprequest,domain=realclearpolitics.com|realclearpolitics.com|realclearhealth.com|realclearreligion.org|realclearenergy.org|realclearhistory.com|realclearpolicy.com|realclearworld.com|realclearmarkets.com|realclearbooks.com|realcleareducation.com|realclearscience.com|realcleardefense.com
 ! Adblock-Tracking: vice.com
 @@||web-scripts.vice.com/ad.vice.com/$script,domain=vice.com
+! Anti-adblock: heise.de
+||usercentrics.eu^$third-party
 ! Anti-adblock: dianomi-anti-adblock
 @@||pcwelt.de^$generichide
 @@||formel1.de^$generichide


### PR DESCRIPTION
Visiting `https://www.heise.de/ct/artikel/Streamen-ohne-Schuldgefuehle-Was-Nutzer-fuer-den-Klimaschutz-tun-koennen-4665976.html` would show an anti-adblock.

Blocking `usercentrics.eu` will prevent this adblock check from occurring, and let the page display normally.
