### PR TITLE
Fix localhost issue on crust.network

### DIFF
--- a/brave-lists/brave-specific.txt
+++ b/brave-lists/brave-specific.txt
@@ -26,3 +26,7 @@
 ! Fix localhost block on Trezor Bridge/Connect
 ! https://community.brave.com/t/bug-brave-shields-break-trezor-bridge-connect-when-accessing-wallet/219544/
 @@||127.0.0.1^$domain=trezor.io
+
+! Fix localhost block on https://apps.crust.network/
+! https://community.brave.com/t/specific-filter-whitelist-application/223212
+@@||127.0.0.1^$domain=crust.network


### PR DESCRIPTION
Was reported via https://community.brave.com/t/specific-filter-whitelist-application/223212

> Crust Apps (a Dapp of Crust Network, you can check this: https://apps.crust.network) basically provides decentralized IPFS Pin services. But when we used Brave to explore Crust Apps, we found that Brave Shield would intercept the connection request of 127.0.0.1 from our Apps, and users need to manually close Brave Shield for normal use.