### PR TITLE
Fix Anti-adblock on https://www.cinemablend.com/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -225,6 +225,8 @@ megaup.net#@#.adBanner
 @@||golem.de^*/showAds.js$script,domain=golem.de
 @@||pcwelt.de/js/advert.js$script,domain=pcwelt.de
 hardwareluxx.de,formel1.de,reuters.com,golem.de,finanzen.net,autobild.de,gamestar.de,tagesspiegel.de##+js(acis, parseInt)
+! Anti-adblock message cinemablend.com (ported from uBO Annoyances)
+cinemablend.com##+js(abort-on-property-read, __cmpGdprAppliesGlobally)
 ! chip.de
 ||mms.chip.de^
 ! Anti-adblock: neowin.net


### PR DESCRIPTION
Fix anti-adblock message popup on `https://www.cinemablend.com/news/2546992/why-christopher-nolan-actually-blew-up-a-real-plane-for-tenet`

Filter ported from uBO Annoyances 