### PR TITLE
Fix Yellow Google funding bar in https://github.com/brave/brave-browser/issues/11945

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -353,6 +353,8 @@ archive.is,btdig.com,archive.today,archive.vn,archive.fo,archive.md,archive.li,a
 ||fncstatic.com^*/google-funding-choices.js$script,domain=foxbusiness.com|foxnews.com
 ||foxnews.com/static/strike/scripts/libs/google.funding.choices.js$script,domain=foxnews.com
 @@||fncstatic.com/static/v/all/js/ads.js$script,domain=foxbusiness.com|foxnews.com
+! Temp fix for Google funding Yellow Bar (https://github.com/brave/brave-browser/issues/11945)
+##div[style*="box-shadow: rgb(136, 136, 136) 0px 0px 12px; color: "]
 ! Adblock-Tracking: vg247.com
 @@||vg247.com/wp-content/themes/vg247/scripts/AdsLoad.js$script,domain=vg247.com
 ! Anti-adblock: indiatimes.com / timesofindia.com


### PR DESCRIPTION
This is a temp fix for https://github.com/brave/brave-browser/issues/11945

Hides the Google funding element as seen on (sample site) `https://www.geekzone.co.nz/`  and also reported on:

https://community.brave.com/t/problem-the-message-that-detects-the-blocking-of-ads-returns-to-the-web/167308
https://old.reddit.com/r/brave_browser/comments/j1jbqz/this_message_on_the_bottom_keeps_appearing_on/
