### PR TITLE
A new fix for youtube.com (from adb-japanese)

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -450,6 +450,8 @@ hardwareluxx.de,formel1.de,reuters.com,golem.de,finanzen.net,autobild.de,gamesta
 @@||googleusercontent.com/videoplayback?$domain=google.com
 @@||youtube.com^*/watch_autoplayrenderer.js$script,domain=youtube.com
 @@||youtube.com/yts/jsbin/*-pagead-$script,domain=youtube.com
+@@||youtube.com/s/player/$script,stylesheet,domain=youtube.com
+@@||m.youtube.com/s/player/$script,stylesheet,domain=youtube.com
 @@||googlevideo.com/videoplayback?$xmlhttprequest,domain=youtube.com
 ! ABP Japanese blocking: Youtube (reverse ABP-JPN filters)
 |http:*?*&ip=$third-party,badfilter


### PR DESCRIPTION
`https://m.youtube.com/s/player/f676c671/player-plasma-ias-phone-en_US.vflset/ad.js`

Have done script comparisons, This is the only script being blocked in the Brave/ABP-Japanese. 
I've created 2 whitelists, hoping this is the last fix for this.