### PR TITLE
Fix non-selectable items on simon.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -258,6 +258,9 @@ cinemablend.com##+js(abort-on-property-read, __cmpGdprAppliesGlobally)
 chicago.suntimes.com,theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com,mmafighting.com,racked.com,mmamania.com,funnyordie.com,riftherald.com##+js(nostif, adsBlocked)
 chicago.suntimes.com,theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com,mmafighting.com,racked.com,mmamania.com,funnyordie.com,riftherald.com##.adblock-allowlist-messaging__wrapper
 ||concert.io/lib/adblock/$subdocument
+! uBO-redirect work around simon.com
+@@||google-analytics.com/analytics.js$script,domain=simon.com
+@@||googletagmanager.com/gtm.js$script,domain=simon.com
 ! uBO-redirect work around nation.africa (Anti-adblock)
 @@||evolok.net/acd/api/$xmlhttprequest,domain=nation.africa
 ! uBO-redirect work around turreta.com (Anti-adblock)


### PR DESCRIPTION
On `https://www.simon.com/mall/king-of-prussia/stores`  Unable to select `search by All Stores, Men’s, Women’s, Dining, Entertainment,..`

Fixed in https://github.com/uBlockOrigin/uAssets/pull/10402

Needs these fixes for uBO redirect.