### PR TITLE
Fix itest.5ch.net placeholders

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -865,11 +865,9 @@ livejournal.com##+js(aopr, webpackJsonpSSPjs)
 @@||stat100.ameba.jp/blogportal/img/banner/$image
 itest.5ch.net###instant_ad
 itest.5ch.net###js-bottom-ad-300x250
-itest.5ch.net###js-bottom-ad-320x250
 itest.5ch.net###js-cardview_ad
 itest.5ch.net##.js-cardview_ad-320x180 > iframe
 itest.5ch.net##.js-cardview_ad-320x50
 itest.5ch.net##.js-overlay_ad
 itest.5ch.net##.ad_320x50
 itest.5ch.net##div[class^="sproutad_"]
-itest.5ch.net##.res_ad

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -863,3 +863,13 @@ livejournal.com##+js(aopr, webpackJsonpSSPjs)
 @@||ad.pr.ameba.jp/tpc/$xmlhttprequest
 @@||amebame.com/pub/ads/$domain=ameblo.jp
 @@||stat100.ameba.jp/blogportal/img/banner/$image
+itest.5ch.net###instant_ad
+itest.5ch.net###js-bottom-ad-300x250
+itest.5ch.net###js-bottom-ad-320x250
+itest.5ch.net###js-cardview_ad
+itest.5ch.net##.js-cardview_ad-320x180 > iframe
+itest.5ch.net##.js-cardview_ad-320x50
+itest.5ch.net##.js-overlay_ad
+itest.5ch.net##.ad_320x50
+itest.5ch.net##div[class^="sproutad_"]
+itest.5ch.net##.res_ad


### PR DESCRIPTION
URL: `https://itest.5ch.net/egg/test/read.cgi/android/1596440216`
Issue: placeholders; there are really many patterns and I hope showing just three is enough.
<details><summary>Screenshots</summary>

![5ch-1](https://user-images.githubusercontent.com/58900598/91560033-1837a700-e974-11ea-9aa9-25e436d6ad38.png)

![5ch-2](https://user-images.githubusercontent.com/58900598/91560036-1a9a0100-e974-11ea-98b3-c466b1907c7d.png)

![5ch-3](https://user-images.githubusercontent.com/58900598/91560042-1c63c480-e974-11ea-85a8-e64066fe332f.png)

</details>

Env: Brave for Android 1.12.113 on Android 10
Note: just copied from AdGuard Mobile filters