### PR TITLE
Revert "Fix Anti-adblock warning on www.stuff.co.nz"

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -343,7 +343,6 @@ krunker.io,archive.is,archive.today,archive.vn,archive.fo##+js(aopw, navigator.b
 ! Adblock-Tracking: motherjones.com
 @@||motherjones.com/wp-content/themes/motherjones/js/ads.min.js$script,domain=motherjones.com
 ! Adblock-Tracking: foxnews.com / foxbusiness.com
-||stuff.co.nz/static/funding-choice/$domain=stuff.co.nz
 ||fncstatic.com^*/google-funding-choices.js$script,domain=foxbusiness.com|foxnews.com
 ||foxnews.com/static/strike/scripts/libs/google.funding.choices.js$script,domain=foxnews.com
 @@||fncstatic.com/static/v/all/js/ads.js$script,domain=foxbusiness.com|foxnews.com


### PR DESCRIPTION
Reverts brave/adblock-lists#446

Okay, uBO included it. https://github.com/uBlockOrigin/uAssets/commit/29b8f9279f9213140840f452fecab24f45a49c90