### PR TITLE
Fix CNAME on https://www.imdb.com/video/vi935705113?playlistId=tt1568346

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -23,7 +23,7 @@ stats.brave.com#@#adsContent
 @@||yab.yomiuri.co.jp/adv/$first-party
 @@||omicroncdn.net^$domain=yab.yomiuri.co.jp
 ! CNAME: https://www.imdb.com/video/vi935705113?playlistId=tt1568346
-@@||cloudfront.net^$domain=imdb.com
+@@||cloudfront.net^$domain=imdb.com|media-imdb.com
 ! yt embed exceptions
 @@||youtube.com/yts/jsbin^$domain=thegatewaypundit.com|godlikeproductions.com|techcrunch.com
 ! theatlantic.com anti-blocker filters


### PR DESCRIPTION
To fix further CNAME issues on `https://www.imdb.com/video/vi935705113?playlistId=tt1568346` causing breaking playback.

Continuation from https://github.com/brave/adblock-lists/pull/526