### PR TITLE
Update paramountplus.com and cbs.com filters

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -249,7 +249,8 @@ cinemablend.com##+js(abort-on-property-read, __cmpGdprAppliesGlobally)
 @@||static.adsafeprotected.com/vans-adapter-google-ima.js$script,domain=motorsport.tv|motorsport.com
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=motorsport.tv|motorsport.com
 ! Temp fix for CBS/Paramountplus (https://github.com/brave/brave-browser/issues/12705)
-@@||s0.2mdn.net/instream/video/client.js$script,domain=cbs.com|paramountplus.com
+@@||s0.2mdn.net/instream/html5/ima3.js$script,domain=paramountplus.com|cbs.com
+@@||adservice.google.com/adsid/integrator.js$script,domain=paramountplus.com|cbs.com
 ||ad.doubleclick.net^$image,redirect=1x1.gif,domain=cbs.com|paramountplus.com
 ! Anti-adblock: concert.io (vox sites)
 chicago.suntimes.com,theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com,mmafighting.com,racked.com,mmamania.com,funnyordie.com,riftherald.com##+js(nostif, adsBlocked)


### PR DESCRIPTION
Update from previous https://github.com/brave/adblock-lists/pull/581

Tested `https://www.cbs.com/shows/48_hours/video/4qq8qSZUiXVtgjPe4bp0GrtlHWi_ld3D/the-deliveryman-murders/`

Tested `https://www.paramountplus.com/shows/the-late-show-with-stephen-colbert/video/rdtCzJSZkaJUzUw2Vzb9Xnc2OkfcPm53/plot-roulette-with-sarah-paulson/`

Prevents the Anti-adblock warning from showing up.
![110596511-43813580-81e4-11eb-9b59-49cbcb37b8b5](https://user-images.githubusercontent.com/1659004/133015003-4a8ed572-d3ca-409f-9dcf-5e672f3af950.png)

