### PR TITLE
Fix alien script warning on dslreports.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -564,6 +564,8 @@ mycima.me##+js(acis, Math, zfgloaded)
 ||tapfiliate.com^$badfilter
 ! Fix blank page on flipp.com
 @@||wishabi.net^$image,domain=flipp.com
+! Fix "Alien Warning" script check on dslreports.com https://community.brave.com/t/alien-script-detected-inline-code-at-dslreports-com-speedtest/173716/
+dslreports.com###errorlog
 ! Anti-adblock: docker.events.cube365.net 
 cube365.net##+js(aopr, bootbox.alert)
 ! Allow ads on DDG: brave-browser/issues#4533


### PR DESCRIPTION
Error message with shields down `http://www.dslreports.com/speedtest?httpsok=0` (with https disabled) caused by this script `https://i.dslr.net/css/chart6.js`. Seems they're checking a few tracking internals, which is causing a "Alien script" warning. https://www.dslreports.com/faq/17944

![816c368ac378bc01403257c22d732081d1c891ad](https://user-images.githubusercontent.com/1659004/97378309-eff20780-1926-11eb-9de6-d83f043acbb9.png)

Have also attempted to reach out to DSLreports, no response.

Was reported by a few users: https://community.brave.com/t/alien-script-detected-inline-code-at-dslreports-com-speedtest/173716