### PR TITLE
Fix/unblock liveperson.com 

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -530,6 +530,8 @@ hardwareluxx.de,formel1.de,reuters.com,golem.de,finanzen.net,autobild.de,gamesta
 @@||plus.google.com/js/$script,domain=shapeways.com
 ! Anti-adblock tracking: abc.com
 @@||edgedatg.com^*/ads.min.js$script,domain=abc.com
+! Fix liveperson.com (Disconnect block) breaks website chat
+||liveperson.com^$badfilter,third-party,domain=~liveperson.net
 ! Fix Costco (Disconnect block on channeladvisor.com)
 @@||channeladvisor.com/ImageDelivery/$image,third-party
 ! Fix yac.chat (Disconnect block on viral-loops.com)


### PR DESCRIPTION
`||liveperson.com^$third-party,domain=~liveperson.net`

Due to this block, it'll prevent web commerce sites from using web chat communication between them and customers.

`https://www.lowes.com/` and `https://www.darphin.com/` uses liveperson.com/.net (and many https://publicwww.com/websites/%22liveperson.com%22/) 

Interesting enough Disconnect list does not block `liveperson.net`, which is doing the same thing.

We have two blocks on these domains in EL/EP:
`easylist/easylist_thirdparty.txt:||liveperson.com/affiliates/`
`easyprivacy/easyprivacy_specific.txt:||liveperson.net/hc/*/?visitor=`