### PR TITLE
Fixes anti-adblock on photopea.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -284,6 +284,8 @@ akwam.cc##+js(acis, eval, ignielAdBlock)
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=rp5.ru
 ! uBO-redirect work around onlinefreecourse.net 
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$xmlhttprequest,domain=onlinefreecourse.net
+! uBO-redirect work around photopea.com
+@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=photopea.com
 ! Fix Playback on http://v6.player.abacast.net/6508 (https://community.brave.com/t/problem-loading-http-v6-player-abacast-net-6508/71822)
 @@||imasdk.googleapis.com/js/core/$subdocument,domain=player.abacast.net
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=player.abacast.net


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/16928

Opening `https://www.photopea.com/` will randomly display a message on load images.