### PR TITLE
Fix ads on https://www.joemygod.com/ (ios)

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -175,6 +175,9 @@ youtube.com##+js(json-prune, playerAds)
 @@||datacrunch.9c9media.ca^$xmlhttprequest,domain=tsn.ca
 ! 2mdn video playback script
 @@||2mdn.net/instream/html5/ima3.js$script,domain=zdnet.com|techrepublic.com
+! Adservers (ios)
+||pixfuture.com^$third-party
+||taboola.com^$third-party
 ! Allow doubleclick clickthrough (ios)
 @@||ad.doubleclick.net/ddm/clk/$domain=ad.doubleclick.net
 ! ca.yahoo.com (ios)


### PR DESCRIPTION
Was reported here: https://community.brave.com/t/1-18-1-ios-fails-to-block-ads/143905

Scrolling on the site, will show ads on `https://www.joemygod.com/2020/07/chatter-away-overnight-open-thread-843/`

Prevents 2 adservers from loading on ios (checked against latest.json)

