### PR TITLE
Fixes brave/brave-browser#9656

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -430,7 +430,7 @@ hardwareluxx.de,formel1.de,reuters.com,golem.de,finanzen.net,autobild.de,gamesta
 ! Mailchimp issues
 ! Fix Mailchimp stylesheet issued (https://www.fallingsquirrel.com/post/the-demo-is-here)
 @@||mailchimp.com/embedcode/$stylesheet
-@@||downloads.mailchimp.com/js/signup-forms/$third-party,script
+@@||downloads.mailchimp.com^*/signup-forms/$third-party,script,stylesheet
 @@||gallery.mailchimp.com^$third-party,image
 @@||cdn-images.mailchimp.com^$third-party,image
 ! bandai-hobby.net (maxmind check causing blank pages)


### PR DESCRIPTION
This will fix issues regarding blocks on `mailchimp.com` caused by the Disconnect list. 

Fixing https://github.com/brave/brave-browser/issues/9656 on website: https://nocsok.com/about

`https://downloads.mailchimp.com/css/signup-forms/popup/2.0/banner.css`
`https://downloads.mailchimp.com/css/signup-forms/popup/2.0/layout-2.css`
`https://downloads.mailchimp.com/css/signup-forms/popup/2.0/modal.css`

Have requested removal of mailchimp from the Disconnect list.