### PR TITLE
Fix anti-adblock on vox sister sites

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -320,8 +320,7 @@ hardwareluxx.de,formel1.de,reuters.com,golem.de,finanzen.net,autobild.de,gamesta
 ||pcgamer-gb.pcgamer.com^$domain=pcgamer.com
 ! Anti-adblock: concert.io (vox sites)
 @@||vox-cdn.com/packs/concert_ads-$script,domain=theverge.com|eater.com|polygon.com|vox.com|sbnation.com|curbed.com|theringer.com|mmafighting.com|racked.com|mmamania.com|funnyordie.com|riftherald.com
-theverge.com##+js(nostif, (), 1500)
-vox.com,theverge.com##+js(nostif, adsBlocked)
+theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com,mmafighting.com,racked.com,mmamania.com,funnyordie.com,riftherald.com##+js(nostif, adsBlocked)
 ! Anti-adblock: shush.se
 @@||shush.se/_ads.js$script,domain=shush.se
 ! Adblock-Tracking: tweakers.net


### PR DESCRIPTION
Rolled out fixes to other voxmedia.

covering more domains, slightly mirror a recent commit's in uBO 

https://github.com/uBlockOrigin/uAssets/commit/ee195bc4b35d4dfccde7a4954b4c5ba3360637dc
https://github.com/uBlockOrigin/uAssets/commit/13309618b122f95685267d64c376b601b9bfc2e2

From the original fix in https://github.com/brave/adblock-lists/pull/433