### PR TITLE
Fix googlefunding on https://www.foxbusiness.com/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -316,7 +316,7 @@ latimes.com##body:style(overflow: auto !important;)
 latimes.com##.fc-dialog-container
 latimes.com##.fc-ab-root
 ! googlefunding (foxnews / foxbusiness)
-||foxnews.com/static/strike/scripts/libs/google.funding.choices.js$script,domain=foxnews.com|foxbusiness.com
+||foxnews.com^*choices.js$script,domain=foxnews.com|foxbusiness.com
 ! Adblock-Tracking: vg247.com
 @@||vg247.com/wp-content/themes/vg247/scripts/AdsLoad.js$script,domain=vg247.com
 ! Anti-adblock: indiatimes.com / timesofindia.com


### PR DESCRIPTION
Foxbusiness changed the url. Made url more generic. 

test url `https://www.foxbusiness.com/markets/robinhood-sued-by-family-after-sons-suicide`

Reference: `https://static.foxnews.com/static/strike/scripts/libs/google.funding.choices.js`  Foxbusiness
`https://static.foxnews.com/static/strike/scripts/libs/google.funding.choices.js`  Foxnews