### PR TITLE
Fix anti-adblock on turreta.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -253,6 +253,8 @@ cinemablend.com##+js(abort-on-property-read, __cmpGdprAppliesGlobally)
 chicago.suntimes.com,theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com,mmafighting.com,racked.com,mmamania.com,funnyordie.com,riftherald.com##+js(nostif, adsBlocked)
 chicago.suntimes.com,theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com,mmafighting.com,racked.com,mmamania.com,funnyordie.com,riftherald.com##.adblock-allowlist-messaging__wrapper
 ||concert.io/lib/adblock/$subdocument
+! uBO-redirect work around turreta.com (Anti-adblock)
+@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,domain=turreta.com
 ! uBO-redirect work around akwam.cc (Anti-adblock) 
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=akwam.cc
 akwam.cc##+js(acis, eval, ignielAdBlock)


### PR DESCRIPTION
Fixes Anti-adblock on `turreta.com` check due lack of uBO-redirect rule

Countered in ubO with `||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,redirect-rule=googlesyndication_adsbygoogle.js`

https://github.com/brave/adblock-rust/issues/169