### PR TITLE
Add missing youtube trackers

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -43,6 +43,8 @@
 ||youtube.com/api/stats/delayplay?
 ||youtube.com/api/stats/qoe?
 ||youtube.com/get_video?
+||youtube.com/youtubei/v1/log_event?
+||youtube.com/generate_204?
 ||youtube.com/ptracking?
 ||youtube.com/set_awesome?
 # Reddit


### PR DESCRIPTION
Add missing youtube trackers (seen on embedded youtube).

Blocked in Easyprivacy with `/log_event?` and `/generate_204?`