### PR TITLE
Fix CNAME anti-adblock on linkvertise.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -19,6 +19,9 @@ stats.brave.com#@#adsContent
 ||vidazoo.com/proxy^$third-party
 ||mediabong.net^$third-party
 ||imprvdosrv.com^$third-party
+! CNAME: linkvertise.com
+@@||taboola.com/libtrc/linkvertise-link-to/loader.js$domain=linkvertise.com
+@@||taboola.map.fastly.net^$domain=linkvertise.com
 ! CNAME: https://yab.yomiuri.co.jp/adv/presage/3.html
 @@||yab.yomiuri.co.jp/adv/$first-party
 @@||omicroncdn.net^$domain=yab.yomiuri.co.jp


### PR DESCRIPTION
Fix anti-adblock due to taboola CNAME blocking

1. Visit `https://linkvertise.com/161996/LoledFurniture4`
2. Click on `Free Access`
3. Get Anti-adblock message.

Was reported: https://community.brave.com/t/how-turn-off-adblock-for-certain-websites/208519/6 
and 2nd most popular internal reported site as broken.