### PR TITLE
Avoid googlefunding messages in https://github.com/brave/adblock-lists/issues/498

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -366,6 +366,8 @@ archive.is,btdig.com,archive.today,archive.vn,archive.fo,archive.md,archive.li,a
 @@||fncstatic.com/static/v/all/js/ads.js$script,domain=foxbusiness.com|foxnews.com
 ! Temp fix for Google funding Yellow Bar (https://github.com/brave/brave-browser/issues/11945)
 ##div[style*="box-shadow: rgb(136, 136, 136) 0px 0px 12px; color: "]
+! Fix googlefunding issues (Android) https://github.com/uBlockOrigin/uAssets/blob/master/filters/filters.txt#L21331
+||fundingchoicesmessages.google.com^$third-party,badfilter
 ! To counter $ghide in uBO
 geekzone.co.nz,elpais.com,abc.es,lapresse.ca##div[style*="box-shadow: rgb(136, 136, 136) 0px 0px 12px; color: "]
 geekzone.co.nz,elpais.com,abc.es,lapresse.ca##+js(nostif, removeChild(f), 100)


### PR DESCRIPTION
Unblocking `fundingchoicesmessages.google.com` this stop will generate googlefunding on Android/IOS. Affecting in desktop if it wasn't for the generic cosmetic. `##div[style*="box-shadow: rgb(136, 136, 136) 0px 0px 12px; color: "]`

Should fix https://github.com/brave/adblock-lists/issues/498 & https://community.brave.com/t/annoying-anti-ad-blocker-message-on-android-www-marca-com/177882

