### PR TITLE
Quick fix to prevent errors on ios/android from loading youtube.com

### DIFF
--- a/brave-lists/brave-android-specific.txt
+++ b/brave-lists/brave-android-specific.txt
@@ -4,3 +4,6 @@
 fmovies.to##+js(acis, JSON.parse)
 fmovies.to##+js(acis, atob)
 fmovies.to##+js(acis, XMLHttpRequest)
+
+!temp fix (prevent errors showing up)
+@@||youtube.com/watch?

--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -14,3 +14,6 @@
 
 ! Anti-adblock: concert.io (vox sites)
 @@||vox-cdn.com/packs/concert_ads-$script,domain=chicago.suntimes.com|theverge.com|eater.com|polygon.com|vox.com|sbnation.com|curbed.com|theringer.com|mmafighting.com|racked.com|mmamania.com|funnyordie.com|riftherald.com
+
+!temp fix (prevent errors showing up)
+@@||youtube.com/watch?


### PR DESCRIPTION
Just a temp fix on mobile due to youtube adjusting the url to prefetch ads. Which is currently having adverse issues on Android and ios.  Given ads were already showing previously, nothing will change here except for the error messages.

We can revert once we know the Eastlist filters work well in ios/android.  (https://github.com/easylist/easylist/commit/df0456c9)

![screenshot_20210514-194918](https://user-images.githubusercontent.com/1659004/118270562-58e04c00-b514-11eb-96cb-40342473c4cf.jpg)