### PR TITLE
Anti-adblock on https://www.lewat.club/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -182,6 +182,8 @@ stats.brave.com#@#adsContent
 @@||snmc.io^*/advertisement.js$script,domain=rateyourmusic.com
 ! Adblock-Tracking: kijiji.ca
 @@||classistatic.com^*/ads.js$script,domain=kijiji.ca
+! Anti-adblock: lewat.club
+@@||lewat.club/js/ads.js$script,domain=lewat.club
 ! Adblock-Tracking: explosm.net
 @@||explosm.net/js/adsense.js$script,domain=explosm.net
 ! Adblock-Tracking:  mediaite.com


### PR DESCRIPTION
Was reported here https://community.brave.com/t/ad-blocker-detected/110483/3

Checked on Brave nightly, not preventing the Anti-adblock check on `https://www.lewat.club/post/aplikasi-belajar-jadi-DJ-terbaik`

**Source:**
`var e=document.createElement('div');e.id='test-block';e.style.display='none';document.body.appendChild(e);`