### PR TITLE
Fixes Anti-adblock on globalnews.ca

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -265,6 +265,10 @@ bellasephina.com,tecknity.com,ebook-searcher.com##+js(acis, request)
 ! Anti-Brave checks (uploadbank.com)
 ||uploadbank.com/js/checkbrave.js
 uploadbank.com##+js(set, XMLHttpRequest, noopFunc)
+! globalnews.ca Anti-adblock
+@@||globalnews.ca^$ghide
+globalnews.ca##.l-headerAd__container
+globalnews.ca##.c-newsletterSignup
 ! y2mate popup 
 y2mate.com##+js(acis, spro)
 y2mate.com##+js(acis, clickAds)


### PR DESCRIPTION
Fixes anti-adblock on globalnews.ca (video playback), which was rejected by UBO. https://github.com/uBlockOrigin/uAssets/pull/8502

To avoid user disruption, and the warning message.  We'll include in Brave instead.
![globalnews](https://user-images.githubusercontent.com/1659004/105617627-8e1d3d00-5e44-11eb-84f7-cc9986525b1c.png)

