### PR TITLE
Fix missing wildcard on https://github.com/brave/adblock-lists/pull/671

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -22,7 +22,7 @@
       "*://freetutsdownload.net/redirect-to/?url=*",
       "*://mcpedl.com/leaving/?url=*",
       "*://track.adtraction.com/t/*&url=*",
-      "*://track.effiliation.com/servlet/effi.redir*&url="
+      "*://track.effiliation.com/servlet/effi.redir*&url=*"
     ],
     "exclude": [
     ],


### PR DESCRIPTION
Just a minor tweak too https://github.com/brave/adblock-lists/pull/671  Add wildcard to end of line.