### PR TITLE
block requests to local resources from non-local origins

### DIFF
--- a/brave-lists/brave-specific.txt
+++ b/brave-lists/brave-specific.txt
@@ -1,1 +1,4 @@
 ! Specific filters (Tracking or ads) for Brave
++||localhost^$third-party,domain=~127.0.0.1|~[::1]
++||127.0.0.1^$third-party,domain=~localhost|~[::1]
++||[::1]^$third-party,domain=~localhost|~127.0.0.1


### PR DESCRIPTION
re-doing https://github.com/brave/adblock-lists/pull/463 now that we know `localhost^` matches all ports on localhost