### PR TITLE
Fix mailchimp images

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -410,6 +410,7 @@ stats.brave.com#@#adsContent
 ! Mailchimp issues
 ! Fix Mailchimp stylesheet issued (https://www.fallingsquirrel.com/post/the-demo-is-here)
 @@||mailchimp.com/embedcode/$stylesheet
+@@||downloads.mailchimp.com/js/signup-forms/$third-party,script
 @@||gallery.mailchimp.com^$third-party,image
 @@||cdn-images.mailchimp.com^$third-party,image
 ! bandai-hobby.net (maxmind check causing blank pages)

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -407,8 +407,11 @@ stats.brave.com#@#adsContent
 ! fix first-party items on maxmind.com (https://community.brave.com/t/stop-blocking-the-website-for-maxmind-com/68326)
 @@||blog.maxmind.com^$~third-party
 @@||static.maxmind.com^$~third-party
+! Mailchimp issues
 ! Fix Mailchimp stylesheet issued (https://www.fallingsquirrel.com/post/the-demo-is-here)
 @@||mailchimp.com/embedcode/$stylesheet
+@@||gallery.mailchimp.com^$third-party,image
+@@||cdn-images.mailchimp.com^$third-party,image
 ! bandai-hobby.net (maxmind check causing blank pages)
 @@||js.maxmind.com/js/apis/geoip2/v2.1/geoip2.js$script,domain=bandai-hobby.net
 @@||geoip-js.maxmind.com/geoip/$xmlhttprequest,domain=bandai-hobby.net


### PR DESCRIPTION
While looking through email newsletters, seems mailchimp is used for hosting of images, we shouldn't block these. 

No trackers originating from `mailchimp.com`

**Sample images:**
`http://cdn-images.mailchimp.com/icons/social-block/color-googleplus-128.png`
`http://cdn-images.mailchimp.com/icons/social-block/color-facebook-128.png`

`https://gallery.mailchimp.com/34fce217e454abc62a260a345/images/415d3ea0-5255-4536-94be-50b20aa7871b.jpg`
`https://gallery.mailchimp.com/34fce217e454abc62a260a345/images/8d7325bc-c1eb-4bc9-9f8f-553b411bcdb4.jpg`
`https://gallery.mailchimp.com/34fce217e454abc62a260a345/images/2f16f44a-0286-4ed0-978d-014df29e6572.jpg`

![mailchimp](https://user-images.githubusercontent.com/1659004/77819490-186f1480-7140-11ea-87ca-b1164908df5a.png)
