### PR TITLE
Fix CNAME on imdb.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -19,9 +19,11 @@ stats.brave.com#@#adsContent
 ||vidazoo.com/proxy^$third-party
 ||mediabong.net^$third-party
 ||imprvdosrv.com^$third-party
-! https://yab.yomiuri.co.jp/adv/presage/3.html
+! CNAME: https://yab.yomiuri.co.jp/adv/presage/3.html
 @@||yab.yomiuri.co.jp/adv/$first-party
 @@||omicroncdn.net^$domain=yab.yomiuri.co.jp
+! CNAME: https://www.imdb.com/video/vi935705113?playlistId=tt1568346
+@@||cloudfront.net^$domain=imdb.com
 ! yt embed exceptions
 @@||youtube.com/yts/jsbin^$domain=thegatewaypundit.com|godlikeproductions.com|techcrunch.com
 ! theatlantic.com anti-blocker filters


### PR DESCRIPTION
Reported here: https://community.brave.com/t/trailer-videos-on-imdb-cant-be-played/184335

CNAME issue causing broken playback.

```
;; ANSWER SECTION:
imdb-video.media-imdb.com.      669     IN      CNAME   d22ohr3ltkx6p.cloudfront.net.
d22ohr3ltkx6p.cloudfront.net.   60      IN      A       13.224.93.10
d22ohr3ltkx6p.cloudfront.net.   60      IN      A       13.224.93.84
d22ohr3ltkx6p.cloudfront.net.   60      IN      A       13.224.93.3
d22ohr3ltkx6p.cloudfront.net.   60      IN      A       13.224.93.116

```