### PR TITLE
Fix warning on https://www.ovagames.com/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -233,6 +233,8 @@ cinemablend.com##+js(abort-on-property-read, __cmpGdprAppliesGlobally)
 theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com,mmafighting.com,racked.com,mmamania.com,funnyordie.com,riftherald.com##+js(nostif, adsBlocked)
 theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com,mmafighting.com,racked.com,mmamania.com,funnyordie.com,riftherald.com##.adblock-allowlist-messaging__wrapper
 ||concert.io/lib/adblock/$subdocument
+! uBO-redirect work around ovagames.com 
+@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,domain=ovagames.com
 ! Anti-adblock: shush.se
 @@||shush.se/_ads.js$script,domain=shush.se
 ! Adblock-Tracking: tweakers.net


### PR DESCRIPTION
Reported here: https://community.brave.com/t/ovagames-adblock-blocker/184091

Anti-adblock message seen on `https://www.ovagames.com/`

Filter used by uBO: `||googlesyndication.com^$script,redirect-rule=googlesyndication_adsbygoogle.js,domain=ovagames.com`