### PR TITLE
Fix first-party blocks by Peter Lowes list

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -499,6 +499,9 @@ mycima.me##+js(acis, Math, zfgloaded)
 @@||googletagmanager.com/gtm.js$script,domain=porsche.com
 ! Fix abcnews.go.com video playback
 @@||akamaihd.net/player/2.106.5/akamai/amp/chartbeatanalytics/Chartbeatanalytics.min.js$domain=abcnews.go.com
+! Peter Lowe fixes
+||criteo.com^$badfilter
+||pubmatic.com^$badfilter
 ! Fix blank page on flipp.com
 @@||wishabi.net^$image,domain=flipp.com
 ! Anti-adblock: docker.events.cube365.net 


### PR DESCRIPTION
Both of these sites are already blocked in Easyprivacy already.

Causing issues if a user visit site directly (first party). Due to these filters

```
||criteo.com^
||pubmatic.com^
```

Safe to badfilter any requests
