### PR TITLE
Fixes https://github.com/brave/brave-browser/issues/16629

### DIFF
--- a/brave-lists/brave-android-specific.txt
+++ b/brave-lists/brave-android-specific.txt
@@ -5,4 +5,4 @@ fmovies.to##+js(acis, JSON.parse)
 fmovies.to##+js(acis, atob)
 fmovies.to##+js(acis, XMLHttpRequest)
 ! https://github.com/brave/brave-browser/issues/16629
-01net.com##.mrf-adv__wrapper
+diariodocentrodomundo.com.br,01net.com,gizchina.com,pocketpc.ch##.mrf-adv__wrapper 

--- a/brave-lists/brave-android-specific.txt
+++ b/brave-lists/brave-android-specific.txt
@@ -4,4 +4,5 @@
 fmovies.to##+js(acis, JSON.parse)
 fmovies.to##+js(acis, atob)
 fmovies.to##+js(acis, XMLHttpRequest)
-
+! https://github.com/brave/brave-browser/issues/16629
+01net.com##.mrf-adv__wrapper

--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -16,4 +16,4 @@
 @@||vox-cdn.com/packs/concert_ads-$script,domain=chicago.suntimes.com|theverge.com|eater.com|polygon.com|vox.com|sbnation.com|curbed.com|theringer.com|mmafighting.com|racked.com|mmamania.com|funnyordie.com|riftherald.com
 
 ! https://github.com/brave/brave-browser/issues/16629
-01net.com##.mrf-adv__wrapper
+diariodocentrodomundo.com.br,01net.com,gizchina.com,pocketpc.ch##.mrf-adv__wrapper 

--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -15,3 +15,5 @@
 ! Anti-adblock: concert.io (vox sites)
 @@||vox-cdn.com/packs/concert_ads-$script,domain=chicago.suntimes.com|theverge.com|eater.com|polygon.com|vox.com|sbnation.com|curbed.com|theringer.com|mmafighting.com|racked.com|mmamania.com|funnyordie.com|riftherald.com
 
+! https://github.com/brave/brave-browser/issues/16629
+01net.com##.mrf-adv__wrapper


### PR DESCRIPTION
Fixes cosmetic elements on `01net.com`  from https://github.com/brave/brave-browser/issues/16629

https://github.com/AdguardTeam/AdguardFilters/pull/86864 wasn't merged due to Adguard having differences with desktop and mobile lists.