### PR TITLE
Fix https://ca.yahoo.com/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -147,6 +147,8 @@ stats.brave.com#@#adsContent
 @@||auth.9c9media.ca^$script,domain=ctv.ca|crave.ca
 ! 2mdn video playback script
 @@||2mdn.net/instream/html5/ima3.js$script,domain=zdnet.com|techrepublic.com
+! ca.yahoo.com (ios)
+/av/ads/*
 ! suumo.jp (ios)
 @@||suumo.jp/sp/js/beacon.js$script,domain=suumo.jp
 ! ups.com fix (ios)

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -148,7 +148,7 @@ stats.brave.com#@#adsContent
 ! 2mdn video playback script
 @@||2mdn.net/instream/html5/ima3.js$script,domain=zdnet.com|techrepublic.com
 ! ca.yahoo.com (ios)
-/av/ads/*
+/av/ads/*$domain=yahoo.com
 ! suumo.jp (ios)
 @@||suumo.jp/sp/js/beacon.js$script,domain=suumo.jp
 ! ups.com fix (ios)


### PR DESCRIPTION
Will prevent inline ad-videos on `https://ca.yahoo.com/` from loading (Using a .ca VPN)

Ad elements picked up.

`https://s.yimg.com/uu/api/res/1.2/V7gU.rpV5gRXgNst41gp4g--~B/Zmk9c3RyaW07aD0zOTI7cHlvZmY9MDt3PTc1MDtzbT0xO2FwcGlkPXl0YWNoeW9u/https://s.yimg.com/av/ads/1584853238138-4462.jpg.cf.webp`

`https://s.yimg.com/uu/api/res/1.2/GrsUjITQxlghAL0axNtIBg--~B/Zmk9c3RyaW07dz0xNjA7aD0xNjA7YXBwaWQ9eXRhY2h5b24-/https://s.yimg.com/av/ads/1539205411300-3868.jpg`


Also committed fixes in EL: https://github.com/easylist/easylist/commit/c2479372470c2ea4e6fc3b29d4ffac82b6403b5a

If we sync with Easylist in Ios, it should pick up my changes.