### PR TITLE
Include new facebook.com debounce

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -86,7 +86,8 @@
   },
   {
     "include": [
-      "*://*.facebook.com/1.php"
+      "*://*.facebook.com/1.php",
+      "*://*.facebook.com/l.php"
     ],
     "exclude": [
     ],


### PR DESCRIPTION
"l.php?" used on facebook (different to the 1.php in the list). Forwards to a kickstarter website.


`https://l.facebook.com/l.php?u=https%3A%2F%2Fpledge-tools27.com%2FEyeDear-rd-55679390239.html%3Fref%3Dcbrry2%26utm_source%3Djellop%26ja%3Djcf%26utm_term%3D001.jcf%26utm_content%3DEyeDear-VD03%26utm_medium%3Dfacebook%26fbclid%3DIwAR327PVexHtEZGRnrxXDhxG5KftwEe0-C_gkQ4d3dezxXPTpk1qI1ZRXElo&h=AT0x_Sw0L5sap_U2y5daD0SnhGwXglETHE1oEbTpkytP-FemRi75TVAmxzEwIRg4UC8SB6dZOK7r2J3YxIUmLD5tLIFc-CD-PbFsmvKenlQOuITGxfssfes5ZsqIm4KNHSQ&__tn__=%2C%3C%2CmH-R&c[0]=AT2wVwrOIj5RVRjlNbeoYV1cLqErRPWD6xY8hA66RaErpXcDHOmU3uV2iu9brW9CtDPGYvErE-aw7hHZL6nrQM9X12fu5mxyiwE7CXq0Mu1Nur6OIg_3h65Q19XH_P_SylD18oddlq8JZQHwv0AzP-YYqSLq_a1UqPkejZk4iYGg60mS7Q4NwXhlvgsKr00_nNPdd5GK3DV20ehot-uEBhGcntZRFrCVj_mXPXkvax3vigArIJbKI7TMAoE2KRVYVRBh2sSd-1HqpspmiNUxA_pqBtsrgqe8ljUWSY67MQ_XW7XHaJM7Jm7TAJPE6HebqrliLqIjq_k74Z4efi670V0OZ-c8CrPpcK0OeYTA`

cc: @pes10k 