### PR TITLE
Fix playback on https://www.cbssports.com/nfl/superbowl/live

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -240,6 +240,8 @@ cinemablend.com##+js(abort-on-property-read, __cmpGdprAppliesGlobally)
 @@||adservice.google.com/adsid/integrator.js$script,domain=cbs.com
 @@||tags.tiqcdn.com/utag/cbsi/cbscomsite/prod/utag.js$script,domain=cbs.com
 @@||securepubads.g.doubleclick.net/tag/js/gpt.js$script,domain=cbs.com
+! cbssports
+@@||tags.tiqcdn.com/utag/cbsi/cbssportssite/prod/utag.js$script,domain=www.cbssports.com
 ! Anti-adblock: concert.io (vox sites)
 @@||vox-cdn.com/packs/concert_ads-$script,domain=theverge.com|eater.com|polygon.com|vox.com|sbnation.com|curbed.com|theringer.com|mmafighting.com|racked.com|mmamania.com|funnyordie.com|riftherald.com
 theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com,mmafighting.com,racked.com,mmamania.com,funnyordie.com,riftherald.com##+js(nostif, adsBlocked)


### PR DESCRIPTION
Fixes breakage on `https://www.cbssports.com/nfl/superbowl/live` due to Peter Lowes List.