### PR TITLE
Stop Weather.com Your privacy dialog box:

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -157,6 +157,8 @@ stats.brave.com#@#adsContent
 @@||irishmirror.ie^*/ads.js$script,domain=irishmirror.ie
 ! Adblock-Tracking: imgbox.com
 @@||imgbox.com/site_ads.js$script,domain=imgbox.com
+! weather.com "Your privacy" dialogbox
+||weather.com/weather/*.PrivacyDataNotice.$domain=weather.com
 ! thothub.tv (NSFW)
 @@||awemwh.com^$media,domain=thothub.tv
 ! Allow godaddy signup forums

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -158,7 +158,7 @@ stats.brave.com#@#adsContent
 ! Adblock-Tracking: imgbox.com
 @@||imgbox.com/site_ads.js$script,domain=imgbox.com
 ! weather.com "Your privacy" dialogbox
-||weather.com/weather/*.PrivacyDataNotice.$domain=weather.com
+||weather.com/*.PrivacyDataNotice.$domain=weather.com
 ! thothub.tv (NSFW)
 @@||awemwh.com^$media,domain=thothub.tv
 ! Allow godaddy signup forums


### PR DESCRIPTION
Visiting: `https://weather.com/weather/today/l/37.3519,-121.952??cm_ven=PS_GGL_SLRadar_9102015_1&par=MK_GGL&gcl`

Will bring up a "Your privacy" dialog box, was requested to be fixed.

`https://weather.com/weather/assets/64.PrivacyDataNotice.8009c2a96231540aba0f.js`