### PR TITLE
Include youtube specific adblock counter

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -39,6 +39,7 @@ youtube.com,youtube-nocookie.com##+js(json-prune, playerResponse.adPlacements)
 youtube.com,youtube-nocookie.com##+js(json-prune, playerResponse.playerAds)
 youtube.com,youtube-nocookie.com##+js(json-prune, adPlacements)
 youtube.com,youtube-nocookie.com##+js(json-prune, playerAds)
+youtube.com##+js(set, ytInitialPlayerResponse.adPlacements, undefined)
 ! Fix browser lockup on skepticalscience.com (https://github.com/brave/brave-browser/issues/5406)
 ||skepticalscience.net/widgets/heat_widget/js/heat_content.js$script,domain=skepticalscience.com
 ! adops.com unusable without this


### PR DESCRIPTION
Re-confirmed that `youtube.com##+js(set, ytInitialPlayerResponse.adPlacements, undefined)` counters the white-screen pre-roll Ad-block overlay,

This should help with a pre-roll. Tested on `https://www.youtube.com/watch?v=pUPMuLpIC0A` 