### PR TITLE
Fix nativead Outbrain cosmetics on https://www.stuff.co.nz/ and other sites

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -108,6 +108,47 @@ twitter.com##[style]>div>div>[data-testid=placementTracking]
 @@||licdn.com^$domain=linkedin.com
 ! Outbrain
 ||outbrain.com^$third-party,domain=~sphere.com
+! Outbrain elements
+###around-the-web
+###g-outbrain
+###js-outbrain-module
+###js-outbrain-relateds
+###js-outbrain-under-article
+###outbrain
+###outbrain1
+###outbrainWidget
+###outbrain_widget_0
+##.ArticleFooter-outbrain
+##.ArticleOutbrainLocal
+##.Atom-outbrain
+##.OUTBRAIN
+##.box-outbrain
+##.c2_outbrain
+##.component-outbrain
+##.nok-outbrain-list
+##.ob-smartfeed-wrapper
+##.outbrain
+##.outbrain-ads
+##.outbrain-bloc
+##.outbrain-content
+##.outbrain-group
+##.outbrain-module
+##.outbrain-placeholder
+##.outbrain-recommended
+##.outbrain-relateds
+##.outbrain-widget
+##.outbrain-wrapper
+##.outbrainWidget
+##.outbrain__main
+##.outbrain_container
+##.outbrain_skybox
+##.outbrainbox
+##.pane-bonnier-outbrain-outbrain-video-vr3-widget
+##.pmc-outbrain-amp-widget
+##.sics-component__outbrain
+##.tr-outbrain-container
+##.widget_ione-outbrain
+##.yom-outbrain
 !
 ! Note that options will be added to exclude these filters soon. They
 ! are added both as a blocking rule and as an exception rule so that


### PR DESCRIPTION
Reported from sample page of nativead outbrain content `https://www.stuff.co.nz/national/123119449/election-day-dogsatpollingstations-light-up-social-media`

Merged filters from https://github.com/easylist/easylist/blob/master/fanboy-addon/fanboy_annoyance_general_hide.txt#L438

Given we're already blocking the javascript for outbrain, its safe to block the css also.