### PR TITLE
Re-work of reuters .com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -236,8 +236,7 @@ megaup.net#@#.adBanner
 @@||golem.de^*/showAds.js$script,domain=golem.de
 @@||pcwelt.de/js/advert.js$script,domain=pcwelt.de
 reuters.com,hardwareluxx.de,formel1.de,golem.de,finanzen.net,autobild.de,gamestar.de,tagesspiegel.de##+js(acis, parseInt)
-reuters.com##+js(acis, insertAdjacentElement)
-reuters.com##+js(acis, innerHTML)
+||s3.reutersmedia.net/resources/$image
 ! Anti-adblock message cinemablend.com (ported from uBO Annoyances)
 cinemablend.com##+js(abort-on-property-read, __cmpGdprAppliesGlobally)
 ! chip.de

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -236,7 +236,7 @@ megaup.net#@#.adBanner
 @@||golem.de^*/showAds.js$script,domain=golem.de
 @@||pcwelt.de/js/advert.js$script,domain=pcwelt.de
 reuters.com,hardwareluxx.de,formel1.de,golem.de,finanzen.net,autobild.de,gamestar.de,tagesspiegel.de##+js(acis, parseInt)
-||s3.reutersmedia.net/resources/$image
+||s3.reutersmedia.net/resources/*&rtn=$image
 ! Anti-adblock message cinemablend.com (ported from uBO Annoyances)
 cinemablend.com##+js(abort-on-property-read, __cmpGdprAppliesGlobally)
 ! chip.de


### PR DESCRIPTION
Previous patch https://github.com/brave/adblock-lists/pull/505 was tested on a new reuters page (UK), and wasn't working as intended. Ads was still showing. Easiest option under the new Reuters ads is a simple network block.

This will help with the ads for the time being.