### PR TITLE
Revert https://github.com/brave/adblock-lists/pull/632

### DIFF
--- a/brave-lists/brave-specific.txt
+++ b/brave-lists/brave-specific.txt
@@ -34,5 +34,3 @@ modalina.jp###header:style(margin-top: 60px!important;)
 ! Used for Brave QA tests
 ?335962573013224749$image,domain=dev-pages.brave.software|dev-pages.bravesoftware.com
 
-! YoutubeTV popup
-youtube.com##.ytd-popup-container


### PR DESCRIPTION
May need to be tweaked, seems the notification popup id is used elsewhere. "YouTube notification, 3dot icon save to and user login not working"

https://community.brave.com/t/youtube-notification-3dot-icon-save-to-and-user-login-not-working/273975