### PR TITLE
Fix Peter Lowes filter on https://blockthrough.com/2015/11/01/halloween-security-breach/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -565,6 +565,7 @@ mycima.me##+js(acis, Math, zfgloaded)
 ! Fix abcnews.go.com video playback
 @@||akamaihd.net/player/2.106.5/akamai/amp/chartbeatanalytics/Chartbeatanalytics.min.js$domain=abcnews.go.com
 ! Peter Lowe fixes
+||blockthrough.com^$badfilter
 ||criteo.com^$badfilter
 ||pubmatic.com^$badfilter
 ||appsflyer.com^$badfilter


### PR DESCRIPTION
In Easylist, we block blockthrough domain `easylist/easylist_adservers.txt:||videohub.com^$third-party` which is their public facing tracking/anti-adblock domain.

`blockthrough.com` isn't used directly for tracking or anti-adblock.  Safe to badfilter this.