### PR TITLE
Fix anti-adblock on realclearpolitics.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -257,7 +257,7 @@ ebay.com,ebay-kleinanzeigen.de##+js(acis, tmx_post_session_params_fixed)
 ! megaup.net
 megaup.net#@#.adBanner
 ! Anti-adblock: realclear
-@@/doubleclick.js$xmlhttprequest,domain=realclearpolitics.com|realclearpolitics.com|realclearhealth.com|realclearreligion.org|realclearenergy.org|realclearhistory.com|realclearpolicy.com|realclearworld.com|realclearmarkets.com|realclearbooks.com|realcleareducation.com|realclearscience.com|realcleardefense.com
+@@/doubleclick.js$domain=realclearpolitics.com|realclearpolitics.com|realclearhealth.com|realclearreligion.org|realclearenergy.org|realclearhistory.com|realclearpolicy.com|realclearworld.com|realclearmarkets.com|realclearbooks.com|realcleareducation.com|realclearscience.com|realcleardefense.com
 ! Adblock-Tracking: vice.com
 @@||web-scripts.vice.com/ad.vice.com/$script,domain=vice.com
 ! Anti-adblock: dianomi-anti-adblock


### PR DESCRIPTION
`https://www.realclearpolitics.com/` changed the script to check for Adblock. Just removed the $xml requirement


Fixes this check: `https://www.realclearpolitics.com/asset/section/doubleclick.js`