### PR TITLE
Fix Brave search ubO snippet filter

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -12,6 +12,8 @@
 @@||ads-admin.brave.com^$first-party
 @@||ads-admin.brave.software^$first-party
 @@||ads.brave.com^$first-party
+! https://github.com/uBlockOrigin/uAssets/blob/master/filters/privacy.txt#L260
+search.brave.com#@#+js(no-fetch-if, body:cohort)
 ! stats.brave.com
 stats.brave.com#@#adsContent
 @@||stats.brave.com/local/img/publisher-icons/$domain=stats.brave.com


### PR DESCRIPTION
Implemented via uBO privacy.txt. filter not needed and should not be applied `search.brave.com##+js(no-fetch-if, body:cohort)`

https://github.com/uBlockOrigin/uAssets/blob/master/filters/privacy.txt#L260