### PR TITLE
Fix google.com clickthroughs on ios

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -1,5 +1,9 @@
 ! Brave IOS specific filters
 
+! Counter Peter Lowes Filters
+||doubleclick.net^$badfilter
+||googleadservices.com^$badfilter
+
 ! coveryourtracks.eff.org
 ||trackersimulator.org^$subdocument
 ||eviltracker.net^$subdocument


### PR DESCRIPTION
Was reported that clickthrough were not working on ios.

Doubleclick and googleadservices already blocked in Easylist, this will just allow clickthrough on the google site.

![google-ios](https://user-images.githubusercontent.com/1659004/112091931-4d9b2f00-8bfb-11eb-8837-07b9f06c372a.png)
