### PR TITLE
Fix Localhost rules from https://github.com/brave/adblock-lists/commit/d7ce770924aacb95cab36bec30d58e900c11c4b6

### DIFF
--- a/brave-lists/brave-specific.txt
+++ b/brave-lists/brave-specific.txt
@@ -1,0 +1,4 @@
+! Specific filters (Tracking or ads) for Brave
+||localhost^$third-party,domain=~127.0.0.1|~[::1]
+||127.0.0.1^$third-party,domain=~localhost|~[::1]
+||[::1]^$third-party,domain=~localhost|~127.0.0.1


### PR DESCRIPTION
Filters were accidentally removed during the cleanup of the lists, 