### PR TITLE
Fixes polldaddy issues from brave/brave-browser#10579

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -586,6 +586,9 @@ mycima.me##+js(acis, Math, zfgloaded)
 @@||channeladvisor.com/ImageDelivery/$image,third-party
 ! Fix yac.chat (Disconnect block on viral-loops.com)
 @@||app.viral-loops.com^$domain=yac.chat
+! Polldaddy (Disconnect block)
+!@@||polldaddy.com/ratings/$domain=cb01.trade
+!@@||polldaddy.com/images/$image,domain=cb01.trade
 ! Fix abcnews.go.com video playback
 @@||akamaihd.net/player/2.106.5/akamai/amp/chartbeatanalytics/Chartbeatanalytics.min.js$domain=abcnews.go.com
 ! Fix blank page on flipp.com

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -587,8 +587,8 @@ mycima.me##+js(acis, Math, zfgloaded)
 ! Fix yac.chat (Disconnect block on viral-loops.com)
 @@||app.viral-loops.com^$domain=yac.chat
 ! Polldaddy (Disconnect block)
-!@@||polldaddy.com/ratings/$domain=cb01.trade
-!@@||polldaddy.com/images/$image,domain=cb01.trade
+@@||polldaddy.com/ratings/$domain=cb01.trade
+@@||polldaddy.com/images/$image,domain=cb01.trade
 ! Fix abcnews.go.com video playback
 @@||akamaihd.net/player/2.106.5/akamai/amp/chartbeatanalytics/Chartbeatanalytics.min.js$domain=abcnews.go.com
 ! Fix blank page on flipp.com


### PR DESCRIPTION
Fixes `polldaddy.com` stars not showing up on cb01.trade in brave/brave-browser#10579

Possibly needs to be reviewed by Disconnect whether polldaddy should be removed. Polldaddy is quite popular, and has a number of scripts.