### PR TITLE
Cover youtube-nocookie.com snippet

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -36,14 +36,14 @@ forbes.com#@#.AD-label300x250
 ||theatlantic.blueconic.net$domain=theatlantic.com
 ||theatlantic.com/please-support-us^
 ! youtube ads
-youtube.com##+js(json-prune, [].playerResponse.adPlacements)
-youtube.com##+js(json-prune, [].playerResponse.playerAds)
-youtube.com##+js(json-prune, playerResponse.adPlacements)
-youtube.com##+js(json-prune, playerResponse.playerAds)
-youtube.com##+js(json-prune, adPlacements)
-youtube.com##+js(json-prune, playerAds)
-youtube.com##+js(set, ytInitialPlayerResponse.adPlacements, undefined)
-youtube.com##+js(set, playerResponse.adPlacements undefined)
+youtube.com,youtube-nocookie.com##+js(json-prune, [].playerResponse.adPlacements)
+youtube.com,youtube-nocookie.com##+js(json-prune, [].playerResponse.playerAds)
+youtube.com,youtube-nocookie.com##+js(json-prune, playerResponse.adPlacements)
+youtube.com,youtube-nocookie.com##+js(json-prune, playerResponse.playerAds)
+youtube.com,youtube-nocookie.com##+js(json-prune, adPlacements)
+youtube.com,youtube-nocookie.com##+js(json-prune, playerAds)
+youtube.com,youtube-nocookie.com##+js(set, ytInitialPlayerResponse.adPlacements, undefined)
+youtube.com,youtube-nocookie.com##+js(set, playerResponse.adPlacements undefined)
 ! Fix browser lockup on skepticalscience.com (https://github.com/brave/brave-browser/issues/5406)
 ||skepticalscience.net/widgets/heat_widget/js/heat_content.js$script,domain=skepticalscience.com
 ! adops.com unusable without this


### PR DESCRIPTION
Used `https://www.youtube-nocookie.com/embed/JwV1iWE8xY0`

and embeded: `https://www.racingcircuits.info/europe/norway/arctic-circle-raceway.html#.XzMw2CiA4uX`

We should also cover `youtube-nocookie.com` domain for our current youtube snippets. And merged in uBO: https://github.com/uBlockOrigin/uAssets/pull/7756