### PR TITLE
Fix feedback url on search.brave.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -8,6 +8,7 @@
 @@||ads.brave.software^$first-party
 @@||ads-admin.bravesoftware.com^$first-party
 @@||ads.bravesoftware.com^$first-party
+@@||search.brave.com/api/$first-party
 @@||ads-admin.brave.com^$first-party
 @@||ads-admin.brave.software^$first-party
 @@||ads.brave.com^$first-party


### PR DESCRIPTION
Allow `search.brave.com` feedback to work correct when a user is searching on Brave search.

Fixes the xhr request on https://search.brave.com/api/*