### PR TITLE
Fixes scrollbar on https://github.com/brave/brave-browser/issues/13759

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -73,6 +73,8 @@ twitter.com##[style]>div>div>[data-testid=placementTracking]
 ||privacy-mgmt.com^$third-party
 ||sp-prod.net^$third-party
 @@||notice.sp-prod.net^$subdocument,domain=telegraph.co.uk
+! Scroll bar-consent
+collegeconfidential.com##body:style(overflow: auto !important; max-height: 1px !important;)
 ! Brave-social (temp)
 ! List used by Brave for preventing social elements from loading
 !


### PR DESCRIPTION
Caused by a consent tracking servers being blocked, the page will disable the scroll bar. Fixes https://github.com/brave/brave-browser/issues/13759

The following will fix the scrollbar, without needing to allow the consent trackers to run.

