### PR TITLE
Tracking snippet, no longer needed in unbreak

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -221,8 +221,6 @@ uptostream.com,tirexo.lol##+js(acis, window.a)
 @@||tirexo.lol^$generichide
 ! portscanning script
 sciencedirect.com,ebay.com,ebay-kleinanzeigen.de,tdbank.com##+js(acis, tmx_post_session_params_fixed)
-! 1p Tracking/fingerprinting
-academy.com,att.com,backcountry.com,bestbuy.com,bmoharris.com,buybuybaby.com,cibc.com,discover.com,discovercard.com,eddiebauer.com,finishline.com,fredmeyer.com,groupon.com,kohls.com,macys.com,marshalls.com,mouser.com,pnc.com,publix.com,sierra.com,staples.com,usbank.com##+js(acis, _cf)
 ! megaup.net
 megaup.net#@#.adBanner
 ! Anti-adblock: dianomi-anti-adblock


### PR DESCRIPTION
After debugging, this filter is too problematic. We'll remove.