### PR TITLE
Re-instate youtube filters

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -30,10 +30,10 @@ stats.brave.com#@#adsContent
 ||theatlantic.blueconic.net$domain=theatlantic.com
 ||theatlantic.com/please-support-us^
 ! youtube ads
-! youtube.com,youtube-nocookie.com##+js(json-prune, [].playerResponse.adPlacements)
-! youtube.com,youtube-nocookie.com##+js(json-prune, [].playerResponse.playerAds)
-! youtube.com,youtube-nocookie.com##+js(json-prune, playerResponse.adPlacements)
-! youtube.com,youtube-nocookie.com##+js(json-prune, playerResponse.playerAds)
+youtube.com,youtube-nocookie.com##+js(json-prune, [].playerResponse.adPlacements)
+youtube.com,youtube-nocookie.com##+js(json-prune, [].playerResponse.playerAds)
+youtube.com,youtube-nocookie.com##+js(json-prune, playerResponse.adPlacements)
+youtube.com,youtube-nocookie.com##+js(json-prune, playerResponse.playerAds)
 youtube.com,youtube-nocookie.com##+js(json-prune, adPlacements)
 youtube.com,youtube-nocookie.com##+js(json-prune, playerAds)
 ! Fix browser lockup on skepticalscience.com (https://github.com/brave/brave-browser/issues/5406)


### PR DESCRIPTION
Given the complaint by a user regarding youtube, these filters are still needed

https://community.brave.com/t/youtube-adds-are-back/184786/10

Couldn't replicate it regardless of location.