### PR TITLE
Add assoc-redirect.amazon.com debounce

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -120,7 +120,7 @@
     "exclude": [
     ],
     "action": "redirect",
-    "param": "u"
+    "param": "r"
   },
   {
     "include": [

--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -115,6 +115,15 @@
   },
   {
     "include": [
+      "*://assoc-redirect.amazon.com/g/r/*"
+    ],
+    "exclude": [
+    ],
+    "action": "redirect",
+    "param": "u"
+  },
+  {
+    "include": [
       "*://*.linksynergy.com/*"
     ],
     "exclude": [


### PR DESCRIPTION
Fixes amazon debounce service. 

`https://assoc-redirect.amazon.com/g/r/https://www.amazon.com/gp/product/B08J5J9699/ref%3Dox_sc_act_title_1?smid=ATVPDKIKX0DER&tag=extech-20&ascsubtag=`