### PR TITLE
Fix https://cb01.events/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -568,8 +568,8 @@ mycima.me##+js(acis, Math, zfgloaded)
 ! Fix yac.chat (Disconnect block on viral-loops.com)
 @@||app.viral-loops.com^$domain=yac.chat
 ! Polldaddy (Disconnect block)
-@@||polldaddy.com/ratings/$domain=cb01.trade|cb01.design
-@@||polldaddy.com/images/$image,domain=cb01.trade|cb01.design
+@@||polldaddy.com/ratings/$script,thirdparty
+@@||polldaddy.com/images/$image,third-party
 ! Fix abcnews.go.com video playback
 @@||akamaihd.net/player/2.106.5/akamai/amp/chartbeatanalytics/Chartbeatanalytics.min.js$domain=abcnews.go.com
 ! Fix blank page on flipp.com

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -568,8 +568,8 @@ mycima.me##+js(acis, Math, zfgloaded)
 ! Fix yac.chat (Disconnect block on viral-loops.com)
 @@||app.viral-loops.com^$domain=yac.chat
 ! Polldaddy (Disconnect block)
-@@||polldaddy.com/ratings/$script,thirdparty
-@@||polldaddy.com/images/$image,third-party
+@@||polldaddy.com/ratings/$domain=cb01.events
+@@||polldaddy.com/images/$domain=cb01.events
 ! Fix abcnews.go.com video playback
 @@||akamaihd.net/player/2.106.5/akamai/amp/chartbeatanalytics/Chartbeatanalytics.min.js$domain=abcnews.go.com
 ! Fix blank page on flipp.com


### PR DESCRIPTION
Fixing polldaddy issues on https://cb01.events/rogue-warfare-hd-2019/   (unable to click on the stars in the title)

Polldaddy being blocked by Disconnect list, given the domain changes occuring with this site (3rd change so far), was reported again https://community.brave.com/t/rating-stars-for-site-https-cb01-trade/139339/21

No privacy issues with allowing this script(s) to run. This site is used to deliver website polls, or ratings.

![polldaddy-fix](https://user-images.githubusercontent.com/1659004/88005263-21577c00-cb5d-11ea-99a7-14911197e545.png)

Related fixes for the same site:
https://github.com/brave/adblock-lists/pull/410
https://github.com/brave/adblock-lists/pull/408