### PR TITLE
Fix Anti-Brave check on https://ach-photos.com/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -272,7 +272,7 @@ archive.is,btdig.com,archive.today,archive.vn,archive.fo,archive.md,archive.li,a
 ! Anti-Brave checks (jaysndees.com)
 jaysndees.com##+js(acis, detectBBrowser)
 ! Anti-Brave checks (bellasephina.com/tecknity.com/ebook-searcher.com)
-bellasephina.com,tecknity.com,ebook-searcher.com##+js(acis, request)
+ach-photos.com,bellasephina.com,tecknity.com,ebook-searcher.com##+js(acis, request)
 ! Anti-Brave checks (uploadbank.com)
 ||uploadbank.com/js/checkbrave.js
 uploadbank.com##+js(set, XMLHttpRequest, noopFunc)


### PR DESCRIPTION
Fixes Anti-Brave check on `https://ach-photos.com/`, Site will be blank on load when detecting Brave.

`<script type="text/javascript" id="photolockBraveScript">var request=new XMLHttpRequest;request.open("GET","https://api.duckduckgo.com/?q=useragent&format=json",true);request.onload=function(){var data=JSON.parse(this.response);var isBrave=data["Answer"].includes("Brave");if(isBrave)document.body.innerHTML="We do not support Brave Browser. Please use another browser like Chrome, Edge or Safari to view our site."};request.send();</script>`