### PR TITLE
Fix ads on livejournel com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -755,6 +755,9 @@ hardwareluxx.de,formel1.de,reuters.com,golem.de,finanzen.net,autobild.de,gamesta
 mail.ru##.tgb__link
 mail.ru##.trg-banners
 mail.ru##.trg-b-banner
+! livejournal fix
+||livejournal.naydex.net^$xmlhttprequest,domain=livejournal.com
+||livejournal.com/3p1Y1F434/$script,domain=livejournal.com
 ! Chinese specific rules
 /^https?:\/\/asset.bixjf.com\/[0-9]{4}\/[a-z]{2,}\/[0-9].*(.jpg$)/$image,domain=imkan.tv
 /^https?:\/\/asset.bixjf.com\/[0-9]{4}\/ad\/[0-9].*/$domain=imkan.tv


### PR DESCRIPTION
(Russian IP needed) `brave://adblock` ru-regional lists didn't help fix this. Cosmetic via regionals may fix this. 

Blocking these 2 scripts, seems to limit the ads:

`||livejournal.com/3p1Y1F434/$script,domain=livejournal.com`
Stops the ads from loading
`||livejournal.naydex.net^$xmlhttprequest,domain=livejournal.com`
Partially Stops the adblock detection proxy from working.

May need to re-review this, seems `livejournal` don't like adblockers. 
