### PR TITLE
Fix consent issue on spiegel.de

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -80,6 +80,9 @@ twitter.com##[style]>div>div>[data-testid=placementTracking]
 ||privacy-mgmt.com^$third-party
 ||sp-prod.net^$third-party
 @@||notice.sp-prod.net^$subdocument,domain=telegraph.co.uk
+@@||cdn.privacy-mgmt.com/wrapper/$xmlhttprequest,domain=spiegel.de
+@@||cdn.privacy-mgmt.com/index.html$subdocument,domain=spiegel.de
+@@||cdn.privacy-mgmt.com/consent/$subdocument,domain=spiegel.de
 ! Scroll bar-consent
 collegeconfidential.com##body:style(overflow: auto !important; max-height: 1px !important;)
 ! Brave-social (temp)


### PR DESCRIPTION
Was reported here. https://community.brave.com/t/impossible-to-accept-cookies-on-spiegel-de/228155

We're blocking `privacy-mgmt.com` , which is causing a consent issue on `spiegel.de`. User is unable to bypass the consent check, affecting IOS/Android and Desktop.