### PR TITLE
Make reuters.com filter more speicific

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -220,11 +220,11 @@ megaup.net#@#.adBanner
 @@||golem.de^$generichide
 @@||gamestar.de^$generichide
 @@||tagesspiegel.de^$generichide
-@@/ad*.$image,domain=hardwareluxx.de|formel1.de|reuters.com|golem.de|finanzen.net|autobild.de|gamestar.de|tagesspiegel.de
 @@||autobild.de/*&adserv$script,domain=autobild.de
 @@||golem.de^*/showAds.js$script,domain=golem.de
 @@||pcwelt.de/js/advert.js$script,domain=pcwelt.de
-hardwareluxx.de,formel1.de,reuters.com,golem.de,finanzen.net,autobild.de,gamestar.de,tagesspiegel.de##+js(acis, parseInt)
+hardwareluxx.de,formel1.de,golem.de,finanzen.net,autobild.de,gamestar.de,tagesspiegel.de##+js(acis, parseInt)
+reuters.com##+js(acis, parseInt, toString)
 ! Anti-adblock message cinemablend.com (ported from uBO Annoyances)
 cinemablend.com##+js(abort-on-property-read, __cmpGdprAppliesGlobally)
 ! chip.de


### PR DESCRIPTION
Removed un-needed `@@/ad*.$image,domain=`  

Also Tweaked the reuters filter to be more specific.  Tested against dianomi ads, seems to be fine to countering them.

`reuters.com##+js(acis, parseInt, toString)`