### PR TITLE
Allow apps.fbsbx.com to use facebook domains

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -126,6 +126,8 @@ forbes.com#@#.AD-label300x250
 @@||facebook.com/login/$tag=fb-embed
 @@||fbsbx.com^$tag=fb-embeds
 @@||facebook.com/x/oauth/$tag=fb-embeds
+@@||connect.facebook.com^$script,domain=apps.fbsbx.com
+@@||connect.facebook.net^$script,domain=apps.fbsbx.com
 ! Twitter embeds
 @@||twitter.com/sw.js$tag=twitter-embeds
 @@||ton.twimg.com^$tag=twitter-embeds


### PR DESCRIPTION
Visit: https://www.facebook.com/instantgames/play/ click on `Play`, expecting games to load. 
Will cause endless loading.

Allowing:
`@@||connect.facebook.com^$script,domain=apps.fbsbx.com`
`@@||connect.facebook.net^$script,domain=apps.fbsbx.com`

This should be safe, its only contained within facebook's own domain `apps.fbsbx.com`, which is not used externally outside of facebook.com.

I prefer not to whitelist `connect.facebook.com` outright, this is limited to facebook's own domain only. No trackers are whitelisted and are still blocked. Hopefully bring down false positives reported in our stats.

![fb-requests](https://user-images.githubusercontent.com/1659004/82728084-45a40180-9d42-11ea-8650-06f87a42aba1.png)
![fb-requests2](https://user-images.githubusercontent.com/1659004/82728086-489ef200-9d42-11ea-96c8-73b65a117645.png)

