### PR TITLE
Fixes consent issue on vice.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -75,7 +75,7 @@ twitter.com##[style]>div>div>[data-testid=placementTracking]
 @@||geoplugin.net/javascript.gp$script,xmlhttprequest,domain=suicidepreventionlifeline.org
 ! Consent trackers
 ||opencmp.net^$script,third-party
-||privacy-mgmt.com^$script,third-party
+||privacy-mgmt.com^$third-party
 ||sp-prod.net^$third-party
 @@||notice.sp-prod.net^$subdocument,domain=telegraph.co.uk
 ! Block additional trackers


### PR DESCRIPTION
When visiting `vice.com` and `t-online.de` from an EU country causing the scrollbar to disappear due to consent message.

Removing the `$script` requirement will fix this.


Fixing this report: https://github.com/brave/brave-browser/issues/12734