### PR TITLE
Another fix for youtube (caused by Korean Adblock List)

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -429,6 +429,8 @@ hardwareluxx.de,formel1.de,reuters.com,golem.de,finanzen.net,autobild.de,gamesta
 ! bandai-hobby.net (maxmind check causing blank pages)
 @@||js.maxmind.com/js/apis/geoip2/v2.1/geoip2.js$script,domain=bandai-hobby.net
 @@||geoip-js.maxmind.com/geoip/$xmlhttprequest,domain=bandai-hobby.net
+! KOR: Korean Adblock List problematic filters 
+/ad.js^$badfilter,domain=~betanews.net
 ! ABP Japanese problematic filters
 |http:*^ad-$badfilter
 |https:*^ad-$badfilter


### PR DESCRIPTION
Since the KOR: Korea Adblock list seems unsupported, this a temp fix around the same issue from https://github.com/brave/adblock-lists/pull/370

Will be intending to remove this list, and Korean users should default to YOUS list (which we have already)