### PR TITLE
Fix cosmetic issues on aftonbladet.se

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -380,6 +380,9 @@ blockadblock.com##+js(nobab)
 @@||thgim.com/static/js/ads.min.js$script,domain=thehindu.com
 ! gifycat.com ads (https://community.brave.com/t/pages-loads-3rd-party-ads-after-page-loads/71472/10)
 ||ga.gfycat.com^$script,domain=gfycat.com
+! Blank spaces aftonbladet.se (:upward)
+aftonbladet.se##.css-4thb3o
+aftonbladet.se##.css-1d3w5wq
 ! Cosmetic fixes (https://github.com/brave/brave-browser/issues/14825)
 ! Counter blocked by extension warnings
 naver.com###veta_top


### PR DESCRIPTION
Due to lack of procedural cosmetics, https://github.com/brave/adblock-rust/issues/145

`aftonbladet.se##[data-ad-subtype]:upward(1):style(min-height:unset!important)`  This is a quick work-around to mitigate the blank spaces.