### PR TITLE
Fix Disqus on https://www.nytimes.com/wirecutter/reviews/best-noise-cancelling-headphones/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -285,6 +285,8 @@ y2mate.com##+js(acis, clickAds)
 @@||gazeta.ru^*/advertising.js$script,domain=gazeta.ru
 ! Adblock-Tracking: nytimes.com
 @@||nytimes.com/ads/google/adsbygoogle.js$script,domain=nytimes.com
+! Nytimes/Wirecutter Disqus https://github.com/brave/brave-browser/issues/13241
+nytimes.com##+js(cookie-remover, nyt-purr)
 ! Adblock-Tracking: cpubenchmark.net / videocardbenchmark.net
 @@||videocardbenchmark.net/js/ads.js$script,domain=videocardbenchmark.net
 @@||cpubenchmark.net/js/ads.js$script,domain=cpubenchmark.net

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -287,6 +287,7 @@ y2mate.com##+js(acis, clickAds)
 @@||nytimes.com/ads/google/adsbygoogle.js$script,domain=nytimes.com
 ! Nytimes/Wirecutter Disqus https://github.com/brave/brave-browser/issues/13241
 nytimes.com##+js(cookie-remover, nyt-purr)
+nytimes.com##+js(acis, document.cookie, PURR_COOKIE_NAME)
 ! Adblock-Tracking: cpubenchmark.net / videocardbenchmark.net
 @@||videocardbenchmark.net/js/ads.js$script,domain=videocardbenchmark.net
 @@||cpubenchmark.net/js/ads.js$script,domain=cpubenchmark.net


### PR DESCRIPTION
Opening https://www.nytimes.com/wirecutter/reviews/best-noise-cancelling-headphones/  even with shields down, brings up a warning at the bottom. 

```
Comments are disabled
We respect your privacy. Comments are disabled because they require cookies and you’ve opted out of cookies for this site. You can change your cookie preferences to enable comments.

You can also send us a note or a tweet, or find us on Facebook.
```

Clearing the specific cookie `nyt-purr` fixes the Disqus issue on wirecutter articles.  

Ref:  https://github.com/brave/brave-browser/issues/13241