### PR TITLE
Fixes black screen on ios for https://game.friends.ponta.jp/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -851,7 +851,6 @@ mail.ru##.trg-b-banner
 ||addlv.smt.docomo.ne.jp^$third-party
 ||chosunonline.com/common/ifr01/$subdocument
 ||top.bcdn.jp/i/hd_banner/
-||its-mo.com^$third-party
 ||estlier.net^$third-party
 ||netmile.co.jp/images/bnr/sugutama_640_120.png
 ||netmile.co.jp/user/images/regist-sub-bnr.png


### PR DESCRIPTION
Black screen on `https://game.friends.ponta.jp/` caused by old Japanese filter

Safe to just remove.

Was reported by @chkk525 