### PR TITLE
Fix uBO redirection on https://golf.com/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -248,6 +248,8 @@ cinemablend.com##+js(abort-on-property-read, __cmpGdprAppliesGlobally)
 chicago.suntimes.com,theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com,mmafighting.com,racked.com,mmamania.com,funnyordie.com,riftherald.com##+js(nostif, adsBlocked)
 chicago.suntimes.com,theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com,mmafighting.com,racked.com,mmamania.com,funnyordie.com,riftherald.com##.adblock-allowlist-messaging__wrapper
 ||concert.io/lib/adblock/$subdocument
+! uBO-redirect work around golf.com https://github.com/uBlockOrigin/uAssets/pull/8805
+@@||securepubads.g.doubleclick.net/tag/js/gpt.js$domain=golf.com
 ! uBO-redirect work around vpnstunnel.com
 @@||google.com/adsense/start/images/favicon.ico$image,domain=vpnstunnel.com
 ! uBO-redirect work around ovagames.com 


### PR DESCRIPTION
Fix rendering issues on https://golf.com/news/tour-confidential-match-play-concession-augusta-womens-am/

Reported https://github.com/uBlockOrigin/uAssets/pull/8805 but due to redirect changes needed to fix this (reimplement the initial patch)