### PR TITLE
Fixes anti-ad check https://ww2.tirexo.cc/streaming-6688612.html

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -214,6 +214,8 @@ twitter.com##[style]>div>div>[data-testid=placementTracking]
 @@||braze.com^$third-party,domain=blockfi.com
 ! Broken video playback on tn.com.ar (https://community.brave.com/t/the-blocker-does-not-allow-you-to-watch-the-video/76691)
 @@||googletagmanager.com/gtm.js$script,domain=tn.com.ar
+! uptostream
+uptostream.com##+js(acis, window.a)
 ! ebay portscanning script
 ebay.com,ebay-kleinanzeigen.de##+js(acis, tmx_post_session_params_fixed)
 ! megaup.net


### PR DESCRIPTION
Seems to only affect Brave, was reported by a user https://community.brave.com/t/anti-adblock-message-on-tirexo-cc-only-during-a-stream/179675/2  Was unable to reproduce this issue in Chrome/uBO.

From `https://ww2.tirexo.cc/streaming-6688612.html` (allow all cookies needed)

Aborting this anti-adblock script:
```
		function cl(i) {

			if (window.a && typeof google !== typeof window.a) {
				document.getElementById('blocked').style.display = 'block'; 
				document.getElementById('player').style.display = 'none';
			}

			if (!window.l) {
				document.getElementById('blocked').style.display = 'block'; 
				document.getElementById('player').style.display = 'none';
			}
			window.l = false
		}
      
```
