### PR TITLE
Fix ads on dianomi sites (snippets)

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -224,8 +224,6 @@ stats.brave.com#@#adsContent
 @@||gamestar.de^$generichide
 @@||tagesspiegel.de^$generichide
 @@/ad*.$image,domain=hardwareluxx.de|formel1.de|reuters.com|golem.de|finanzen.net|autobild.de|gamestar.de|tagesspiegel.de
-@@||reuters.com/ads.js$script,domain=reuters.com
-@@||golem.de/*&adserv$script,domain=golem.de
 @@||autobild.de/*&adserv$script,domain=autobild.de
 @@||golem.de^*/showAds.js$script,domain=golem.de
 @@||pcwelt.de/js/advert.js$script,domain=pcwelt.de

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -229,6 +229,7 @@ stats.brave.com#@#adsContent
 @@||autobild.de/*&adserv$script,domain=autobild.de
 @@||golem.de^*/showAds.js$script,domain=golem.de
 @@||pcwelt.de/js/advert.js$script,domain=pcwelt.de
+hardwareluxx.de,formel1.de,reuters.com,golem.de,finanzen.net,autobild.de,gamestar.de,tagesspiegel.de##+js(acis, parseInt)
 ! Anti-adblock: neowin.net
 ||mdn.neowin.net^$domain=neowin.net
 ! Anti-adblock: grapevine.is


### PR DESCRIPTION
With the roll out of cosmetic filtering, ads will now start showing on `reuters.com`. Was reported by @fmarier  And affecting the other dianomi sites we work around.

`reuters.com##+js(nostif, .call(null), 10)`  From uBO would fix it (but not working correctly or implemented). This is just a work around on this filter.