### PR TITLE
Fix Facebook logins on https://www.pets-n-friends.com/login.php

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -109,6 +109,7 @@ forbes.com#@#.AD-label300x250
 ! Facebook logins and embeds
 @@||facebook.com^*/sdk.js$tag=fb-embeds
 @@||facebook.net^*/sdk.js$tag=fb-embeds 
+@@||facebook.net^*/all.js$tag=fb-embeds
 @@||facebook.net^*/fbds.js$tag=fb-embeds
 @@||facebook.com^*/fbds.js$tag=fb-embeds
 @@||facebook.com/connect$tag=fb-embed


### PR DESCRIPTION
This fixes a missing whitelist for facebook logins. `https://connect.facebook.net/en_US/all.js`

Used on `https://www.pets-n-friends.com/login.php`

Without this whitelist, it would prevent the user signing up.