### PR TITLE
Cleanup reddit links

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -92,12 +92,10 @@ youtube.com##+js(set, playerResponse.adPlacements undefined)
 ||theatlantic.com/packages/adsjs^$script,domain=theatlantic.com
 ! crypto ad network
 ||ctnetload.com^$third-party
-! Internal reddit API that breaks reddit for many users
-@@||gateway.reddit.com^
 ! https://github.com/brave/adblock-lists/issues/39
 @@||alb.reddit.com^
 ! Adblock Tracking
-@@||redditstatic.com^*/ads.js$script,domain=reddit.com
+@@||redditstatic.com^*/xads.js$script,domain=reddit.com
 ! Twitter ad cosmetic element 
 twitter.com##[style]>div>div>[data-testid=placementTracking]
 ! Allow twitter.com readahead (using the twitter api)


### PR DESCRIPTION
2 Filter changes.

We have removed `gateway.reddit.com` from Easyprivacy, this isn't needed: https://github.com/easylist/easylist/commit/e21704efc5812a911b6f9c0dd6eac72c1d25773f

Also update existing tracking filter `https://www.redditstatic.com/desktop2x/js/xads.js`  (Since we removed the `/ads.js`)