### PR TITLE
Fix Facebook issues with https://apps.facebook.com/candycrush/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -116,6 +116,9 @@ forbes.com#@#.AD-label300x250
 @@||staticxx.facebook.com^$tag=fb-embeds
 @@||graph.facebook.com^$tag=fb-embeds
 @@||xx.fbcdn.net^$tag=fb-embeds
+@@||graph.facebook.com^*width=$tag=fb-embeds
+@@||fbsbx.com/platform/$tag=fb-embeds
+@@||graph.facebook.com^*?access_token=$tag=fb-embeds
 @@||facebook.com^*/plugins/$tag=fb-embeds
 @@||facebook.com/plugins/$tag=fb-embeds
 @@||facebook.com/rsrc.php$tag=fb-embeds


### PR DESCRIPTION
As reported in https://community.brave.com/t/candy-crush-problem/121100

This will fix users with Candy Crush https://apps.facebook.com/candycrush/  without these whitelists, the game won't play.

**@@||graph.facebook.com^*?access_token=$tag=fb-embeds**  (xmlhttprequest)
`https://graph.facebook.com/v6.0/me/apprequests?access_token=EAACZCwCGi5JABAKG4OIB2TNyaemfNkD7kPKQfQMKg5riSuDTKwSqO0FUXwhZB5vDZChfedCQvwdjWOVM4YkgVCfOSe8uTErQmcJxIMgy6OgQwk1hX7Rbhvqw3EZA6Et75N3GjbwSEOpRiylq1Ge9qpa6dUGsObkCqNp1FJ5U4pGH5YkVqDACvUQXvX2hQPD0KfrDwiNDxgZDZD&fields=data&method=get&pretty=0&sdk=joey&suppress_http_code=1`

**@@||fbsbx.com/platform/$tag=fb-embeds**   (xmlhttprequest)
`https://platform-lookaside.fbsbx.com/platform/profilepic/?asid=363216112214165&height=100&width=100&ext=1590400401&hash=AeT1hl8s877aM2FS`

**@@||graph.facebook.com^width=$tag=fb-embeds**  (xmlhttprequest)
`https://graph.facebook.com/v6.0/671094402/picture?width=100&height=100`
