### PR TITLE
Fix Brave check on krunker.io

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -307,6 +307,8 @@ hardwareluxx.de,formel1.de,reuters.com,golem.de,finanzen.net,autobild.de,gamesta
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=player.abacast.net
 ! Potential Tracker, Annoyance
 ||govdelivery.com^$third-party
+! Anti-Brave checks
+krunker.io##+js(aopw, navigator.brave)
 ! Anti-adblock: cellmapper.net
 @@||cellmapper.net/js/ads.js$script,domain=cellmapper.net
 ! Anti-adblock: cyberciti.biz


### PR DESCRIPTION
Tried to reach out to `krunker.io` about the Brave warning, with no response so far.

https://twitter.com/fanboynz/status/1278521869788786688

`@krunkerio Hey, just investigating an issue with @brave and the website, regarding the performance issues. Can detail what the issues are or re-test in the current Brave builds?`

![krunk-warning](https://user-images.githubusercontent.com/1659004/87090984-fe8bb480-c28c-11ea-9592-298d21cd3cb8.png)

This is just a work around, ideally Krunker should let us know of the issues.