### PR TITLE
Improve android popup blocking on fmovies

### DIFF
--- a/brave-lists/brave-android-specific.txt
+++ b/brave-lists/brave-android-specific.txt
@@ -1,1 +1,6 @@
 ! Brave Android specific filters
+
+! fmovies
+fmovies.to##+js(acis, JSON.parse)
+fmovies.to##+js(acis, atob)
+fmovies.to##+js(acis, XMLHttpRequest)


### PR DESCRIPTION
Popups are being generated on android when playing back video on `fmovies.to`

`fmovies.*##+js(abort-current-inline-script, Math, /XMLHttpRequest|break/)`

Minimized the filter to be more compatible on Android