### PR TITLE
Fix cookie check on archieve

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -277,7 +277,6 @@ theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com
 krunker.io,archive.is,archive.today,archive.vn,archive.fo##+js(aopw, navigator.brave)
 archive.is,archive.today,archive.vn,archive.fo##+js(acis, navigator.brave)
 archive.is,archive.today,archive.vn,archive.fo##+js(acis, Object.getPrototypeOf, join) 
-archive.is,archive.today,archive.vn,archive.fo##+js(acis, document.cookie)
 ! Anti-adblock: cellmapper.net
 @@||cellmapper.net/js/ads.js$script,domain=cellmapper.net
 ! Anti-adblock: cyberciti.biz


### PR DESCRIPTION
Clearing the document.cookie is a causing a redirection  with cloudflare. Unsure if its a recent change or not, but we don't need it.

Safe to remove, the rest the scriptlets can still stay.