### PR TITLE
Fixes protonmail.com clickthrough links on iOS

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -147,6 +147,8 @@ twitter.com##[style]>div>div>[data-testid=placementTracking]
 ||taboola.com^$third-party
 ! Allow doubleclick clickthrough (ios)
 @@||ad.doubleclick.net/ddm/clk/$domain=ad.doubleclick.net
+! Fix protomail clickthrough on ios
+@@||proton.go2cloud.org^$domain=protonmail.com
 ! ca.yahoo.com (ios)
 /av/ads/*$domain=yahoo.com
 ! suumo.jp (ios)


### PR DESCRIPTION
Links being blocked on ios `https://proton.go2cloud.org/aff_c?offer_id=77&aff_id=9999`

![image_from_ios](https://user-images.githubusercontent.com/1659004/90453111-d1f87180-e143-11ea-8f46-c7e79e87923f.png)
