### PR TITLE
Include Brave social disconnect

### DIFF
--- a/brave-lists/brave-social.txt
+++ b/brave-lists/brave-social.txt
@@ -1,0 +1,15 @@
+! List used by Brave for preventing social elements from loading
+!
+! Facebook
+||connect.facebook.net^$third-party,domain=~atlassolutions.com|~facebook.com|~facebook.de|~facebook.fr|~facebook.net|~fb.com|~fb.me|~fbcdn.net|~fbsbx.com|~friendfeed.com|~instagram.com|~internalfb.com|~messenger.com|~oculus.com|~whatsapp.com|~workplace.com
+||connect.facebook.com^$third-party,domain=~atlassolutions.com|~facebook.com|~facebook.de|~facebook.fr|~facebook.net|~fb.com|~fb.me|~fbcdn.net|~fbsbx.com|~friendfeed.com|~instagram.com|~internalfb.com|~messenger.com|~oculus.com|~whatsapp.com|~workplace.com
+! Facebook Plugins (3rd-party embedded plugins)
+||facebook.com/plugins/$third-party,domain=~atlassolutions.com|~facebook.com|~facebook.de|~facebook.fr|~facebook.net|~fb.com|~fb.me|~fbcdn.net|~fbsbx.com|~friendfeed.com|~instagram.com|~internalfb.com|~messenger.com|~oculus.com|~whatsapp.com|~workplace.com
+! Twitter
+||api.twitter.com^$third-party,domain=~tweetdeck.com|~twitter.com|~twitter.jp
+||platform.twitter.com^$third-party,domain=~tweetdeck.com|~twitter.com|~twitter.jp
+! Linkedin
+||licdn.com^$third-party,domain=~linkedin.com
+||linkedin.com^$third-party
+! Outbrain
+||outbrain.com^$third-party,domain=~sphere.com


### PR DESCRIPTION
Having a few versions of a cut-down version of the previous `brave-disconnect.txt`. This is the better way to go:

1. We're not reliant on unknown reasons on why a filter is in the list
2. Avoiding over blockage of non-tracking domains.
3. We're covering our needs only what is part of `brave://settings/socialBlocking`
4. Many of the domains aren't used for tracking or we already block them via existing generic filters in https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_general.txt anything missing will added to Easyprivacy as we normally address this.

This list could be trimmed further (removing some of the google domains already in EL/EP). But this is a good base to start with.