### PR TITLE
Fixing https://github.com/brave/brave-browser/issues/8477  (WIP)

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -286,8 +286,6 @@ stats.brave.com#@#adsContent
 @@||rambler.ru/widget.js$script
 ! Adblock-Tracking: gazeta.ru
 @@||gazeta.ru^*/advertising.js$script,domain=gazeta.ru
-! Adblock-Tracking: nytimes.com
-@@||nytimes.com/ads/google/adsbygoogle.js$script,domain=nytimes.com
 ! Adblock-Tracking: cpubenchmark.net / videocardbenchmark.net
 @@||videocardbenchmark.net/js/ads.js$script,domain=videocardbenchmark.net
 @@||cpubenchmark.net/js/ads.js$script,domain=cpubenchmark.net


### PR DESCRIPTION
Seems this whitelist is preventing the top space from collapsing from the main page of `https://www.nytimes.com/`. Confirmed this still occurs in Nightly.  

Looking at developing a snippet for uBo as a counter (as a possible option, assuming it doesn't include the spacing issue)
