### PR TITLE
Update reuters.com ads

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -235,8 +235,9 @@ megaup.net#@#.adBanner
 @@||autobild.de/*&adserv$script,domain=autobild.de
 @@||golem.de^*/showAds.js$script,domain=golem.de
 @@||pcwelt.de/js/advert.js$script,domain=pcwelt.de
-hardwareluxx.de,formel1.de,golem.de,finanzen.net,autobild.de,gamestar.de,tagesspiegel.de##+js(acis, parseInt)
-reuters.com##+js(acis, parseInt, toString)
+reuters.com,hardwareluxx.de,formel1.de,golem.de,finanzen.net,autobild.de,gamestar.de,tagesspiegel.de##+js(acis, parseInt)
+reuters.com##+js(acis, insertAdjacentElement)
+reuters.com##+js(acis, innerHTML)
 ! Anti-adblock message cinemablend.com (ported from uBO Annoyances)
 cinemablend.com##+js(abort-on-property-read, __cmpGdprAppliesGlobally)
 ! chip.de


### PR DESCRIPTION
Reported by @fmarier 

Reuters started to show ads again, They have changed the scripts to show the ads (from a non-US geo location)

Aborting the following should help here:
`innerHTML` is used to insert the ads within the page
`insertAdjacentElement` function to call the ads.

**Tested:** Videos played fine, photos and page displayed fine with these blocks.

Will address the `hardwareluxx.de,formel1.de,golem.de,finanzen.net,autobild.de,gamestar.de,tagesspiegel.de` filters once this confirmed as a fix.