### PR TITLE
Fix portscanning perf issues on cibc.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -221,7 +221,7 @@ livemint.com##+js(aeld, DOMContentLoaded)
 uptostream.com,tirexo.lol##+js(acis, window.a)
 @@||tirexo.lol^$generichide
 ! portscanning script
-sciencedirect.com,ebay.com,ebay-kleinanzeigen.de,tdbank.com##+js(acis, tmx_post_session_params_fixed)
+cibc.com,sciencedirect.com,ebay.com,ebay-kleinanzeigen.de,tdbank.com##+js(acis, tmx_post_session_params_fixed)
 ! megaup.net
 megaup.net#@#.adBanner
 ! slate.com Anti-adblock workaround https://github.com/brave/brave-browser/issues/15702


### PR DESCRIPTION
`cibc.com` is using port scans, causing perf issues even when blocked. Blocking this script like the existing will help with performance.