### PR TITLE
Fix doubleclick.net clickthroughs

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -147,6 +147,8 @@ stats.brave.com#@#adsContent
 @@||auth.9c9media.ca^$script,domain=ctv.ca|crave.ca|much.com
 ! 2mdn video playback script
 @@||2mdn.net/instream/html5/ima3.js$script,domain=zdnet.com|techrepublic.com
+! Allow doubleclick clickthrough (ios)
+@@||ad.doubleclick.net/ddm/clk/$domain=ad.doubleclick.net
 ! suumo.jp (ios)
 @@||suumo.jp/sp/js/beacon.js$script,domain=suumo.jp
 ! ups.com fix (ios)


### PR DESCRIPTION
On Ios, doubleclick click Visiting: `http://bitly.com/1XsNTuz` Blocking of doubleclick in ios prevents the clickthroughs from working. Only affects IOS.


The debug log of the redirections:

![doubleclick](https://user-images.githubusercontent.com/1659004/77806338-42e1b300-70e9-11ea-9b55-dd16978972ed.png)

