### PR TITLE
Fix Anti-adblock warning on www.stuff.co.nz

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -343,7 +343,6 @@ krunker.io,archive.is,archive.today,archive.vn,archive.fo##+js(aopw, navigator.b
 ! Adblock-Tracking: motherjones.com
 @@||motherjones.com/wp-content/themes/motherjones/js/ads.min.js$script,domain=motherjones.com
 ! Adblock-Tracking: foxnews.com / foxbusiness.com
-/fundingChoice.js
 ||stuff.co.nz/static/funding-choice/$domain=stuff.co.nz
 ||fncstatic.com^*/google-funding-choices.js$script,domain=foxbusiness.com|foxnews.com
 ||foxnews.com/static/strike/scripts/libs/google.funding.choices.js$script,domain=foxnews.com

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -343,6 +343,8 @@ krunker.io,archive.is,archive.today,archive.vn,archive.fo##+js(aopw, navigator.b
 ! Adblock-Tracking: motherjones.com
 @@||motherjones.com/wp-content/themes/motherjones/js/ads.min.js$script,domain=motherjones.com
 ! Adblock-Tracking: foxnews.com / foxbusiness.com
+/fundingChoice.js
+||stuff.co.nz/static/funding-choice/$domain=stuff.co.nz
 ||fncstatic.com^*/google-funding-choices.js$script,domain=foxbusiness.com|foxnews.com
 ||foxnews.com/static/strike/scripts/libs/google.funding.choices.js$script,domain=foxnews.com
 @@||fncstatic.com/static/v/all/js/ads.js$script,domain=foxbusiness.com|foxnews.com


### PR DESCRIPTION
Prevent Funding choices warning on `https://www.stuff.co.nz/national/health/coronavirus/122448300/coronavirus-heres-how-the-government-is-making-the-covid19-lockdown-decision`, same as the foxnews warning.

This filter will be applied to uBlock Annoyances only, but warning should be block by us.