### PR TITLE
allow audited yandex code when on yandex sites

### DIFF
--- a/brave-lists/brave-specific.txt
+++ b/brave-lists/brave-specific.txt
@@ -2,3 +2,15 @@
 ||localhost^$third-party,domain=~127.0.0.1|~[::1]
 ||127.0.0.1^$third-party,domain=~localhost|~[::1]
 ||[::1]^$third-party,domain=~localhost|~127.0.0.1
+
+! Re-enable 1p scripts for Yandex after finding no privacy concerns for
+! Brave users.
+! Privacy Review: https://github.com/brave/brave-browser/issues/11591
+! Main Issue: https://github.com/brave/brave-browser/issues/12327
+@@||yandex.ru/log?$~script
+@@||yandex.com/clck/$~script
+@@||yandex.ru/clck/click$~script
+@@||mc.yandex.ru^$~script
+@@||yandex.*/count/$~script
+@@||yandex.ru/clck/jclck/$~script
+@@||yandex.*/clck/$xmlhttprequest


### PR DESCRIPTION
Allows Yandex to load some first party scripts, after auditing by brave.  This change does not affect storage policy or result in any 3p storage being enabled / allowed

re https://github.com/brave/brave-browser/issues/12327
after review in https://github.com/brave/brave-browser/issues/11591

cc @bsclifton 