### PR TITLE
Include Twitter trackers

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -3,5 +3,7 @@
 #
 ||akamaized.net/audio/*$media,redirect=noopmp3-0.1s,domain=open.spotify.com
 ||scdn.co/audio/*$media,redirect=noopmp3-0.1s,domain=open.spotify.com
+||ads-api.twitter.com^
 #
 # Trackers
+||twitter.com/1.1/jot/client_event.json


### PR DESCRIPTION
Cover Twitter ads/trackers first party.

https://api.twitter.com/1.1/jot/client_event.json -> `||twitter.com/1.1/jot/client_event.json`   (no issues blocking)
https://ads-api.twitter.com/9/measurement/dcm_local_id -> `||ads-api.twitter.com^` (no issues blocking)