### PR TITLE
Workaround anti-adblock on slate.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -222,6 +222,8 @@ uptostream.com,tirexo.lol##+js(acis, window.a)
 sciencedirect.com,ebay.com,ebay-kleinanzeigen.de,tdbank.com##+js(acis, tmx_post_session_params_fixed)
 ! megaup.net
 megaup.net#@#.adBanner
+! slate.com Anti-adblock workaround https://github.com/brave/brave-browser/issues/15702
+||tinypass.com^$domain=slate.com
 ! Anti-adblock: dianomi-anti-adblock
 @@||pcwelt.de^$generichide
 @@||formel1.de^$generichide


### PR DESCRIPTION
Network will apply to Android, Desktop and IOS.

Scriptlet fix in uBO, addressed in https://github.com/brave/brave-browser/issues/15702

**Will fix anti-adblock overlay from showing:** 
![slate com](https://user-images.githubusercontent.com/1659004/117558908-17dfd600-b0d5-11eb-95fe-b501fbbd8793.png)

Reported by user on https://old.reddit.com/r/brave_browser/comments/n81kdf/slatecom_does_not_like_that_i_am_using_brave_and/
