### PR TITLE
Remove redundant filters

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -4,8 +4,6 @@
 ||webspectator.com^$third-party
 ! Twitch main video
 ||cloudfront.net/esf.js$domain=twitch.tv
-! LA Times forced-whitelisting modal fix
-||tribdss.com/meter/assets$script,domain=www.latimes.com
 ! Hearst anti-ad blocking fix
 ||aps.hearstnp.com^$script,image
 ! brave.com specfic filters

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -6,12 +6,6 @@
 ||cloudfront.net/esf.js$domain=twitch.tv
 ! LA Times forced-whitelisting modal fix
 ||tribdss.com/meter/assets$script,domain=www.latimes.com
-! LA Times and Chicago Tribune native ads fixes
-||aggrego.org^$script,image,domain=latimes.com|chicagotribune.com
-||jadserve.postrelease.com^$script,image,domain=latimes.com|chicagotribune.com
-||troncdata.com^$script,image,domain=latimes.com
-||polarmobile.com^$script,image,domain=latimes.com|chicagotribune.com
-||ntv.io^$script,image,domain=latimes.com|chicagotribune.com
 ! Hearst anti-ad blocking fix
 ||aps.hearstnp.com^$script,image
 ! brave.com specfic filters

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -12,14 +12,6 @@
 ||troncdata.com^$script,image,domain=latimes.com
 ||polarmobile.com^$script,image,domain=latimes.com|chicagotribune.com
 ||ntv.io^$script,image,domain=latimes.com|chicagotribune.com
-! Expressen.se and aftonbladet.set ad blocking evasion fix
-||biowebb-data.s3.amazonaws.com^$script,image,domain=expressen.se|aftonbladet.se
-||richmetrics.com^$script,image,domain=expressen.se|aftonbladet.se
-||adtomafusion.net^$script,image,domain=expressen.se|aftonbladet.se
-||ld1.lpbeta.com^$script,image,domain=expressen.se|aftonbladet.se
-||csp.screen9.com^$script,image,domain=expressen.se|aftonbladet.se
-||glimr.io^$script,image,domain=expressen.se|aftonbladet.se
-||aka-cdn-ns.adtech.de^$script,image,domain=aftonbladet.se|expressen.se
 ! Hearst anti-ad blocking fix
 ||aps.hearstnp.com^$script,image
 ! brave.com specfic filters

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -2,8 +2,6 @@
 @@||adm.fwmrm.net^*/AdManager.js$domain=msnbc.com|sky.com|cnbc.com
 ||novately.com^$third-party
 ||webspectator.com^$third-party
-! Twitch main video
-||cloudfront.net/esf.js$domain=twitch.tv
 ! Hearst anti-ad blocking fix
 ||aps.hearstnp.com^$script,image
 ! brave.com specfic filters


### PR DESCRIPTION
Filters for expressen.se and aftonbladet.se are no longer needed, confirm none of these filters are being used on either website.

Easylist, Easyprivacy + uBO has taken care of most, if not all of the issues.