### PR TITLE
Add additional anti-ad fixes for https://github.com/brave/brave-browser/issues/12705

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -273,6 +273,8 @@ cinemablend.com##+js(abort-on-property-read, __cmpGdprAppliesGlobally)
 ! Temp fix for CBS All Access (https://github.com/brave/brave-browser/issues/12705)
 @@||s0.2mdn.net/instream/video/client.js$script,domain=cbs.com
 @@||adservice.google.com/adsid/integrator.js$script,domain=cbs.com
+@@||tags.tiqcdn.com/utag/cbsi/cbscomsite/prod/utag.js$script,domain=cbs.com
+@@||securepubads.g.doubleclick.net/tag/js/gpt.js$script,domain=cbs.com
 ! Anti-adblock: concert.io (vox sites)
 @@||vox-cdn.com/packs/concert_ads-$script,domain=theverge.com|eater.com|polygon.com|vox.com|sbnation.com|curbed.com|theringer.com|mmafighting.com|racked.com|mmamania.com|funnyordie.com|riftherald.com
 theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com,mmafighting.com,racked.com,mmamania.com,funnyordie.com,riftherald.com##+js(nostif, adsBlocked)


### PR DESCRIPTION
Missed a couple more scripts that were being checked via cbs all access.

Part 1: https://github.com/brave/adblock-lists/pull/502

Ref: https://github.com/brave/brave-browser/issues/12705