### PR TITLE
Fixes http://pubnooks.com/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -361,10 +361,9 @@ stats.brave.com#@#adsContent
 @@||pay.reddit.com/user/$script,domain=redditcommentsearch.com
 ! Adblock-Tracking: vg247.com
 @@||vg247.com/wp-content/themes/vg247/scripts/AdsLoad.js$script,domain=vg247.com
-! mailchi.mp form fix (https://github.com/brave/brave-browser/issues/5522)
-@@||list-manage.com/signup-form/subscribe?$domain=mailchi.mp
-@@||list-manage.com/signup-form/settings?$domain=mailchi.mp
-! Allow sites to use signup forms from list-manage
+! Allow sites to use signup forms from list-manage (https://github.com/brave/brave-browser/issues/5522)
+@@||list-manage.com/signup-form/subscribe?$script,third-party
+@@||list-manage.com/signup-form/settings?$script,third-party
 @@||list-manage.com/subscribe/$script,third-party
 ! Anti-adblock: indiatimes.com / timesofindia.com
 @@||indiatimes.com/ads.cms$script,domain=indiatimes.com


### PR DESCRIPTION
Reported from here: https://community.brave.com/t/brave-shields-blocking-mail-chimp-mailing-list-signup-field/110976

Visiting: `http://pubnooks.com/` Currently breaking the signup form.

This will fix allow `list-manage.com`, a newsletter/form provider to work on other sites.

Regarding the tracking bits. We're blocking the tracking url for the site already in Easyprivacy. 
`https://mc.us4.list-manage.com/pages/track/open?` And not affected by this whitelist. 


