### PR TITLE
Fix anti-adblock on suncalc.org

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -240,6 +240,9 @@ reuters.com,hardwareluxx.de,formel1.de,golem.de,finanzen.net,autobild.de,gamesta
 ||s3.reutersmedia.net/resources/*&rtn=$image
 ! Anti-adblock message cinemablend.com (ported from uBO Annoyances)
 cinemablend.com##+js(abort-on-property-read, __cmpGdprAppliesGlobally)
+! Anti-adblock message suncalc.org (ported from uBO Annoyances)
+###adsGross1
+###adsKlein
 ! chip.de
 ||mms.chip.de^
 ! Anti-adblock (Brave fix on  https://github.com/brave/brave-browser/issues/12737)


### PR DESCRIPTION
Ported over from uBO Annoyances, worthy of inclusion of main list. https://github.com/uBlockOrigin/uAssets/commit/c6e24b387ae

Prevents anti-adblock messages from showing on `suncalc.org` and `sonnenverlauf.de`