### PR TITLE
Update CBS Allaccess to paramount plus

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -241,11 +241,8 @@ cinemablend.com##+js(abort-on-property-read, __cmpGdprAppliesGlobally)
 ! Anti-adblock (Brave fix on  https://github.com/brave/brave-browser/issues/12737)
 @@||static.adsafeprotected.com/vans-adapter-google-ima.js$script,domain=motorsport.tv|motorsport.com
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=motorsport.tv|motorsport.com
-! Temp fix for CBS All Access (https://github.com/brave/brave-browser/issues/12705)
-@@||s0.2mdn.net/instream/video/client.js$script,domain=cbs.com
-@@||adservice.google.com/adsid/integrator.js$script,domain=cbs.com
-@@||tags.tiqcdn.com/utag/cbsi/cbscomsite/prod/utag.js$script,domain=cbs.com
-@@||securepubads.g.doubleclick.net/tag/js/gpt.js$script,domain=cbs.com
+! Temp fix for CBS/Paramountplus (https://github.com/brave/brave-browser/issues/12705)
+@@||s0.2mdn.net/instream/video/client.js$script,domain=cbs.com|paramountplus.com
 ! Anti-adblock: concert.io (vox sites)
 chicago.suntimes.com,theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com,mmafighting.com,racked.com,mmamania.com,funnyordie.com,riftherald.com##+js(nostif, adsBlocked)
 chicago.suntimes.com,theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com,mmafighting.com,racked.com,mmamania.com,funnyordie.com,riftherald.com##.adblock-allowlist-messaging__wrapper


### PR DESCRIPTION
Clean up older filters, no longer needed. And defeat Anti-adblock check.

Site is still using both `cbs.com` and `paramountplus.com`  

Tested on `https://www.paramountplus.com/shows/the-late-show-with-stephen-colbert/video/x1gpE9i_RZIkK4ia5SOGt3o9i4C0OaqG/bahamas-ft-lucius-less-than-love-/`


Merged related fixes into uBO https://github.com/uBlockOrigin/uAssets/pull/8684