### PR TITLE
Fix broken tn.com.ar pages

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -17,6 +17,11 @@
 
 ! https://github.com/brave/brave-browser/issues/16629
 diariodocentrodomundo.com.br,01net.com,gizchina.com,pocketpc.ch##.mrf-adv__wrapper 
+! tn.com.ar 
+@@||scdn.cxense.com^$domain=tn.com.ar
+@@||cdn.cxense.com^$domain=tn.com.ar
+@@||api.cxense.com/public/widget/$domain=tn.com.ar
+@@||player.vodgc.net^
 ! Random adservers
 ||closureevaporatefume.com^
 ||revcontent.com^$third-party


### PR DESCRIPTION
Reported in https://community.brave.com/t/broken-website-in-brave-for-ios-ipados-tn-com-ar-default-settings/301408

2 issues on website breakage on tn.com.ar, Broken video player player.vodgc.net:  

![26d56012d8201c8b67dc0afc4957c94d37511a4b_2_690x390](https://user-images.githubusercontent.com/1659004/141705550-848f7c63-a855-48c2-80ed-e490e96368f1.png)

Breaks the Links of the bottom page.  (Tracker, `https://comcluster.cxense.com/Repo/rep.gif?`.. still blocked)
![6670fb83547949f796a29bd95f0a0fb2865877b9_2_690x393](https://user-images.githubusercontent.com/1659004/141705556-224db800-727b-46f6-9814-e6eeb57bc201.jpeg)

```
@@||scdn.cxense.com^$domain=tn.com.ar
@@||cdn.cxense.com^$domain=tn.com.ar
@@||api.cxense.com/public/widget/$domain=tn.com.ar
```



Fixes for these will land in Android and Desktop.

https://github.com/easylist/easylist/commit/a8d2dc96d20dfb812d0c6c68906274707334298e
https://github.com/easylist/easylist/commit/d88518f975caf0e48ad92cd5177707d0e21344b2

