### PR TITLE
Fix anit-adblock check on onlinefreecourse.net

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -259,6 +259,8 @@ chicago.suntimes.com,theverge.com,vox.com,eater.com,polygon.com,sbnation.com,cur
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=livexlive.com
 @@||www.googletagservices.com/tag/js/gpt.js$script,domain=livexlive.com
 @@||securepubads.g.doubleclick.net^$script,domain=livexlive.com
+! uBO-redirect work around onlinefreecourse.net 
+@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$xmlhttprequest,domain=onlinefreecourse.net
 ! Fix Playback on http://v6.player.abacast.net/6508 (https://community.brave.com/t/problem-loading-http-v6-player-abacast-net-6508/71822)
 @@||imasdk.googleapis.com/js/core/$subdocument,domain=player.abacast.net
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=player.abacast.net


### PR DESCRIPTION
Fixes Anti-adblock check on `onlinefreecourse.net`. Was reported by @srirambv  

uBO redirect work around.  