### PR TITLE
Undo fixes for twitch.tv

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -351,8 +351,6 @@ latimes.com##body:style(overflow: auto !important;)
 @@||timesofindia.com/acms/$xmlhttprequest,domain=timesofindia.com
 ! /track/view| fix for amazon tracking
 @@||amazon.*/shiptrack/view.html$~third-party
-! Disable twitch.js (due to https://old.reddit.com/r/uBlockOrigin/comments/jlquxz/twitch_now_shows_this_if_you_have_ublock_enabled/ )
-twitch.tv#@#+js(twitch-videoad)
 ! Anti-adblock: Instart
 ||vxq18c.g02.ign.com^$script,domain=ign.com
 ||earzxzsl.g02.ign.com^$subdocument,domain=ign.com


### PR DESCRIPTION
With the updated twitch-videoad snippet in https://github.com/brave/uBlock/commit/0d3a1932e998c0cb3f4c5ff1d9a3fe62e12a3cf4

We can remove the exception now, fix twitch ads. Resolving: https://github.com/brave/adblock-lists/issues/2