### PR TITLE
Update ads on techpowerup[.]com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -306,11 +306,9 @@ akwam.cc##+js(acis, eval, ignielAdBlock)
 $websocket,domain=whatleaks.com 
 whatleaks.com##+js(acis, init_port_check_waiting)
 ! techpowerup.com
-techpowerup.com##[href*=".xlv"]
-techpowerup.com##[href*=".xly"]
-techpowerup.com##[href*=".xlz"]
-techpowerup.com##.mnnusjsddg
-techpowerup.com##.nkuzlfvdywj
+techpowerup.com##.site-headr > section > div > [href]
+techpowerup.com##[class^="side-"] > .sidebar-item img
+techpowerup.com##[class*="-bar"] > .sidebar-item img
 ! Anti-Brave checks
 apple.com,krunker.io,kodekloud.com,gommonauti.it,btdig.com,archive.is,archive.today,archive.vn,archive.fo,archive.md,archive.li,archive.ph,archivecaslytosk.onion,archiveiya74codqgiixo33q62qlrqtkgmcitqx5u2oeqnmn5bpcbiyd.onion,caratoday.com,sybertrek.com,pethouse.com.au##+js(aopw, navigator.brave)
 archive.is,btdig.com,archive.today,archive.vn,archive.fo,archive.md,archive.li,archive.ph,archiveiya74codqgiixo33q62qlrqtkgmcitqx5u2oeqnmn5bpcbiyd.onion##+js(acis, document.cookie, document.location.href)


### PR DESCRIPTION
Fixes website ads on `techpowerup`. Site continues to counter and watch Easylist/Adguard. Safer to block here.