### PR TITLE
Fix clickthrough for https://go.nordpass.io/aff_c?offer_id=000&aff_id=000

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -147,8 +147,9 @@ twitter.com##[style]>div>div>[data-testid=placementTracking]
 ||taboola.com^$third-party
 ! Allow doubleclick clickthrough (ios)
 @@||ad.doubleclick.net/ddm/clk/$domain=ad.doubleclick.net
-! Fix protomail clickthrough on ios
-@@||proton.go2cloud.org^$domain=protonmail.com
+! Fix nordpass/protomail clickthrough on ios
+@@/aff_c?offer_id=
+@@?offer_id=*&aff_id=
 ! ca.yahoo.com (ios)
 /av/ads/*$domain=yahoo.com
 ! suumo.jp (ios)


### PR DESCRIPTION
Fix another clickthrough issue in ios. `https://go.nordpass.io/aff_c?offer_id=000&aff_id=000`

Caused by `"?offer_id=*&aff_id="`, this will let ios click on links without it causing issues. Refined from https://github.com/brave/adblock-lists/pull/449

Fixing `https://go.nordpass.io/aff_c?offer_id=000&aff_id=00000`
and `https://proton.go2cloud.org/aff_c?offer_id=00&aff_id=000`