### PR TITLE
Fix 1p tracking/fingerprinting for various websites

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -218,6 +218,8 @@ uptostream.com,tirexo.lol##+js(acis, window.a)
 @@||tirexo.lol^$generichide
 ! portscanning script
 sciencedirect.com,ebay.com,ebay-kleinanzeigen.de##+js(acis, tmx_post_session_params_fixed)
+! 1p Tracking/fingerprinting
+academy.com,att.com,backcountry.com.bestbuy.com,buybuybaby.com,discover.com,discovercard.com,eddiebauer.com,finishline.com,kohls.com,macys.com,marshalls.com,mouser.com,pnc.com,publix.com,sierra.com,staples.com,usbank.com##+js(acis, _cf)
 ! megaup.net
 megaup.net#@#.adBanner
 ! Anti-adblock: dianomi-anti-adblock

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -219,7 +219,7 @@ uptostream.com,tirexo.lol##+js(acis, window.a)
 ! portscanning script
 sciencedirect.com,ebay.com,ebay-kleinanzeigen.de##+js(acis, tmx_post_session_params_fixed)
 ! 1p Tracking/fingerprinting
-academy.com,att.com,backcountry.com.bestbuy.com,buybuybaby.com,discover.com,discovercard.com,eddiebauer.com,finishline.com,kohls.com,macys.com,marshalls.com,mouser.com,pnc.com,publix.com,sierra.com,staples.com,usbank.com##+js(acis, _cf)
+academy.com,att.com,backcountry.com,bestbuy.com,buybuybaby.com,discover.com,discovercard.com,eddiebauer.com,finishline.com,kohls.com,macys.com,marshalls.com,mouser.com,pnc.com,publix.com,sierra.com,staples.com,usbank.com##+js(acis, _cf)
 ! megaup.net
 megaup.net#@#.adBanner
 ! Anti-adblock: dianomi-anti-adblock


### PR DESCRIPTION
Will prevent these sites from launching 3 (or more) additional xml script's being loaded by these sites impacting performance and privacy.

Example from `backcountry.com`, Being blocked by Easyprivacy[1] currently but url tends to change on these sites to avoid being blocked. This snippet will get around it.

![backcountry](https://user-images.githubusercontent.com/1659004/109100429-b670c200-7789-11eb-8a40-8c7b96f2726e.png)

[1] https://github.com/easylist/easylist/blob/master/easyprivacy/easyprivacy_specific.txt#L2688
