### PR TITLE
Fixes Ios on https://www.nintendo.co.jp/ring/index.html

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -191,6 +191,8 @@ twitter.com##[style]>div>div>[data-testid=placementTracking]
 @@?offer_id=*&aff_id=
 ! ca.yahoo.com (ios)
 /av/ads/*$domain=yahoo.com
+! https://www.nintendo.co.jp/ring/index.html (https://github.com/brave/brave-browser/issues/11448)
+@@||nintendo.co.jp/ring/assets_top/img/adv/$~third-party
 ! suumo.jp (ios)
 @@||suumo.jp/sp/js/beacon.js$script,domain=suumo.jp
 ! usps.com fix (ios)


### PR DESCRIPTION
Fixes ios-specific on `https://www.nintendo.co.jp/ring/index.html` from https://github.com/brave/brave-browser/issues/11448

