### PR TITLE
Fix Foxbusiness.com googlefunding

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -293,10 +293,6 @@ nytimes.com##+js(acis, document.cookie, PURR_COOKIE_NAME)
 ! Fix foxnews video playback
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=foxbusiness.com|foxnews.com
 @@||fncstatic.com/static/isa/app/lib/VisitorAPI.js$script,domain=foxbusiness.com|foxnews.com
-! Adblock-Tracking: foxnews.com / foxbusiness.com
-||fncstatic.com^*/google-funding-choices.js$script,domain=foxbusiness.com|foxnews.com
-||foxnews.com/static/strike/scripts/libs/google.funding.choices.js$script,domain=foxnews.com
-@@||fncstatic.com/static/v/all/js/ads.js$script,domain=foxbusiness.com|foxnews.com
 ! Temp fix for Google funding Yellow Bar (https://github.com/brave/brave-browser/issues/11945)
 ##div[style*="box-shadow: rgb(136, 136, 136) 0px 0px 12px; color: "]
 ! Fix googlefunding issues (Android) https://github.com/uBlockOrigin/uAssets/blob/master/filters/filters.txt#L21331
@@ -319,6 +315,8 @@ latimes.com##body:style(overflow: auto !important;)
 ! hide google fc popup and overlay
 latimes.com##.fc-dialog-container
 latimes.com##.fc-ab-root
+! googlefunding (foxnews / foxbusiness)
+||foxnews.com/static/strike/scripts/libs/google.funding.choices.js$script,domain=foxnews.com|foxbusiness.com
 ! Adblock-Tracking: vg247.com
 @@||vg247.com/wp-content/themes/vg247/scripts/AdsLoad.js$script,domain=vg247.com
 ! Anti-adblock: indiatimes.com / timesofindia.com


### PR DESCRIPTION
Fix `foxbusiness.com` googlefunding overlay, 

Was reported to have issues in https://community.brave.com/t/fox-business-wont-work-with-brave-shields-enabled/202384

This combines into foxnews/foxbusines filters, and removes overlay. Also remove 2 dead filters.