### PR TITLE
Fix anti-adblock on https://www.hindustantimes.com/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -249,7 +249,7 @@ theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com
 ! uBO-redirect work around ovagames.com 
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,domain=ovagames.com
 ! uBO-redirect work around livehindustan.com
-@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=livehindustan.com
+@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=livehindustan.com|hindustantimes.com
 ! Fix Playback on http://v6.player.abacast.net/6508 (https://community.brave.com/t/problem-loading-http-v6-player-abacast-net-6508/71822)
 @@||imasdk.googleapis.com/js/core/$subdocument,domain=player.abacast.net
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=player.abacast.net


### PR DESCRIPTION
Just a further fix from https://github.com/brave/adblock-lists/pull/549

Fixes anti-adblock on Desktop/IOS/Android on `https://www.hindustantimes.com/india-news`

Reported in https://old.reddit.com/r/BATProject/comments/kxq6re/is_it_correct_that_you_dont_always_get_5_ads_per/gk4fwzm/