### PR TITLE
Remove proceding addition + chars

### DIFF
--- a/brave-lists/brave-specific.txt
+++ b/brave-lists/brave-specific.txt
@@ -1,4 +1,4 @@
 ! Specific filters (Tracking or ads) for Brave
-+||localhost^$third-party,domain=~127.0.0.1|~[::1]
-+||127.0.0.1^$third-party,domain=~localhost|~[::1]
-+||[::1]^$third-party,domain=~localhost|~127.0.0.1
+||localhost^$third-party,domain=~127.0.0.1|~[::1]
+||127.0.0.1^$third-party,domain=~localhost|~[::1]
+||[::1]^$third-party,domain=~localhost|~127.0.0.1


### PR DESCRIPTION
Having proceeding `+` doesn't help with filters being implemented

Patch removes these unneeded `+` 