### PR TITLE
allow audited first party, private respecting ads on startpage

### DIFF
--- a/brave-lists/brave-specific.txt
+++ b/brave-lists/brave-specific.txt
@@ -2,3 +2,10 @@
 ||localhost^$third-party,domain=~127.0.0.1|~[::1]
 ||127.0.0.1^$third-party,domain=~localhost|~[::1]
 ||[::1]^$third-party,domain=~localhost|~127.0.0.1
+
+! Add exceptions for first-party, brave-audited start-page resources
+! https://github.com/brave/brave-browser/issues/12257
+@@?adType=$domain=startpage.com
+@@/adsense/*$domain=startpage.com
+@@/afs/ads/*$domain=startpage.com
+@@&adsafe=$domain=startpage.com


### PR DESCRIPTION
Allows Startpage to load some first-party scripts and ads, after being audited to be privacy respecting by brave. This change does not affect storage policy or result in any 3p storage being enabled / allowed

re https://github.com/brave/brave-browser/issues/12257

cc @bsclifton

