### PR TITLE
Fixes https://www.crave.ca/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -141,7 +141,8 @@ stats.brave.com#@#adsContent
 @@||static.licdn.com/sc/p$tag=linked-in-embeds
 ! Fix addthis.com issues on rhmodern.com  https://github.com/brave/brave-browser/issues/3653
 @@||s7.addthis.com^$script,domain=rhmodern.com
-! Fix video playback on ctv.ca
+! 9c9media fixes
+@@||entpay.9c9media.ca^$image,xmlhttprequest,domain=crave.ca
 @@||license.9c9media.ca^$xmlhttprequest,domain=ctv.ca
 @@||auth.9c9media.ca^$script,domain=ctv.ca
 ! 2mdn video playback script

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -143,8 +143,8 @@ stats.brave.com#@#adsContent
 @@||s7.addthis.com^$script,domain=rhmodern.com
 ! 9c9media fixes
 @@||entpay.9c9media.ca^$image,xmlhttprequest,domain=crave.ca
-@@||license.9c9media.ca^$xmlhttprequest,domain=ctv.ca
-@@||auth.9c9media.ca^$script,domain=ctv.ca
+@@||license.9c9media.ca^$xmlhttprequest,domain=ctv.ca|crave.ca
+@@||auth.9c9media.ca^$script,domain=ctv.ca|crave.ca
 ! 2mdn video playback script
 @@||2mdn.net/instream/html5/ima3.js$script,domain=zdnet.com|techrepublic.com
 ! suumo.jp (ios)


### PR DESCRIPTION
Fixes incorrectly blocked items on `https://www.crave.ca/`


**Json Files: (xml requests)**
`https://asset.entpay.9c9media.ca/crave/assets/provinces.json`
`https://asset.entpay.9c9media.ca/crave/assets/bdu.json`

**Their image hosting:**
`https://asset.entpay.9c9media.ca/image-service/version/c:ZDFiMDk5ZmMtZmU4OS00:OGNjNTg0/image.png`