### PR TITLE
Fix ads on techpowerup[.]com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -302,6 +302,12 @@ akwam.cc##+js(acis, eval, ignielAdBlock)
 ! Whatleaks nullifer
 $websocket,domain=whatleaks.com 
 whatleaks.com##+js(acis, init_port_check_waiting)
+! techpowerup.com
+techpowerup.com##[href*=".xlv"]
+techpowerup.com##[href*=".xly"]
+techpowerup.com##[href*=".xlz"]
+techpowerup.com##.mnnusjsddg
+techpowerup.com##.nkuzlfvdywj
 ! Anti-Brave checks
 krunker.io,kodekloud.com,gommonauti.it,btdig.com,archive.is,archive.today,archive.vn,archive.fo,archive.md,archive.li,archive.ph,archivecaslytosk.onion,archiveiya74codqgiixo33q62qlrqtkgmcitqx5u2oeqnmn5bpcbiyd.onion,caratoday.com,sybertrek.com,pethouse.com.au##+js(aopw, navigator.brave)
 archive.is,btdig.com,archive.today,archive.vn,archive.fo,archive.md,archive.li,archive.ph,archiveiya74codqgiixo33q62qlrqtkgmcitqx5u2oeqnmn5bpcbiyd.onion##+js(acis, document.cookie, document.location.href)


### PR DESCRIPTION
Landed this as a Brave only filter, since the website is proactively countering EL and uBO blocks. Unsure if this will countered in Brave, but lets see.

This will prevent the ads from showing up on `https://www.techpowerup.com/`