### PR TITLE
Fixes playback issues on https://darknetdiaries.com/episode/78/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -26,6 +26,9 @@ stats.brave.com#@#adsContent
 @@||cloudfront.net^$domain=imdb.com|media-imdb.com
 ! yt embed exceptions
 @@||youtube.com/yts/jsbin^$domain=thegatewaypundit.com|godlikeproductions.com|techcrunch.com
+! CNAME: https://darknetdiaries.com/episode/78/
+@@||traffic.megaphone.fm^$domain=megaphone.fm|darknetdiaries.com
+@@||adserver.va3.megaphone.cloud.$domain=megaphone.fm|darknetdiaries.com
 ! theatlantic.com anti-blocker filters
 ||theatlantic.blueconic.net$domain=theatlantic.com
 ||theatlantic.com/please-support-us^


### PR DESCRIPTION
When playing back a podcast, `https://darknetdiaries.com/episode/78/`, it's blocked in shields, `https://traffic.megaphone.fm/ADV5381316822.mp3?updated=1607279433`

Blocked due to CNAME,

`traffic.megaphone.fm.   60      IN      CNAME   adserver.va3.megaphone.cloud.`


