### PR TITLE
Prevent ebay port scanning scripts

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -200,6 +200,8 @@ twitter.com##[style]>div>div>[data-testid=placementTracking]
 @@||mediaite.com^*/adsbygoogle.js$script,domain=mediaite.com
 ! Broken video playback on tn.com.ar (https://community.brave.com/t/the-blocker-does-not-allow-you-to-watch-the-video/76691)
 @@||googletagmanager.com/gtm.js$script,domain=tn.com.ar
+! ebay portscanning script
+ebay.com##+js(acis, tmx_post_session_params_fixed)
 ! Adblock-Tracking: silvergames.com
 @@||veedi.com^*/advert.js$script,domain=veedi.com
 ! Adblock-Tracking: thedailybeast.com


### PR DESCRIPTION
Due to more reports of ebay causing excessive CPU reports, this should prevent the script from running.  Regardless if the filename changes, this should prevent high cpu usage.

From: https://community.brave.com/t/thinking-about-switching-away-from-brave-if-performance-issues-continue/166696/2