### PR TITLE
Fix walmart.com portscanning

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -220,7 +220,7 @@ livemint.com##+js(aeld, DOMContentLoaded)
 uptostream.com,tirexo.lol##+js(acis, window.a)
 @@||tirexo.lol^$generichide
 ! portscanning script
-cibc.com,sciencedirect.com,ebay.com,ebay-kleinanzeigen.de,tdbank.com##+js(acis, tmx_post_session_params_fixed)
+cibc.com,sciencedirect.com,ebay.com,ebay-kleinanzeigen.de,tdbank.com,walmart.com##+js(acis, tmx_post_session_params_fixed)
 ! megaup.net
 megaup.net#@#.adBanner
 ! slate.com Anti-adblock workaround https://github.com/brave/brave-browser/issues/15702


### PR DESCRIPTION
Prevents port scanning from being initiating and causing performance issues when we block the localhost requests.