### PR TITLE
Disable googlefunding in Brave specific, move to IOS

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -9,5 +9,8 @@
 ||eviltracker.net^$subdocument
 ||do-not-tracker.org^$subdocument
 
+! Prevent googlefunding error message (ios)
+||fundingchoicesmessages.google.com^$third-party,badfilter
+
 ! Anti-adblock: concert.io (vox sites)
 @@||vox-cdn.com/packs/concert_ads-$script,domain=chicago.suntimes.com|theverge.com|eater.com|polygon.com|vox.com|sbnation.com|curbed.com|theringer.com|mmafighting.com|racked.com|mmamania.com|funnyordie.com|riftherald.com

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -306,24 +306,10 @@ nytimes.com##+js(acis, document.cookie, PURR_COOKIE_NAME)
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=foxbusiness.com|foxnews.com
 @@||fncstatic.com/static/isa/app/lib/VisitorAPI.js$script,domain=foxbusiness.com|foxnews.com
 ! Temp fix for Google funding Yellow Bar (https://github.com/brave/brave-browser/issues/11945)
-##div[style*="box-shadow: rgb(136, 136, 136) 0px 0px 12px; color: "]
+! ##div[style*="box-shadow: rgb(136, 136, 136) 0px 0px 12px; color: "]
 ! Fix googlefunding issues (Android) https://github.com/uBlockOrigin/uAssets/blob/master/filters/filters.txt#L21331
-||fundingchoicesmessages.google.com^$third-party,badfilter
-! To counter $ghide in uBO
-geekzone.co.nz,elpais.com,abc.es,lapresse.ca##div[style*="box-shadow: rgb(136, 136, 136) 0px 0px 12px; color: "]
-! all3dp.com (google funding)
-@@||all3dp.com^$generichide
-all3dp.com##.ad-container--loaded
-all3dp.com##.ad-container--horizontal
-all3dp.com##.ad-container__provider
-! googlefunding popup
-nativeplanet.com,elmundo.es,abc.es,elpais.com,goodreturns.in,drivespark.com,gizbot.com,ign.com,uol.com.br,telva.com,geekzone.co.nz,lapresse.ca,all3dp.com,click.in,filmibeat.com,boldsky.com,careerindia.com##+js(acis, trustedTypes, console)
-natlawreview.com,nativeplanet.com,elmundo.es,livejournal.com,abc.es,elpais.com,goodreturns.in,drivespark.com,gizbot.com,telva.com,lapresse.ca,click.in,filmibeat.com,boldsky.com,careerindia.com##+js(acis, JSON.stringify, instanceof)
 ! googlefunding (latimes.com) (fix scroll)
 latimes.com##body:style(overflow: auto !important;)
-! hide google fc popup and overlay
-latimes.com##.fc-dialog-container
-latimes.com##.fc-ab-root
 ! googlefunding (foxnews / foxbusiness)
 ||foxnews.com^*choices.js$script,domain=foxnews.com|foxbusiness.com
 ! Anti-adblock: indiatimes.com / timesofindia.com


### PR DESCRIPTION
Moving Googlefunding to ios specific, trialing whether we still need these exceptions. 

1. Removed googlefunding fixes from Brave specific
2. Move `||fundingchoicesmessages.google.com^$third-party,badfilter` into ios. 

Can be reverted if we're still running into issues.