### PR TITLE
Fix https://github.com/AdguardTeam/AdguardFilters/issues/85641

### DIFF
--- a/brave-lists/brave-specific.txt
+++ b/brave-lists/brave-specific.txt
@@ -26,3 +26,7 @@
 ! Fix localhost block on Trezor Bridge/Connect
 ! https://community.brave.com/t/bug-brave-shields-break-trezor-bridge-connect-when-accessing-wallet/219544/
 @@||127.0.0.1^$domain=trezor.io
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/85641
+modalina.jp###ggleadv:style(height: 60px!important;)
+modalina.jp###header:style(margin-top: 60px!important;)


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/85641
We at AdGuard gave up fixing this anti-adb for iOS. As Brave uses iOS version of AG lists, the issue have to be fixed for Brave for Desktop/Android:

<details>
<summary>Screenshot</summary>

![modalina1](https://user-images.githubusercontent.com/58900598/127150800-eefbd9ec-9874-4f04-821c-03d7b0841c2b.png)

</details>

Test URL for the 1st rule: `https://www.modalina.jp/modapedia/w/e382b9e382bfe383b3e38380e383bce38389e383bbe382abe383a9e383bc/`