### PR TITLE
Fixes ipfs requests from slate.host 

### DIFF
--- a/brave-lists/brave-specific.txt
+++ b/brave-lists/brave-specific.txt
@@ -3,6 +3,11 @@
 ||127.0.0.1^$third-party,domain=~localhost|~[::1]
 ||[::1]^$third-party,domain=~localhost|~127.0.0.1
 
+! Localhost exceptions
+! slate.host = https://github.com/brave/brave-browser/issues/13641
+@@||127.0.0.1^$third-party,domain=slate.host
+@@||localhost^$third-party,domain=slate.host
+@@||[::1]^$third-party,domain=slate.host
 
 ! Re-enable scripts for Yandex after finding no privacy concerns (given
 ! other Brave privacy protections)


### PR DESCRIPTION
Localhost requests being blocked, on slate.host. (local IPFS node)

Fixes https://github.com/brave/brave-browser/issues/13641
