### PR TITLE
Remove ios/android exceptions (Waiting on next Brave Ad Block Updater) Do not commit just yet

### DIFF
--- a/brave-lists/brave-android-specific.txt
+++ b/brave-lists/brave-android-specific.txt
@@ -5,5 +5,3 @@ fmovies.to##+js(acis, JSON.parse)
 fmovies.to##+js(acis, atob)
 fmovies.to##+js(acis, XMLHttpRequest)
 
-!temp fix (prevent errors showing up)
-@@||youtube.com/watch?

--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -15,5 +15,3 @@
 ! Anti-adblock: concert.io (vox sites)
 @@||vox-cdn.com/packs/concert_ads-$script,domain=chicago.suntimes.com|theverge.com|eater.com|polygon.com|vox.com|sbnation.com|curbed.com|theringer.com|mmafighting.com|racked.com|mmamania.com|funnyordie.com|riftherald.com
 
-!temp fix (prevent errors showing up)
-@@||youtube.com/watch?


### PR DESCRIPTION
In Easylist we've limited the Adblock fixes to [Desktop for the time being](https://github.com/easylist/easylist/commit/f11fc16105756a99d5e689fa15c8f92645b08e39). 

We won't need these exceptions any more. And will allow us to now debug via `brave://adblock` on android the safely block ads on android mobile (and ios).

