### PR TITLE
Fix archive mirrors

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -276,6 +276,8 @@ theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com
 ! Anti-Brave checks
 krunker.io,archive.is,archive.today,archive.vn,archive.fo##+js(aopw, navigator.brave)
 archive.is,archive.today,archive.vn,archive.fo##+js(acis, navigator.brave)
+archive.is,archive.today,archive.vn,archive.fo##+js(acis, Object.getPrototypeOf, join) 
+archive.is,archive.today,archive.vn,archive.fo##+js(acis, document.cookie)
 ! Anti-adblock: cellmapper.net
 @@||cellmapper.net/js/ads.js$script,domain=cellmapper.net
 ! Anti-adblock: cyberciti.biz


### PR DESCRIPTION
This is the script blocking us:

`if (Object.keys(Object.getPrototypeOf(navigator)).join(' ').match(/\bbrave\b/)) { document.cookie = 'unsupported-browser=1;path=/;max-age=86400'; document.location.href='/unsupported-browser'; }`

Script has intentionally changed since https://github.com/brave/adblock-lists/pull/443