### PR TITLE
Add missing wildcards to Youtube and Facebook patterns

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -78,7 +78,7 @@
   },
   {
     "include": [
-      "*://*.youtube.com/redirect"
+      "*://*.youtube.com/redirect*"
     ],
     "exclude": [
     ],
@@ -87,8 +87,8 @@
   },
   {
     "include": [
-      "*://*.facebook.com/1.php",
-      "*://*.facebook.com/l.php"
+      "*://*.facebook.com/1.php*",
+      "*://*.facebook.com/l.php*"
     ],
     "exclude": [
     ],


### PR DESCRIPTION
As noticed by @pes10k the `include` patterns for Youtube and Facebook redirects are missing wildcards and thus will not match.