### PR TITLE
Fix https://cb01.design/ (update domain)

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -589,8 +589,8 @@ mycima.me##+js(acis, Math, zfgloaded)
 ! Fix yac.chat (Disconnect block on viral-loops.com)
 @@||app.viral-loops.com^$domain=yac.chat
 ! Polldaddy (Disconnect block)
-@@||polldaddy.com/ratings/$domain=cb01.trade
-@@||polldaddy.com/images/$image,domain=cb01.trade
+@@||polldaddy.com/ratings/$domain=cb01.trade|cb01.design
+@@||polldaddy.com/images/$image,domain=cb01.trade|cb01.design
 ! Fix abcnews.go.com video playback
 @@||akamaihd.net/player/2.106.5/akamai/amp/chartbeatanalytics/Chartbeatanalytics.min.js$domain=abcnews.go.com
 ! Fix blank page on flipp.com


### PR DESCRIPTION
cb01.trade domain was changed since commit https://github.com/brave/adblock-lists/pull/408 to now `cb01.design`

Just an update of this domain.