### PR TITLE
Fix google funding on sites with generichide

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -357,6 +357,8 @@ archive.is,btdig.com,archive.today,archive.vn,archive.fo,archive.md,archive.li,a
 @@||fncstatic.com/static/v/all/js/ads.js$script,domain=foxbusiness.com|foxnews.com
 ! Temp fix for Google funding Yellow Bar (https://github.com/brave/brave-browser/issues/11945)
 ##div[style*="box-shadow: rgb(136, 136, 136) 0px 0px 12px; color: "]
+! To counter $ghide in uBO
+geekzone.co.nz,elpais.com##+js(nostif, removeChild(f), 100)
 ! Adblock-Tracking: vg247.com
 @@||vg247.com/wp-content/themes/vg247/scripts/AdsLoad.js$script,domain=vg247.com
 ! Anti-adblock: indiatimes.com / timesofindia.com


### PR DESCRIPTION
Fixes uBO $generichide on `geekzone.co.nz` & `elpais.com` which counters our: `##div[style*="box-shadow: rgb(136, 136, 136) 0px 0px 12px; color: "]`

This will allow our filter defeat the google funding Anti-adblock bar.