### PR TITLE
Add debounce from track.adtraction.com

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -20,7 +20,8 @@
       "*://hdblurayindir.com/git.php?url=*",
       "*://gate.sc/?url=*",
       "*://freetutsdownload.net/redirect-to/?url=*",
-      "*://mcpedl.com/leaving/?url=*"
+      "*://mcpedl.com/leaving/?url=*",
+      "*://track.adtraction.com/t/*&url=*"
     ],
     "exclude": [
     ],


### PR DESCRIPTION
Remove the debounce for `https://track.adtraction.com/t/t?a=1578845458&as=1649876489&t=2&tk=1&url=http://www.gog.com/game/fear_platinum`

As seen on `https://www.gog.com/game/fear_platinum?at_gd=A38C87D4DE693146349751051647E62F7CB27771&utm_campaign=adtraction&utm_medium=affiliate&utm_source=adtraction`
Click on `Check out now` Green button



