### PR TITLE
Fixes CBS All Access anti-ads https://github.com/brave/brave-browser/issues/12705

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -270,6 +270,9 @@ cinemablend.com##+js(abort-on-property-read, __cmpGdprAppliesGlobally)
 ||ttauri.space.com^$script,domain=space.com
 ||ttauri.tomsguide.com^$script,domain=tomsguide.com
 ||pcgamer-gb.pcgamer.com^$domain=pcgamer.com
+! Temp fix for CBS All Access (https://github.com/brave/brave-browser/issues/12705)
+@@||s0.2mdn.net/instream/video/client.js$script,domain=cbs.com
+@@||adservice.google.com/adsid/integrator.js$script,domain=cbs.com
 ! Anti-adblock: concert.io (vox sites)
 @@||vox-cdn.com/packs/concert_ads-$script,domain=theverge.com|eater.com|polygon.com|vox.com|sbnation.com|curbed.com|theringer.com|mmafighting.com|racked.com|mmamania.com|funnyordie.com|riftherald.com
 theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com,mmafighting.com,racked.com,mmamania.com,funnyordie.com,riftherald.com##+js(nostif, adsBlocked)


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/12705

Most likely would affect Android and IOS also. Tested with an ad-supported login, this was the easiest option to get around the Anti-adblock check.