### PR TITLE
Fix first-party block on tapfiliate.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -502,6 +502,7 @@ mycima.me##+js(acis, Math, zfgloaded)
 ! Peter Lowe fixes
 ||criteo.com^$badfilter
 ||pubmatic.com^$badfilter
+||tapfiliate.com^$badfilter
 ! Fix blank page on flipp.com
 @@||wishabi.net^$image,domain=flipp.com
 ! Anti-adblock: docker.events.cube365.net 


### PR DESCRIPTION
This will resolve rendering issues on https://community.brave.com/t/tapfilliate-says-the-browser-is-out-of-date/162217

we're blocking this already in EP `easyprivacy/easyprivacy_trackingservers.txt:||tapfiliate.com^$third-party` 

Visiting `tapfiliate.com` breaks due to Peter Lowes list.