### PR TITLE
Fix CNAME on pol.dk redirection

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -25,6 +25,8 @@ stats.brave.com#@#adsContent
 ||vidazoo.com/proxy^$third-party
 ||mediabong.net^$third-party
 ||imprvdosrv.com^$third-party
+! CNAME: pol.dk
+@@||www.pol.dk^
 ! CNAME: linkvertise.com
 @@||taboola.com/libtrc/linkvertise-link-to/loader.js$domain=linkvertise.com
 @@||taboola.map.fastly.net^$domain=linkvertise.com


### PR DESCRIPTION
`www.pol.dk` will attempt to redirect and cause no display issues.

![poldk](https://user-images.githubusercontent.com/1659004/140906380-9cf0e362-50c3-4181-83b5-8a61b29f19c6.png)
 
```
;; ANSWER SECTION:
www.pol.dk.             21600   IN      CNAME   pol.dk.
pol.dk.                 10959   IN      A       91.214.22.205
```

Was reported: https://community.brave.com/t/website-not-displaying-properly-in-brave/298942/2