### PR TITLE
Re-enable google funding fix

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -309,7 +309,9 @@ nytimes.com##+js(acis, document.cookie, PURR_COOKIE_NAME)
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=foxbusiness.com|foxnews.com
 @@||fncstatic.com/static/isa/app/lib/VisitorAPI.js$script,domain=foxbusiness.com|foxnews.com
 ! Temp fix for Google funding Yellow Bar (https://github.com/brave/brave-browser/issues/11945)
-! ##div[style*="box-shadow: rgb(136, 136, 136) 0px 0px 12px; color: "]
+##div[style*="box-shadow: rgb(136, 136, 136) 0px 0px 12px; color: "]
+! To counter $ghide in uBO
+geekzone.co.nz,elpais.com,abc.es,lapresse.ca##div[style*="box-shadow: rgb(136, 136, 136) 0px 0px 12px; color: "]
 ! Fix googlefunding issues (Android) https://github.com/uBlockOrigin/uAssets/blob/master/filters/filters.txt#L21331
 ! googlefunding (latimes.com) (fix scroll)
 latimes.com##body:style(overflow: auto !important;)


### PR DESCRIPTION
https://github.com/brave/adblock-lists/pull/589    Partial fix

Reported google funding issues reported.

https://community.brave.com/t/ad-or-script-blocking-software-is-interfering-with-this-page/231395/2
https://community.brave.com/t/banner-disable-any-ad-or-script-blocking-software-lootlemon-com/231545
https://community.brave.com/t/google-funding-message-on-zerohedge-com/234380