### PR TITLE
Fix anit-Brave check on https://filecr[.]com/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -240,7 +240,7 @@ theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com
 ! Potential Tracker, Annoyance
 ||govdelivery.com^$third-party
 ! Anti-Brave checks
-krunker.io,btdig.com,archive.is,archive.today,archive.vn,archive.fo,archive.md,archive.li,archive.ph,archivecaslytosk.onion,archiveiya74codqgiixo33q62qlrqtkgmcitqx5u2oeqnmn5bpcbiyd.onion##+js(aopw, navigator.brave)
+krunker.io,filecr.com,btdig.com,archive.is,archive.today,archive.vn,archive.fo,archive.md,archive.li,archive.ph,archivecaslytosk.onion,archiveiya74codqgiixo33q62qlrqtkgmcitqx5u2oeqnmn5bpcbiyd.onion##+js(aopw, navigator.brave)
 archive.is,btdig.com,archive.today,archive.vn,archive.fo,archive.md,archive.li,archive.ph,archiveiya74codqgiixo33q62qlrqtkgmcitqx5u2oeqnmn5bpcbiyd.onion##+js(acis, Object.keys)
 archive.is,btdig.com,archive.today,archive.vn,archive.fo,archive.md,archive.li,archive.ph,archiveiya74codqgiixo33q62qlrqtkgmcitqx5u2oeqnmn5bpcbiyd.onion##+js(acis, getPrototypeOf)
 archive.is,btdig.com,archive.today,archive.vn,archive.fo,archive.md,archive.li,archive.ph,archiveiya74codqgiixo33q62qlrqtkgmcitqx5u2oeqnmn5bpcbiyd.onion##+js(acis, Object.getPrototypeOf)


### PR DESCRIPTION
Anti-Brave check done by `https://filecr.com/` Prevents the user from using direct download.

From: `https://filecr.com/wp-content/plugins/deblocker/js/deblocker.js?ver=3.0.0`

`function adsBlocked(callback){let
adsSrc='https://googleads.g.doubleclick.net/pagead/id';let isBrave=(typeof
navigator.brave!=='undefined');if(isBrave){adsSrc='https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js';let
head=document.getElementsByTagName('head')[0];let
script=document.createElement('script');let
done=false;script.setAttribute('src',adsSrc);script.setAttribute('type','text/javascript');script.setAttribute('charset','utf-8');script.onload=script.onreadstatechange=function(){if(!done&&(!this.readyState||this.readyState==='loaded'||this.readyState==='complete')){done=true;script.onload=script.onreadystatechange=null;if('undefined'===typeof
window.adsbygoogle){callback(true);}else{callback(false);}
script.parentNode.removeChild(script);}}`

Was reported https://community.brave.com/t/report-adblocker-detected/182908