### PR TITLE
Fix y2mate.com popups

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -250,6 +250,9 @@ archive.is,btdig.com,archive.today,archive.vn,archive.fo,archive.md,archive.li,a
 jaysndees.com##+js(acis, detectBBrowser)
 ! Anti-Brave checks (bellasephina.com/tecknity.com/ebook-searcher.com)
 bellasephina.com,tecknity.com,ebook-searcher.com##+js(acis, request)
+! y2mate popup 
+y2mate.com##+js(acis, spro)
+y2mate.com##+js(acis, clickAds)
 ! Anti-adblock: cellmapper.net
 @@||cellmapper.net/js/ads.js$script,domain=cellmapper.net
 ! Anti-adblock: cyberciti.biz


### PR DESCRIPTION
Reported here. https://community.brave.com/t/brave-shield-doesnt-prevent-sites-from-opening-new-ads-tabs/183025

Popups being generated on the site, nothing seen on ub0.

From uBO:
`filters/filters.txt:y2mate.com##+js(nostif, adv)`
`filters/filters.txt:y2mate.com##+js(nowoif)`