### PR TITLE
Fix Shields issues with Trezor Bridge/Connect

### DIFF
--- a/brave-lists/brave-specific.txt
+++ b/brave-lists/brave-specific.txt
@@ -22,3 +22,7 @@
 @@/afs/ads/*$domain=startpage.com
 @@&adsafe=$domain=startpage.com
 @@/gen_204?$image,domain=startpage.com
+
+! Fix localhost block on Trezor Bridge/Connect
+! https://community.brave.com/t/bug-brave-shields-break-trezor-bridge-connect-when-accessing-wallet/219544/
+@@||127.0.0.1^$domain=trezor.io


### PR DESCRIPTION
Was reported here: https://community.brave.com/t/bug-brave-shields-break-trezor-bridge-connect-when-accessing-wallet/219544

> Brave Shields seem to cause Trezor Bridge to fail when accessing any variation of trezor-DOT-io (for instance, wallet-DOT-trezor-DOT-io will think the device isn’t connected). When using a Trezor hardware wallet to access external wallets, Brave Shields also prevent Trezor Bridge from working. I’ve tested this both on myetherwallet-DOT-com an adalite-DOT-io. Normally when you choose the hardware (Trezor) option, it redirects to connect-DOT-trezor-DOT-io and allows you to export the key and access the wallet.

![66786cfbe5c8982915f42df6e43cd39a09c7764b](https://user-images.githubusercontent.com/1659004/111890076-1be36600-8a4b-11eb-90fc-c99f9c156455.png)

User confirmed that `@@||127.0.0.1^$domain=trezor.io` worked for him.