### PR TITLE
Fixes anti-brave checks https://www.uploadbank.com/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -250,6 +250,9 @@ archive.is,btdig.com,archive.today,archive.vn,archive.fo,archive.md,archive.li,a
 jaysndees.com##+js(acis, detectBBrowser)
 ! Anti-Brave checks (bellasephina.com/tecknity.com/ebook-searcher.com)
 bellasephina.com,tecknity.com,ebook-searcher.com##+js(acis, request)
+! Anti-Brave checks (uploadbank.com)
+||uploadbank.com/js/checkbrave.js
+uploadbank.com##+js(set, XMLHttpRequest, noopFunc)
 ! y2mate popup 
 y2mate.com##+js(acis, spro)
 y2mate.com##+js(acis, clickAds)


### PR DESCRIPTION
2 fix checks to `http://www.uploadbank.com/1qlisw8hr57n`  which isn't viewable in Brave

Implemented 2 options, if the site changes the filename `checkbrave.js` 