### PR TITLE
Fixes https://sweeps.gg/giveaways/msi-trident-x-plus-gaming-pc-giveaway-2/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -325,6 +325,9 @@ stats.brave.com#@#adsContent
 @@||static.lpcdn.ca/lpweb/common/scripts/advertisement.js$script,domain=lapresse.ca
 ! Anti-adblock: brainyquote.com
 @@||brainyquote.com/st/js/3425190/displayad.js$script,domain=brainyquote.com
+! gleam.io
+@@||gleam.io/images/$image,third-party
+@@||gleam.io^*/embed?$subdocument,third-party
 ! Anti-adblock: notebookcheck.net / notebookcheck.com
 @@||notebookcheck-ru.com/ads.js$script,domain=notebookcheck.net|notebookcheck.com
 @@||static.h-bid.com/prebid/$script,domain=notebookcheck.net|notebookcheck.com


### PR DESCRIPTION
Was reported here: https://community.brave.com/t/how-to-make-gleam-io-embedded-on-sites-show/110662

**Visiting:** `https://sweeps.gg/giveaways/msi-trident-x-plus-gaming-pc-giveaway-2/` The Disconnect list is blocking the gleam.io widget (social sweepstake to win prizes etc).

We're blocking 2 items (an image, and iframe):

`https://gleam.io/zaW56/embed?l=https%3A%2F%2Fsweeps.gg%2Fgiveaways%2Fmsi-trident-x-plus-gaming-pc-giveaway-2%2F%3Fgsr%3DzaW56-Ih2Kmh8fo6&r=&gsr=zaW56-Ih2Kmh8fo6`
`https://js.gleam.io/images/logo.png`

We're already blocking the tracking bits from gleam.io already, looks safe to allow the widget to load. The only tracker listed is `||js-agent.newrelic.com^` which is blocked in Easyprivacy.