### PR TITLE
Fix ios issue on https://7net.omni7.jp/general/004108/200508bts

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -777,6 +777,8 @@ mail.ru##.trg-b-banner
 ! Chinese specific rules
 /^https?:\/\/asset.bixjf.com\/[0-9]{4}\/[a-z]{2,}\/[0-9].*(.jpg$)/$image,domain=imkan.tv
 /^https?:\/\/asset.bixjf.com\/[0-9]{4}\/ad\/[0-9].*/$domain=imkan.tv
+! (Brave-ios Japanese specific )
+@@||flamingo.gomobile.jp^$script,domain=7net.omni7.jp
 ! 5ch.net (Japanese) Desktop/Mobile IOS/Android-specific blocks
 ||thench.net^$third-party
 ||mediad2.jp^$third-party


### PR DESCRIPTION
Was reported by @chkk525 and others in Brave Japanese.

`..Only on the first launch on iOS,  an alert message appears. Could you see if there’s anything we can do to prevent that?`

From the following url: `https://7net.omni7.jp/general/004108/200508bts`

Causing errors on iOS. 
![image (2)](https://user-images.githubusercontent.com/1659004/83867318-565e6980-a77d-11ea-88a0-392dfcf2e626.png)

Seems to be related to issues related too flamingo.js. If blocking flamingo, this error message will occur. 
