### PR TITLE
Fixes port scan and fingerprinting on https://github.com/brave/brave-browser/issues/12722

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -216,8 +216,8 @@ twitter.com##[style]>div>div>[data-testid=placementTracking]
 @@||googletagmanager.com/gtm.js$script,domain=tn.com.ar
 ! uptostream
 uptostream.com##+js(acis, window.a)
-! ebay portscanning script
-ebay.com,ebay-kleinanzeigen.de##+js(acis, tmx_post_session_params_fixed)
+! portscanning script
+sciencedirect.com,ebay.com,ebay-kleinanzeigen.de##+js(acis, tmx_post_session_params_fixed)
 ! megaup.net
 megaup.net#@#.adBanner
 ! Anti-adblock: realclear


### PR DESCRIPTION
Prevents the website `sciencedirect.com`  from launching multiple fingerprinting scripts (and slowing the browser). Blocking the same script used on ebay will help here.

This will address https://github.com/brave/brave-browser/issues/12722  on desktop/android (not yet on iOS)