### PR TITLE
Disable some youtube filters

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -25,10 +25,10 @@ stats.brave.com#@#adsContent
 ||theatlantic.blueconic.net$domain=theatlantic.com
 ||theatlantic.com/please-support-us^
 ! youtube ads
-youtube.com,youtube-nocookie.com##+js(json-prune, [].playerResponse.adPlacements)
-youtube.com,youtube-nocookie.com##+js(json-prune, [].playerResponse.playerAds)
-youtube.com,youtube-nocookie.com##+js(json-prune, playerResponse.adPlacements)
-youtube.com,youtube-nocookie.com##+js(json-prune, playerResponse.playerAds)
+! youtube.com,youtube-nocookie.com##+js(json-prune, [].playerResponse.adPlacements)
+! youtube.com,youtube-nocookie.com##+js(json-prune, [].playerResponse.playerAds)
+! youtube.com,youtube-nocookie.com##+js(json-prune, playerResponse.adPlacements)
+! youtube.com,youtube-nocookie.com##+js(json-prune, playerResponse.playerAds)
 youtube.com,youtube-nocookie.com##+js(json-prune, adPlacements)
 youtube.com,youtube-nocookie.com##+js(json-prune, playerAds)
 ! Fix browser lockup on skepticalscience.com (https://github.com/brave/brave-browser/issues/5406)


### PR DESCRIPTION
Have temp disabled the youtube json-prune snippets, which may help with performance issues. Maybe safe to remove, but being cautious. 

since we're pulling from filters.txt from uBO.  https://github.com/uBlockOrigin/uAssets/blob/master/filters/filters.txt#L116

`youtube.com,youtube-nocookie.com##+js(json-prune, [].playerResponse.adPlacements [].playerResponse.playerAds playerResponse.adPlacements playerResponse.playerAds adPlacements playerAds)`