### PR TITLE
Fix dianomi-anti-adblock on tagesspiegel.de

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -209,7 +209,8 @@ stats.brave.com#@#adsContent
 @@||hardwareluxx.de^$generichide
 @@||golem.de^$generichide
 @@||gamestar.de^$generichide
-@@/ad*.$image,domain=hardwareluxx.de|formel1.de|reuters.com|golem.de|finanzen.net|autobild.de|gamestar.de
+@@||tagesspiegel.de^$generichide
+@@/ad*.$image,domain=hardwareluxx.de|formel1.de|reuters.com|golem.de|finanzen.net|autobild.de|gamestar.de|tagesspiegel.de
 @@||reuters.com/ads.js$script,domain=reuters.com
 @@||golem.de/*&adserv$script,domain=golem.de
 @@||autobild.de/*&adserv$script,domain=autobild.de


### PR DESCRIPTION
This just fixes `https://www.tagesspiegel.de/` was notified via Twitter `https://twitter.com/myphs/status/1233140540587356172` 

Simple fix to prevent the dianomi ads from showing.