### PR TITLE
Fixes Anti-adblock on https://docker.events.cube365.net/docker/dockercon/content/Videos/icm6kmb3P3ZT8vwt5

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -542,6 +542,8 @@ blockadblock.com##+js(nobab)
 @@||akamaihd.net/player/2.106.5/akamai/amp/chartbeatanalytics/Chartbeatanalytics.min.js$domain=abcnews.go.com
 ! Fix blank page on flipp.com
 @@||wishabi.net^$image,domain=flipp.com
+! Anti-adblock: docker.events.cube365.net 
+cube365.net##+js(aopr, Meteor.setTimeout)
 ! Allow ads on DDG: brave-browser/issues#4533
 @@||duckduckgo.com/m.js
 @@||duckduckgo.com/share/spice/amazon/

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -543,7 +543,7 @@ blockadblock.com##+js(nobab)
 ! Fix blank page on flipp.com
 @@||wishabi.net^$image,domain=flipp.com
 ! Anti-adblock: docker.events.cube365.net 
-cube365.net##+js(aopr, Meteor.setTimeout)
+cube365.net##+js(aopr, bootbox.alert)
 ! Allow ads on DDG: brave-browser/issues#4533
 @@||duckduckgo.com/m.js
 @@||duckduckgo.com/share/spice/amazon/


### PR DESCRIPTION
This will abort the script loading the anti-adblock script, used on https://docker.events.cube365.net/docker/dockercon/content/Videos/icm6kmb3P3ZT8vwt5

`Meteor.setTimeout(function(){var e=Session.get("shieldWarnDisplayed");mixpanel.get_distinct_id||e||(bootbox.alert({message:"Please turn off your Brave Shield/Ad Blockers and refresh the page to view the content on this website!",backdrop:!0}),Session.set("shieldWarnDisplayed",!0))},1500)};var o=function(e,n){var t=e.match(/\w\w/g).map(function(e){return parseInt(e,16)}),o=t[0],i=t[1],a=t[2];return"rgba("+o+","+i+","+a+","+n+")"}}).call(this);`