### PR TITLE
Fix anti-adblock on shineads.in

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -284,6 +284,8 @@ akwam.cc##+js(acis, eval, ignielAdBlock)
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=rp5.ru
 ! uBO-redirect work around onlinefreecourse.net 
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$xmlhttprequest,domain=onlinefreecourse.net
+! uBO-redirect work around shineads.in
+@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=shineads.in
 ! uBO-redirect work around photopea.com
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=photopea.com
 ! Fix Playback on http://v6.player.abacast.net/6508 (https://community.brave.com/t/problem-loading-http-v6-player-abacast-net-6508/71822)


### PR DESCRIPTION
Fixes redirect-rule/Anti-adblock check on `shineads.in`. Anti-adblock message will show on the site.

Reported by a user:
https://community.brave.com/t/websites-keep-detecting-ad-blocker-although-disabled/268353