### PR TITLE
Fix amazon tracking

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -357,6 +357,8 @@ krunker.io,archive.is,archive.today,archive.vn,archive.fo##+js(aopw, navigator.b
 @@||timesofindia.com/acms/$xmlhttprequest,domain=timesofindia.com
 ! Adblock-Tracking:indiatoday.in
 @@||indiatoday.in/sites/all/modules/custom/itg_ads_blocker/js/ads.js$script,domain=indiatoday.in
+! /track/view| fix for amazon tracking
+@@||amazon.*/shiptrack/view.html$~third-party
 ! Adblock-Tracking: amazon.com + amazon regional
 @@||media-amazon.com^*/showads.$script,third-party
 ! Adblock-Tracking: salon.com


### PR DESCRIPTION
From a tracking a package on amazon. (seem to affect Android as reported by @srirambv 

We're blocking (randomised characters replaced) `https://www.amazon.in/gp/css/shiptrack/view.html/ref=pe_2024234321_12342341_pe_124200_29623423401_typ?ie=UTF8&addressID=khasdxosdfsd&latestArrivalDate=112312423400&orderID=402-2320140-61533022&shipmentDate=1023332&orderingShipmentId=32301893625222&packageId=1`  

From the filter in Easyprivacy `/track/view|`, The `|` not being properly adhered too (The | being ignored).