### PR TITLE
Add graph.facebook.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -114,6 +114,7 @@ twitter.com##[style]>div>div>[data-testid=placementTracking]
 ! List used by Brave for preventing social elements from loading
 !
 ! Facebook
+||graph.facebook.com^$third-party,domain=~atlassolutions.com|~facebook.com|~facebook.de|~facebook.fr|~facebook.net|~fb.com|~fb.me|~fbcdn.net|~fbsbx.com|~friendfeed.com|~instagram.com|~internalfb.com|~messenger.com|~oculus.com|~whatsapp.com|~workplace.com
 ||connect.facebook.net^$third-party,domain=~atlassolutions.com|~facebook.com|~facebook.de|~facebook.fr|~facebook.net|~fb.com|~fb.me|~fbcdn.net|~fbsbx.com|~friendfeed.com|~instagram.com|~internalfb.com|~messenger.com|~oculus.com|~whatsapp.com|~workplace.com
 ||connect.facebook.com^$third-party,domain=~atlassolutions.com|~facebook.com|~facebook.de|~facebook.fr|~facebook.net|~fb.com|~fb.me|~fbcdn.net|~fbsbx.com|~friendfeed.com|~instagram.com|~internalfb.com|~messenger.com|~oculus.com|~whatsapp.com|~workplace.com
 ! Facebook Plugins (3rd-party embedded plugins)
@@ -135,6 +136,7 @@ twitter.com##[style]>div>div>[data-testid=placementTracking]
 @@||connect.facebook.net^$tag=fb-embeds
 @@||connect.facebook.com^$tag=fb-embeds
 @@||facebook.com/plugins/$tag=fb-embeds
+@@||graph.facebook.com^$tag=fb-embeds
 ! Twitter embeds
 @@||api.twitter.com^$tag=twitter-embeds
 @@||platform.twitter.com^$tag=twitter-embeds


### PR DESCRIPTION
Add missing facebook domain `https://graph.facebook.com/`

From this page: https://threatpost.com/researcher-publishes-bypass-for-patch-for-vbulletin-0-day-flaw/158232/

`https://graph.facebook.com/?id=https%3A%2F%2Fthreatpost.com%2Fresearcher-publishes-bypass-for-patch-for-vbulletin-0-day-flaw%2F158232%2F`