### PR TITLE
Fixes anti-adblock on ivehindustan.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -248,6 +248,8 @@ theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com
 ||concert.io/lib/adblock/$subdocument
 ! uBO-redirect work around ovagames.com 
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,domain=ovagames.com
+! uBO-redirect work around livehindustan.com
+@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=livehindustan.com
 ! Fix Playback on http://v6.player.abacast.net/6508 (https://community.brave.com/t/problem-loading-http-v6-player-abacast-net-6508/71822)
 @@||imasdk.googleapis.com/js/core/$subdocument,domain=player.abacast.net
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=player.abacast.net


### PR DESCRIPTION
Fixes https://github.com/brave/adblock-lists/issues/547

Tested on `https://www.livehindustan.com/national/story-pm-modi-and-cms-likely-to-be-vaccinated-against-covid19-in-second-phase-3772365.html`

Anti-adblock caused by the /adsbygoogle.js redirection in uBO