### PR TITLE
Fix salesforce.com on asics.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -254,6 +254,7 @@ hardwareluxx.de,formel1.de,reuters.com,golem.de,finanzen.net,autobild.de,gamesta
 ! Fix use of salesforce 
 @@||my.salesforce.com^$subdocument,third-party
 @@||salesforce.com/jslibrary/$script,third-party
+@@||salesforce.com/embeddedservice/$third-party
 ! Adblock-Tracking: biblegateway.com
 @@||biblegateway.com/assets/js/ads.js$xmlhttprequest,domain=biblegateway.com
 ! Adblock-Tracking: pagesix.com


### PR DESCRIPTION
Another `salesforce.com` issue on https://www.asics.com/us/en-us/gel-cumulus-22/p/ANA_1012A741-020.html?size=10&width=Standard

`https://asicsdigitalinc.my.salesforce.com/embeddedservice/5.0/esw.html?parent=https://www.asics.com/us/en-us/gel-cumulus-22/p/ANA_1012A741-020.html?size=5&width=Standard`
`https://asicsdigitalinc.my.salesforce.com/embeddedservice/5.0/client/liveagent.esw.min.js`
`https://asicsdigitalinc.my.salesforce.com/embeddedservice/5.0/esw.min.css`
`https://asicsdigitalinc.my.salesforce.com/embeddedservice/5.0/utils/common.min.js`