### PR TITLE
Add debounce for track.effiliation.com

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -21,7 +21,8 @@
       "*://gate.sc/?url=*",
       "*://freetutsdownload.net/redirect-to/?url=*",
       "*://mcpedl.com/leaving/?url=*",
-      "*://track.adtraction.com/t/*&url=*"
+      "*://track.adtraction.com/t/*&url=*",
+      "*://track.effiliation.com/servlet/effi.redir*&url="
     ],
     "exclude": [
     ],


### PR DESCRIPTION
From `https://www.sport-passion.fr/comparatifs/meilleurs-compteurs-gps-de-velo-et-vtt.php`

We're debouncing the following url:  `https://track.effiliation.com/servlet/effi.redir?id_compteur=22262101&url=https://www.alltricks.fr/C-1645006-black-friday&effi_id=hab-alltricks`  