### PR TITLE
Fix Twitter ad cosmetic elements

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -103,6 +103,8 @@ youtube.com##+js(set, adPlacements, undefined)
 @@||reddit.com/static/button/$subdocument,third-party
 ! Adblock Tracking
 @@||redditstatic.com^*/ads.js$script,domain=reddit.com
+! Twitter ad cosmetic element 
+twitter.com##[style]>div>div>[data-testid=placementTracking]
 ! Allow twitter.com readahead (using the twitter api)
 @@||twitter.com/i/search/typeahead.json$third-party
 ! DDG 1P analytics and optimization


### PR DESCRIPTION
Since we don't support has-text (see below), to hide twitter cosmetic ads, this alternative cosmetic to hide them

`twitter.com##div[data-testid="placementTracking"]:has(svg + div[dir="auto"] > span:has-text(/Promoted|Gesponsert|Promocionado|Sponsorisé|Sponsorizzato|Promowane|Promovido|Реклама|Uitgelicht|Sponsorlu|Mainostettu|推廣|推广|推薦|推荐/))`

Confirmed with @jonathansampson and tested this twitter element works.