### PR TITLE
Fix page rendering on https://www.tsn.ca/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -158,8 +158,9 @@ forbes.com#@#.AD-label300x250
 @@||s7.addthis.com^$script,domain=rhmodern.com
 ! 9c9media fixes
 @@||entpay.9c9media.ca^$image,xmlhttprequest,domain=crave.ca
-@@||license.9c9media.ca^$xmlhttprequest,domain=ctv.ca|crave.ca|much.com
-@@||auth.9c9media.ca^$script,domain=ctv.ca|crave.ca|much.com
+@@||license.9c9media.ca^$xmlhttprequest,domain=ctv.ca|crave.ca|much.com|tsn.ca
+@@||auth.9c9media.ca^$script,domain=ctv.ca|crave.ca|much.com|tsn.ca
+@@||datacrunch.9c9media.ca^$xmlhttprequest,domain=tsn.ca
 ! 2mdn video playback script
 @@||2mdn.net/instream/html5/ima3.js$script,domain=zdnet.com|techrepublic.com
 ! Allow doubleclick clickthrough (ios)


### PR DESCRIPTION
Was reported here: https://old.reddit.com/r/brave_browser/comments/gso5et/sites_are_not_fully_loaded_on_brave/

Website: https://www.tsn.ca/ is broken due to Disconnect block on `9c9media.ca`, no trackers or security issues regarding this.


