### PR TITLE
Improve IOS blocking on https://coveryourtracks.eff.org/

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -1,1 +1,6 @@
 ! Brave IOS specific filters
+
+! coveryourtracks.eff.org
+||trackersimulator.org^$subdocument
+||eviltracker.net^$subdocument
+||do-not-tracker.org^$subdocument


### PR DESCRIPTION
With discussions in `https://www.reddit.com/r/brave_browser/comments/kzxz86/brave_browser_on_ios_is_the_only_one_that/` regarding blocking scores on `https://coveryourtracks.eff.org/`

Just for public perception, it's an easy counter to improve scores on coveryourtracks.