### PR TITLE
Fix 127.0.0.1 port scans on ebay-kleinanzeigen.de

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -201,7 +201,7 @@ twitter.com##[style]>div>div>[data-testid=placementTracking]
 ! Broken video playback on tn.com.ar (https://community.brave.com/t/the-blocker-does-not-allow-you-to-watch-the-video/76691)
 @@||googletagmanager.com/gtm.js$script,domain=tn.com.ar
 ! ebay portscanning script
-ebay.com##+js(acis, tmx_post_session_params_fixed)
+ebay.com,ebay-kleinanzeigen.de##+js(acis, tmx_post_session_params_fixed)
 ! Adblock-Tracking: silvergames.com
 @@||veedi.com^*/advert.js$script,domain=veedi.com
 ! Adblock-Tracking: thedailybeast.com


### PR DESCRIPTION
Fixes rolled out to Easyprivacy. https://github.com/easylist/easylist/commit/6216339d30c1d8162d20b166d8eecf7061ebcf1b

But this will also cover if ebay changes the script again. 

Was reported here: https://old.reddit.com/r/brave_browser/comments/j4tggj/this_ebay_site_freezes_brave_for_several_seconds/