### PR TITLE
Fixes blank space issues on various radio sites

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -291,6 +291,12 @@ akwam.cc##+js(acis, eval, ignielAdBlock)
 ! Fix Playback on http://v6.player.abacast.net/6508 (https://community.brave.com/t/problem-loading-http-v6-player-abacast-net-6508/71822)
 @@||imasdk.googleapis.com/js/core/$subdocument,domain=player.abacast.net
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=player.abacast.net
+! uBO-redirect work around, Fixes Blank page 
+@@||googletagservices.com/tag/js/gpt.js$domain=invisibleoranges.com|nj1015.com|tasteofcountry.com|wyrk.com|xxlmag.com|ultimateclassicrock.com
+@@||googletagmanager.com/gtm.js$domain=invisibleoranges.com|nj1015.com|tasteofcountry.com|wyrk.com|xxlmag.com|ultimateclassicrock.com
+@@||google-analytics.com/analytics.js$domain=invisibleoranges.com|nj1015.com|tasteofcountry.com|wyrk.com|xxlmag.com|ultimateclassicrock.com
+! uBO-redirect work around Fixes Anti-Adblock detection in player
+@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=invisibleoranges.com|nj1015.com|tasteofcountry.com|wyrk.com|xxlmag.com|ultimateclassicrock.com
 ! Potential Tracker, Annoyance
 ||govdelivery.com^$third-party
 ! Whatleaks nullifer


### PR DESCRIPTION
Works around the google redirect-rule fixes done in uBO. for 

1. invisibleoranges.com,
2. nj1015.com,
3. tasteofcountry.com,
4. wyrk.com,
5. xxlmag.com,
6. ultimateclassicrock.com

A blank page will show. due to redirect-rule.

![xxlmag](https://user-images.githubusercontent.com/1659004/127086238-598da5f0-46ed-498a-98d5-f90c6cf3b94e.png)
![xxlmag2](https://user-images.githubusercontent.com/1659004/127086250-17c1c1e5-8d24-4ea0-b488-1a25c7860aeb.png)

Addressed a 2nd fix for audio playback. (also redirect-rule)
`@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=invisibleoranges.com|nj1015.com|tasteofcountry.com|wyrk.com|xxlmag.com|ultimateclassicrock.com` 