### PR TITLE
Fix ads on https://mail.ru/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -745,8 +745,8 @@ stats.brave.com#@#adsContent
 ! Russian specific rules
 mail.ru##.tgb__link
 mail.ru##.trg-banners
-mail.ru##.pulse-lenta
 mail.ru##.trg-b-banner
+||pulse.mail.ru^$script,domain=mail.ru
 ! Chinese specific rules
 /^https?:\/\/asset.bixjf.com\/[0-9]{4}\/[a-z]{2,}\/[0-9].*(.jpg$)/$image,domain=imkan.tv
 /^https?:\/\/asset.bixjf.com\/[0-9]{4}\/ad\/[0-9].*/$domain=imkan.tv

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -745,8 +745,8 @@ stats.brave.com#@#adsContent
 ! Russian specific rules
 mail.ru##.tgb__link
 mail.ru##.trg-banners
+mail.ru##.pulse-lenta
 mail.ru##.trg-b-banner
-||pulse.mail.ru^$script,domain=mail.ru
 ! Chinese specific rules
 /^https?:\/\/asset.bixjf.com\/[0-9]{4}\/[a-z]{2,}\/[0-9].*(.jpg$)/$image,domain=imkan.tv
 /^https?:\/\/asset.bixjf.com\/[0-9]{4}\/ad\/[0-9].*/$domain=imkan.tv

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -745,7 +745,6 @@ stats.brave.com#@#adsContent
 ! Russian specific rules
 mail.ru##.tgb__link
 mail.ru##.trg-banners
-mail.ru##.pulse-lenta
 mail.ru##.trg-b-banner
 ! Chinese specific rules
 /^https?:\/\/asset.bixjf.com\/[0-9]{4}\/[a-z]{2,}\/[0-9].*(.jpg$)/$image,domain=imkan.tv

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -742,6 +742,11 @@ stats.brave.com#@#adsContent
 ||untidyrice.com^$third-party
 ||womanear.com^$third-party
 ||zlp6s.pw^$third-party
+! Russian specific rules
+mail.ru##.tgb__link
+mail.ru##.trg-banners
+mail.ru##.pulse-lenta
+mail.ru##.trg-b-banner
 ! Chinese specific rules
 /^https?:\/\/asset.bixjf.com\/[0-9]{4}\/[a-z]{2,}\/[0-9].*(.jpg$)/$image,domain=imkan.tv
 /^https?:\/\/asset.bixjf.com\/[0-9]{4}\/ad\/[0-9].*/$domain=imkan.tv


### PR DESCRIPTION
From `https://news.mail.ru/` and `https://mail.ru/`

Was reported by @iefremov (tested in Nightly + RUS list + cosmetic filtering) Was unable to hide the  ads. Given its `#6 on the top Alexa` list of sites, might be a good idea to clean up.

Will need a revisit once cosmetic is working on the regional lists.