### PR TITLE
Fix ads on spiegel.de and wetter.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -236,7 +236,6 @@ megaup.net#@#.adBanner
 @@||tagesspiegel.de^$generichide
 @@||autobild.de/*&adserv$script,domain=autobild.de
 wetter.com,spiegel.de##[referrerpolicy]
-spiegel.de##[referrerpolicy]
 reuters.com,hardwareluxx.de,formel1.de,golem.de,finanzen.net,autobild.de,gamestar.de,tagesspiegel.de##+js(acis, parseInt)
 ||s3.reutersmedia.net/resources/*&rtn=$image
 ! Anti-adblock message cinemablend.com (ported from uBO Annoyances)


### PR DESCRIPTION
Fixes a minor consent issue and hides the ads on these popular .de sites.

Resolving: https://community.brave.com/t/spiegel-de-is-full-of-ads/277357

Fixes: https://github.com/brave/brave-browser/issues/16723