### PR TITLE
Fix Facebook check on https://igniteunmc.com/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -85,6 +85,8 @@ twitter.com##[style]>div>div>[data-testid=placementTracking]
 @@||cdn.privacy-mgmt.com/consent/$subdocument,domain=spiegel.de
 ! Scroll bar-consent
 collegeconfidential.com##body:style(overflow: auto !important; max-height: 1px !important;)
+! Fix preloader (facebook check)
+igniteunmc.com##.preloader
 ! Brave-social (temp)
 ! List used by Brave for preventing social elements from loading
 !


### PR DESCRIPTION
When loading https://igniteunmc.com/ 

Due to facebook checks, page will endless loading page if `connect.facebook.com`. Can be easily bypassed with a cosmetic