### PR TITLE
Fix https://suumo.jp/ on IOS

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -148,6 +148,8 @@ stats.brave.com#@#adsContent
 @@||auth.9c9media.ca^$script,domain=ctv.ca
 ! 2mdn video playback script
 @@||2mdn.net/instream/html5/ima3.js$script,domain=zdnet.com|techrepublic.com
+! suumo.jp (ios)
+@@||suumo.jp/sp/js/beacon.js$script,domain=suumo.jp
 ! ups.com fix (ios)
 @@||usps.com/go/scripts/tracking.js$script,domain=usps.com
 ! Adblock-Tracking: theintercept.com


### PR DESCRIPTION
Filter is taken from https://github.com/easylist/easylist/commit/04d3f7179ce7

Url we're whitelisting: `https://asset01.suumo.jp/sp/js/beacon.js?id=2020022728cf47abcd`

Visiting: `https://suumo.jp/sp/chintai/tokyo/ek_004026540/cond/?sjoken%5B0%5D=059` wouldn't let the user go the next page at the bottom.

Affecting IOS as reported by @chkk525 