### PR TITLE
Fix anti-adblock on megaup.net

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -226,6 +226,8 @@ forbes.com#@#.AD-label300x250
 @@||sdlcdn.com^*/ads.js$script,domain=snapdeal.com
 ! myer.com.au (https://github.com/brave/brave-browser/issues/8434)
 @@||digitalexperience.ibm.com^$image,xmlhttprequest,domain=myer.com.au
+! megaup.net
+megaup.net#@#.adBanner
 ! Anti-adblock: realclear
 @@/doubleclick.js$xmlhttprequest,domain=realclearpolitics.com|realclearpolitics.com|realclearhealth.com|realclearreligion.org|realclearenergy.org|realclearhistory.com|realclearpolicy.com|realclearworld.com|realclearmarkets.com|realclearbooks.com|realcleareducation.com|realclearscience.com|realcleardefense.com
 ! Adblock-Tracking: vice.com


### PR DESCRIPTION
Visiting  `https://megaup.net/2d0e8/Balloon_-_Sarkari_Hi._Pra._Shaale_Kasaragodu_.mp3`  will generate an anti-adblock message.

Due to lack of $generichide https://github.com/brave/brave-browser/issues/8803
 (used in uBO for this site), we need to whitelist this specific div element to prevent the Anti-adblock message from showing.

Was reported by @srirambv 