### PR TITLE
Fix Anti-Brave on facetime.apple.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -310,7 +310,7 @@ techpowerup.com##[href*=".xlz"]
 techpowerup.com##.mnnusjsddg
 techpowerup.com##.nkuzlfvdywj
 ! Anti-Brave checks
-icloud.com,krunker.io,kodekloud.com,gommonauti.it,btdig.com,archive.is,archive.today,archive.vn,archive.fo,archive.md,archive.li,archive.ph,archivecaslytosk.onion,archiveiya74codqgiixo33q62qlrqtkgmcitqx5u2oeqnmn5bpcbiyd.onion,caratoday.com,sybertrek.com,pethouse.com.au##+js(aopw, navigator.brave)
+apple.com,krunker.io,kodekloud.com,gommonauti.it,btdig.com,archive.is,archive.today,archive.vn,archive.fo,archive.md,archive.li,archive.ph,archivecaslytosk.onion,archiveiya74codqgiixo33q62qlrqtkgmcitqx5u2oeqnmn5bpcbiyd.onion,caratoday.com,sybertrek.com,pethouse.com.au##+js(aopw, navigator.brave)
 archive.is,btdig.com,archive.today,archive.vn,archive.fo,archive.md,archive.li,archive.ph,archiveiya74codqgiixo33q62qlrqtkgmcitqx5u2oeqnmn5bpcbiyd.onion##+js(acis, document.cookie, document.location.href)
 ! Anti-Brave checks (DuckDuckGo UA check)
 ||api.duckduckgo.com/?q=useragent$domain=i-rotary.com|mynewsmedia.co|tecknity.com|jaysndees.com|recherche-ebook.fr|bellasephina.com|pokedi.xyz|unitythemovement.world|thebeautyboothe.com


### PR DESCRIPTION
Anti-Brave message on `https://facetime.apple.com/`  
![image (11)](https://user-images.githubusercontent.com/1659004/135185809-0dc40090-65aa-483e-bf3d-e9079f474cac.png)

1. Create `https://facetime.apple.com/` link, and open in Brave.
2. Receive "Unsupported Browser" Warning.

Source causing it:
`i=/brave chrome/.test(t)||window.navigator.brave&&window.navigator.brave.isBrave&&"isBrave"===window.navigator.brave.isBrave.name,n=t.match(/fban/`