### PR TITLE
Fix anti-adblock of allmusic.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -238,6 +238,8 @@ megaup.net#@#.adBanner
 wetter.com,spiegel.de##[referrerpolicy]
 reuters.com,hardwareluxx.de,formel1.de,golem.de,finanzen.net,autobild.de,gamestar.de,tagesspiegel.de##+js(acis, parseInt)
 ||s3.reutersmedia.net/resources/*&rtn=$image
+! Anti-adblock message allmusic.com (ported from uBO Annoyances)
+allmusic.com##+js(abort-current-script, $, adblock)
 ! Anti-adblock message cinemablend.com (ported from uBO Annoyances)
 cinemablend.com##+js(abort-on-property-read, __cmpGdprAppliesGlobally)
 ! Anti-adblock message suncalc.org (ported from uBO Annoyances)


### PR DESCRIPTION
Fixes anti-adblock warning on `allmusic.com`, ported from uBO Annoyances.

![screen_shot_2021-10-07_at_5 39 22_pm_720](https://user-images.githubusercontent.com/1659004/136619478-d18a8924-b06a-4ae8-8af4-379a8bae378d.png)


