### PR TITLE
Remove obsolete Japanese rules

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -781,7 +781,6 @@ mail.ru##.trg-b-banner
 ||r10s.jp/com/rat/js/rat-main.js
 ||yomiuri.co.jp/media/2019/06/190530_1000x240_B-002.jpg
 ||ismedia.jp/common/money-gendai/images/header/sponsored.png
-||yads.yahoo.co.jp^$third-party
 ||addlv.smt.docomo.ne.jp^$third-party
 ||chosunonline.com/common/ifr01/$subdocument
 ||top.bcdn.jp/i/hd_banner/
@@ -805,12 +804,10 @@ mail.ru##.trg-b-banner
 ||pitadtag.jp^$third-party
 ||itmedia.co.jp/spv/images/career_en_300x250.jpg
 ||itmedia.co.jp/spv/images/career_en_320x50.jpg
-||zucks.net^$third-party
 @@||vippers.jp/settings/ad.js
 @@||netmile.co.jp/ad/images/banner/$image
 @@||netmile.co.jp/features/catchpig/images/bnr_120_60.png
 @@||netmile.co.jp/features/furufuru/images/$image
-@@||apple.com^*/promos/$domain=apple.com
 @@||samplefan.com/img/ad/$image
 @@||netmile.co.jp/features/jan/images/bnr_120_60.png
 @@||ad.pr.ameba.jp/tpc/$xmlhttprequest


### PR DESCRIPTION
Removed rules included in AdGuard Japanese and also a rule for ABP Japanese.