### PR TITLE
Add debounce for go.skimresources.com

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -22,7 +22,8 @@
       "*://freetutsdownload.net/redirect-to/?url=*",
       "*://mcpedl.com/leaving/?url=*",
       "*://track.adtraction.com/t/*&url=*",
-      "*://track.effiliation.com/servlet/effi.redir*&url=*"
+      "*://track.effiliation.com/servlet/effi.redir*&url=*",
+      "*://go.skimresources.com/?id=*&url=*"
     ],
     "exclude": [
     ],


### PR DESCRIPTION
Clicking `https://fave.co/3BbvHvH`

First debounce: fixes debounce of `https://go.skimresources.com/?id=177227X1640269&xs=1&xcreo=500012&url=https://girlfriend.com/products/alpine-heather-float-cleo-bra`

2nd debounce : `https://click.linksynergy.com/deeplink?id=TnL5HPStwAw&u1=177227X1642438X3f4f66ead448e108a191fb12c90efb1&subid=190015&mid=43011&murl=https%3A%2F%2Fgirlfriend.com%2Fproducts%2Fblack-compressive-high-rise-legging`   (Blocked already)

