### PR TITLE
Fix pubmatic.com block

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -514,6 +514,7 @@ mycima.me##+js(acis, Math, zfgloaded)
 ! Peter Lowe fixes
 ||criteo.com^$badfilter
 ||pubmatic.com^$badfilter
+||appsflyer.com^$badfilter
 ||tapfiliate.com^$badfilter
 ! Fix blank page on flipp.com
 @@||wishabi.net^$image,domain=flipp.com


### PR DESCRIPTION
Visiting `https://www.appsflyer.com/performance-index/` will be broken due to Peter Lowes list block on `||appsflyer.com^` Which is blocking first-party content.

Privacy, we're blocking the tracking scripts in Easyprivacy already:

```
easyprivacy_specific.txt:||t.appsflyer.com^
easyprivacy_trackingservers.txt:||appsflyer.com^$third-party
```