### PR TITLE
Further fix for archive

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -277,6 +277,7 @@ theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com
 ||govdelivery.com^$third-party
 ! Anti-Brave checks
 krunker.io,archive.is,archive.today,archive.vn,archive.fo##+js(aopw, navigator.brave)
+archive.is,archive.today,archive.vn,archive.fo##+js(acis, navigator.brave)
 ! Anti-adblock: cellmapper.net
 @@||cellmapper.net/js/ads.js$script,domain=cellmapper.net
 ! Anti-adblock: cyberciti.biz


### PR DESCRIPTION
Just to be sure we null'd the script, we should try to abort the inline script also for archive mirrors.

We have had some reports the message still showing up.