### PR TITLE
Fix localhost ipfs/ipns

### DIFF
--- a/brave-lists/brave-specific.txt
+++ b/brave-lists/brave-specific.txt
@@ -3,11 +3,14 @@
 ||127.0.0.1^$third-party,domain=~localhost|~[::1]
 ||[::1]^$third-party,domain=~localhost|~127.0.0.1
 
-! Localhost exceptions
-! slate.host = https://github.com/brave/brave-browser/issues/13641
-@@||127.0.0.1^$third-party,domain=slate.host
-@@||localhost^$third-party,domain=slate.host
-@@||[::1]^$third-party,domain=slate.host
+! ipfs localhost exceptions
+! https://github.com/brave/brave-browser/issues/13641
+@@||127.0.0.1*/ipfs/$third-party
+@@||127.0.0.1*/ipns/$third-party
+@@||localhost*/ipfs/$third-party
+@@||localhost*/ipns/$third-party
+@@||[::1]*/ipfs/$third-party
+@@||[::1]*/ipns/$third-party
 
 ! Re-enable scripts for Yandex after finding no privacy concerns (given
 ! other Brave privacy protections)

--- a/brave-lists/brave-specific.txt
+++ b/brave-lists/brave-specific.txt
@@ -9,6 +9,8 @@
 @@||127.0.0.1*/ipns/$third-party
 @@||localhost*/ipfs/$third-party
 @@||localhost*/ipns/$third-party
+@@||ipfs.localhost^$third-party
+@@||ipns.localhost^$third-party
 @@||[::1]*/ipfs/$third-party
 @@||[::1]*/ipns/$third-party
 


### PR DESCRIPTION
Was notified that ipfs will still be affected by https://github.com/brave/adblock-lists/pull/542

This will cover generic localhost domains  under `/ipfs/{cid}` or `/ipns/{peerid}`

Ref: https://github.com/brave/brave-browser/issues/13641