### PR TITLE
Fix youtube.com (Japanese geo location)

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -439,6 +439,11 @@ hardwareluxx.de,formel1.de,reuters.com,golem.de,finanzen.net,autobild.de,gamesta
 |http:*^ad_$badfilter
 |https:*^ad_$badfilter
 |https:*_ad_$badfilter
+|http:*-ad-$badfilter
+|https:*-ad-$badfilter
+|http:*-ad^$badfilter
+|https:*-ad^$badfilter
+|https:*-ad_$badfilter
 ! ABP Japanese blocking: Google
 @@||googleusercontent.com/videoplayback?$domain=google.com
 @@||googlevideo.com/videoplayback?$xmlhttprequest,domain=youtube.com


### PR DESCRIPTION
These filters are causing issues on Japanese users. The are too broad and need to be badfilter'd

Is caused by ABP-Japanese filter, `|https:*-ad-`

`https://m.youtube.com/s/player/4fbb4d5b/player-plasma-ias-phone-remote-ad-en_US.vflset/base.js`

Have also badfiltered other problematic filters.