### PR TITLE
Fix anti-brave checks on archive mirrors

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -273,8 +273,7 @@ theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com
 ! Potential Tracker, Annoyance
 ||govdelivery.com^$third-party
 ! Anti-Brave checks
-krunker.io##+js(aopw, navigator.brave)
-archive.is,archive.today,archive.vn,archive.fo##+js(aopw, navigator.brave)
+krunker.io,archive.is,archive.today,archive.vn,archive.fo##+js(aopw, navigator.brave)
 ! Anti-adblock: cellmapper.net
 @@||cellmapper.net/js/ads.js$script,domain=cellmapper.net
 ! Anti-adblock: cyberciti.biz

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -274,6 +274,7 @@ theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com
 ||govdelivery.com^$third-party
 ! Anti-Brave checks
 krunker.io##+js(aopw, navigator.brave)
+archive.is,archive.today,archive.vn,archive.fo##+js(aopw, navigator.brave)
 ! Anti-adblock: cellmapper.net
 @@||cellmapper.net/js/ads.js$script,domain=cellmapper.net
 ! Anti-adblock: cyberciti.biz


### PR DESCRIPTION
Fix anti-Brave check on archive mirrors. archive.is,archive.today,archive.vn,archive.fo is checking for the Brave and limiting access.  