### PR TITLE
Fix cbs.com playback error

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -1,4 +1,4 @@
-|ntv.io^$third-party
+||ntv.io^$third-party
 @@||adm.fwmrm.net^*/AdManager.js$domain=msnbc.com|sky.com|cnbc.com
 ||novately.com^$third-party
 ||webspectator.com^$third-party

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -1,4 +1,4 @@
-||ntv.io^$third-party
+|ntv.io^$third-party
 @@||adm.fwmrm.net^*/AdManager.js$domain=msnbc.com|sky.com|cnbc.com
 ||novately.com^$third-party
 ||webspectator.com^$third-party
@@ -243,6 +243,7 @@ cinemablend.com##+js(abort-on-property-read, __cmpGdprAppliesGlobally)
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=motorsport.tv|motorsport.com
 ! Temp fix for CBS/Paramountplus (https://github.com/brave/brave-browser/issues/12705)
 @@||s0.2mdn.net/instream/video/client.js$script,domain=cbs.com|paramountplus.com
+||ad.doubleclick.net^$image,redirect=1x1.gif,domain=cbs.com|paramountplus.com
 ! Anti-adblock: concert.io (vox sites)
 chicago.suntimes.com,theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com,mmafighting.com,racked.com,mmamania.com,funnyordie.com,riftherald.com##+js(nostif, adsBlocked)
 chicago.suntimes.com,theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com,mmafighting.com,racked.com,mmamania.com,funnyordie.com,riftherald.com##.adblock-allowlist-messaging__wrapper


### PR DESCRIPTION
cbs.com is generating errors when playing back video (for the first time). Cookies/cache cleared, testing in private window mode.

![cbs-error](https://user-images.githubusercontent.com/1659004/110596511-43813580-81e4-11eb-9b59-49cbcb37b8b5.png)

From a bit debugging, CBS is checking on doubleclick images are being set. 

`@@||ad.doubleclick.net/ddm/ad/$image,domain=cbs.com` would also work. But after further testing using a `$redirect` is better for privacy and redirect works without issue. The message won't show up.

Tested with cbs homepage, and cbs video `https://www.cbs.com/shows/oprah-with-meghan-and-harry-a-cbs-primetime-special/video/i6UW_WTQjLrEeOoObMmlwrFLTTypvuZm/cbs-presents-oprah-with-meghan-and-harry-a-primetime-special/`

As a precaution, also covered `paramountplus.com`, since they're also using the same video player.