### PR TITLE
Fix cosmetic ads on https://newtoki64.com/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -440,6 +440,9 @@ hardwareluxx.de,formel1.de,reuters.com,golem.de,finanzen.net,autobild.de,gamesta
 @@||geoip-js.maxmind.com/geoip/$xmlhttprequest,domain=bandai-hobby.net
 ! KOR: Korean Adblock List problematic filters 
 /ad.js^$badfilter,domain=~betanews.net
+! Korean adblock (cosmetic) 
+newtoki64.com##.basic-banner
+newtoki64.com##.board-tail-banner
 ! Anti-adblock: pandora.com
 @@||pandora.com/web-version/*/ads.json$xmlhttprequest,domain=pandora.com
 ! Anti-adblock: laptopmedia.com


### PR DESCRIPTION
Due to cosmetic not being applied to `brave://adblock` was reported by 2 users on 
 https://community.brave.com/t/ads-on-newtoki64/132661

Visiting `https://newtoki64.com/` and `https://newtoki64.com/webtoon/93284`  Will help with ads showing on the site.