### PR TITLE
Fix scrollbar and Anti-adblock on latimes.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -359,6 +359,11 @@ all3dp.com##.ad-container__provider
 ! googlefunding popup
 nativeplanet.com,elmundo.es,abc.es,elpais.com,goodreturns.in,drivespark.com,gizbot.com,telva.com,geekzone.co.nz,lapresse.ca,all3dp.com,click.in,filmibeat.com,boldsky.com,careerindia.com##+js(acis, trustedTypes, console)
 nativeplanet.com,elmundo.es,abc.es,elpais.com,goodreturns.in,drivespark.com,gizbot.com,telva.com,lapresse.ca,click.in,filmibeat.com,boldsky.com,careerindia.com##+js(acis, JSON.stringify, instanceof)
+! googlefunding (latimes.com) (fix scroll)
+latimes.com##body:style(overflow: auto !important;)
+! hide google fc popup and overlay
+latimes.com##.fc-dialog-container
+latimes.com##.fc-ab-root
 ! Adblock-Tracking: vg247.com
 @@||vg247.com/wp-content/themes/vg247/scripts/AdsLoad.js$script,domain=vg247.com
 ! Anti-adblock: indiatimes.com / timesofindia.com


### PR DESCRIPTION
Fixes 2 issues on `https://www.latimes.com`. Still keeps the subscription/paywall working.

`latimes.com##body:style(overflow: auto !important;)`
>  Fixes scroll bar

`latimes.com##.fc-dialog-container`
`latimes.com##.fc-ab-root`
> Removes Anti-adblock message and overlay