### PR TITLE
Fix Anti-adblock on nation.africa

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -252,6 +252,8 @@ cinemablend.com##+js(abort-on-property-read, __cmpGdprAppliesGlobally)
 chicago.suntimes.com,theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com,mmafighting.com,racked.com,mmamania.com,funnyordie.com,riftherald.com##+js(nostif, adsBlocked)
 chicago.suntimes.com,theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com,mmafighting.com,racked.com,mmamania.com,funnyordie.com,riftherald.com##.adblock-allowlist-messaging__wrapper
 ||concert.io/lib/adblock/$subdocument
+! uBO-redirect work around nation.africa (Anti-adblock)
+@@||evolok.net/acd/api/$xmlhttprequest,domain=nation.africa
 ! uBO-redirect work around turreta.com (Anti-adblock)
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,domain=turreta.com
 ! uBO-redirect work around akwam.cc (Anti-adblock) 


### PR DESCRIPTION
Fix anti-adblock on `https://nation.africa/kenya/news/huduma-card-renews-family-s-hope-of-tracing-kin-missing-for-45-years--3410578` related redirect-rule


```
filters-2021.txt:||evolok.net/*/authorize/*$xhr,redirect-rule=nooptext,domain=nation.africa
filters.txt:||evolok.net/acd/api/*/authorize/*adblock$xhr,3p
```