### PR TITLE
Remove uneeded filter for mail.yahoo.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -176,8 +176,6 @@ collegeconfidential.com##body:style(overflow: auto !important; max-height: 1px !
 ! Fix nordpass/protomail clickthrough on ios
 @@/aff_c?offer_id=
 @@?offer_id=*&aff_id=
-! Fix Anti-adblock message https://github.com/uBlockOrigin/uAssets/pull/8276
-mail.yahoo.com##.gl_C.ab_C.I_Zjpytw.Z_3mRud
 ! ca.yahoo.com (ios)
 /av/ads/*$domain=yahoo.com
 ! https://www.nintendo.co.jp/ring/index.html (https://github.com/brave/brave-browser/issues/11448)


### PR DESCRIPTION
Filter no longer needed, Anti-adblock no longer seen. Causing an issue with removing yahoo contacts, so it's safe remove.

Can be re-addressed if and tune against, if Yahoo Anti-adblock returns.