### PR TITLE
Fix embeded video in https://www.crashdebug.fr/the-hall-of-lame

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -582,6 +582,8 @@ mycima.me##+js(acis, Math, zfgloaded)
 @@||edgedatg.com^*/ads.min.js$script,domain=abc.com
 ! Fix consent issue on porsche.com (IOS)
 @@||googletagmanager.com/gtm.js$script,domain=porsche.com
+! VK.com fix (Disconnect block)
+@@||vk.com/video_ext.php$subdocument,third-party
 ! Fix liveperson.com (Disconnect block) breaks website chat
 ||liveperson.com^$badfilter,third-party,domain=~liveperson.net
 ! Fix Costco (Disconnect block on channeladvisor.com)


### PR DESCRIPTION
Visiting `https://www.crashdebug.fr/the-hall-of-lame` the embedded `vk.com` video is is being blocked due to the Disconnect list.

Only element being trusted is `https://vk.com/video_ext.php?oid=-19555151&id=456241659&hash=002dffbe7df9a0fd&hd=2`

`Allow all cookies` will also be needed also.

Fixed tracker: https://github.com/easylist/easylist/commit/c5eead8880c52f0c97e7c2f95514ba825757bd34

Was reported by user: https://community.brave.com/t/brave-does-not-show-up-embed-vk-com-video/141436