### PR TITLE
Add anti-adblock on blockadblock com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -471,6 +471,8 @@ hardwareluxx.de,formel1.de,reuters.com,golem.de,finanzen.net,autobild.de,gamesta
 @@||digitalartsonline.co.uk/scripts/ads.js$script,domain=digitalartsonline.co.uk
 @@||cio.co.uk/scripts/ads.js$script,domain=cio.co.uk
 @@||techworld.com/scripts/ads.js$script,domain=techworld.com
+! blockadblock 
+blockadblock.com##+js(nobab)
 ! Anti-adblock: dagbladet.no
 @@||dagbladet.no^*/prebid.js$script,domain=dagbladet.no
 ! Adblock-Tracking: hanime.tv


### PR DESCRIPTION
Due to uBO avoiding the block on `blockadblock.com` https://github.com/gorhill/uBlock/issues/1271#issuecomment-182831923

`The point of uBO is not to defeat proofs of concept like this, it's to defeat the real use cases. It's why I won't add this filter to the stock filters. By the way, this blockadblock.com site is completely unrelated to fuckadblock.js, which was the original issue here`

But I see no issues with blocking this script, regardless of being a concept or not.  (Was reported here, https://twitter.com/BrendanEich/status/1264785691268898818)