### PR TITLE
Address supleks.jp reinjection on mobile (fixes https://github.com/Ad…

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -869,3 +869,4 @@ livejournal.com##+js(aopr, webpackJsonpSSPjs)
 @@||ad.pr.ameba.jp/tpc/$xmlhttprequest
 @@||amebame.com/pub/ads/$domain=ameblo.jp
 @@||stat100.ameba.jp/blogportal/img/banner/$image
+supleks.jp##+js(acis, document.getElementsByClassName, adBlocked)


### PR DESCRIPTION
…guardTeam/AdguardFilters/issues/64521)

Details:
https://github.com/AdguardTeam/AdguardFilters/issues/64521

Reproduced on Brave Android without AG:

![ramendb](https://user-images.githubusercontent.com/58900598/94540658-a9ef4880-0281-11eb-83dd-149a84a14089.png)

I think `##div[class*="_"][data-height]` is too broad for generic (likely to cause FP) so skipped to report to EL. I'm not sure if we should add cosmetic rules for some placeholder now or should wait for mobile support of cosmetic filtering.

Off-topic: if it was uAssets I would have added `!#if  env_mobile` but I guess it's not supported on Brave, right?