### PR TITLE
Improve site fixes for Googlefunding popups

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -346,14 +346,17 @@ y2mate.com##+js(acis, clickAds)
 ||fundingchoicesmessages.google.com^$third-party,badfilter
 ! To counter $ghide in uBO
 geekzone.co.nz,elpais.com,abc.es,lapresse.ca##div[style*="box-shadow: rgb(136, 136, 136) 0px 0px 12px; color: "]
-geekzone.co.nz,elpais.com,abc.es,lapresse.ca##+js(nostif, removeChild(f), 100)
+geekzone.co.nz##.fc-ab-root > .fc-dialog-container
 ! all3dp.com (google funding)
 @@||all3dp.com^$generichide
 all3dp.com##.ad-container--loaded
 all3dp.com##.ad-container--horizontal
 all3dp.com##.ad-container__provider
+! googlefunding (non-overlay, bottom window) as seen on geekzone.co.nz
+##.fc-ab-root > .fc-dialog-container
 ! googlefunding popup
-gizbot.com,drivespark.com,goodreturns.in,nativeplanet.com,careerindia.com,click.in,filmibeat.com,boldsky.com##+js(acis, JSON.stringify)
+nativeplanet.com,elmundo.es,abc.es,elpais.com,goodreturns.in,drivespark.com,gizbot.com,telva.com,geekzone.co.nz,lapresse.ca,all3dp.com,click.in,filmibeat.com,boldsky.com,careerindia.com##+js(acis, trustedTypes, console)
+nativeplanet.com,elmundo.es,abc.es,elpais.com,goodreturns.in,drivespark.com,gizbot.com,telva.com,lapresse.ca,click.in,filmibeat.com,boldsky.com,careerindia.com##+js(acis, JSON.stringify, instanceof)
 ! Adblock-Tracking: vg247.com
 @@||vg247.com/wp-content/themes/vg247/scripts/AdsLoad.js$script,domain=vg247.com
 ! Anti-adblock: indiatimes.com / timesofindia.com


### PR DESCRIPTION
Update on our Google Funding popup warnings. A break down of all the changes:

> `geekzone.co.nz,elpais.com,abc.es,lapresse.ca##+js(nostif, removeChild(f), 100)`

Was not working as intended and removed. Other filters below will take care of this.

> `geekzone.co.nz##.fc-ab-root > .fc-dialog-container`

Added to counter `geekzone.co.nz^$ghide` in uBO.

> `##.fc-ab-root > .fc-dialog-container`

Used as a different google funding popup window, non-overlay. (a bottom div element). Which doesn't disable the scrollbar. Safe as a generic.

> `##+js(acis, JSON.stringify)` 

Has been adjusted to avoid any potential false-positives. Adjusted to ##+js(acis, JSON.stringify, instanceof)

> `##+js(acis, trustedTypes, console)` 

New addition, since on some googlefunding popups were still showing (possibly a newer revision of the google funding script). With the other JSON.stringify filter. Only caused one false positive `all3dp.com`, which was not included.

> And new sites added to counter these google-funding.

Was reported by a few users: https://community.brave.com/t/el-mundo-and-more-the-message-that-detects-the-blocking-of-ads-returns-to-the-web/184622/4

