### PR TITLE
Fix logins for slate.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -224,6 +224,7 @@ sciencedirect.com,ebay.com,ebay-kleinanzeigen.de,tdbank.com##+js(acis, tmx_post_
 megaup.net#@#.adBanner
 ! slate.com Anti-adblock workaround https://github.com/brave/brave-browser/issues/15702
 ||tinypass.com^$domain=slate.com
+@@||id.tinypass.com^$domain=slate.com
 ! Anti-adblock: dianomi-anti-adblock
 @@||pcwelt.de^$generichide
 @@||formel1.de^$generichide


### PR DESCRIPTION
Just a small tweak from the [previous fix](https://github.com/brave/adblock-lists/pull/599), tinypass is used as a auth also not just anti-adblock.

`https://slate.com/sign-in` will fail to load correctly,

Related: https://github.com/brave/brave-browser/issues/15702