### PR TITLE
Fix Anti-adblock message on https://www.latimes.com/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -353,9 +353,6 @@ archive.is,btdig.com,archive.today,archive.vn,archive.fo,archive.md,archive.li,a
 ||fncstatic.com^*/google-funding-choices.js$script,domain=foxbusiness.com|foxnews.com
 ||foxnews.com/static/strike/scripts/libs/google.funding.choices.js$script,domain=foxnews.com
 @@||fncstatic.com/static/v/all/js/ads.js$script,domain=foxbusiness.com|foxnews.com
-! Anti-adblock message (fundingchoices)
-||fundingchoicesmessages.google.com^$3p,badfilter
-||fundingchoicesmessages.google.com^$xmlhttprequest
 ! Adblock-Tracking: vg247.com
 @@||vg247.com/wp-content/themes/vg247/scripts/AdsLoad.js$script,domain=vg247.com
 ! Anti-adblock: indiatimes.com / timesofindia.com


### PR DESCRIPTION
This filter isn't needed now, uBO has better counters against googlefunding messages on a per site basis.

Leaving this script partially running will cause this:

![latimes-bug](https://user-images.githubusercontent.com/1659004/94100098-cb66c380-fe80-11ea-959d-b3eaceeba84e.png)
