### PR TITLE
Add adservers on https://mangasee123.com/

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -17,6 +17,9 @@
 
 ! https://github.com/brave/brave-browser/issues/16629
 diariodocentrodomundo.com.br,01net.com,gizchina.com,pocketpc.ch##.mrf-adv__wrapper 
+! Random adservers
+||closureevaporatefume.com^
+||revcontent.com^$third-party
 ! Admiral
 ||6ldu6qa.com^$third-party
 ||absorbingband.com^$third-party


### PR DESCRIPTION
Was reported here; https://community.brave.com/t/ios-adblock-issue-on-mangasee123-om/289013

Adservers from Easylist to stop popups on this site.