### PR TITLE
Adjust usps.com tracking filter for ios to be more specific

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -153,8 +153,8 @@ stats.brave.com#@#adsContent
 /av/ads/*$domain=yahoo.com
 ! suumo.jp (ios)
 @@||suumo.jp/sp/js/beacon.js$script,domain=suumo.jp
-! ups.com fix (ios)
-@@||usps.com/go/scripts/tracking.js$script,domain=usps.com
+! usps.com fix (ios)
+@@||tools.usps.com/go/scripts/tracking.js$script,domain=tools.usps.com
 ! Adblock-Tracking: theintercept.com
 @@||theintercept.com/ads.js$script,domain=theintercept.com
 ! Adblock-Tracking: irishmirror.ie


### PR DESCRIPTION
Just a minor edit, seems out filter in https://github.com/brave/adblock-lists/pull/302 wasn't working in IOS.

re-done to point to `tools.usps.com` and fixed typo.

Was re-reported in https://community.brave.com/t/usps-tracking-history-accordion-does-not-expand/115377  