### PR TITLE
Fixes Notifcations on blockfi.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -223,6 +223,8 @@ youtube.com##+js(json-prune, playerAds)
 @@||lewat.club/js/ads.js$script,domain=lewat.club
 ! Adblock-Tracking: explosm.net
 @@||explosm.net/js/adsense.js$script,domain=explosm.net
+! Blockfi Notifcations
+@@||braze.com^$third-party,domain=blockfi.com
 ! Adblock-Tracking:  mediaite.com
 @@||mediaite.com^*/adsbygoogle.js$script,domain=mediaite.com
 ! Broken video playback on tn.com.ar (https://community.brave.com/t/the-blocker-does-not-allow-you-to-watch-the-video/76691)


### PR DESCRIPTION
Due to the block in the notifications list on `braze.com` they're requesting removal of this block.

Was reported here: https://community.brave.com/t/in-app-messaging-in-brave-desktop-browser/140846

Orginal commit for `braze.com` came here:

https://github.com/easylist/easylist/commit/0c8fa624982c263aadf7fa9580e97bfa4e6ec17a