### PR TITLE
Allow users to read nationalgeographic.com articles

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -319,6 +319,9 @@ apple.com,krunker.io,kodekloud.com,gommonauti.it,btdig.com,archive.is,archive.to
 archive.is,btdig.com,archive.today,archive.vn,archive.fo,archive.md,archive.li,archive.ph,archiveiya74codqgiixo33q62qlrqtkgmcitqx5u2oeqnmn5bpcbiyd.onion##+js(acis, document.cookie, document.location.href)
 ! Anti-Brave checks (DuckDuckGo UA check)
 ||api.duckduckgo.com/?q=useragent$domain=i-rotary.com|mynewsmedia.co|tecknity.com|jaysndees.com|recherche-ebook.fr|bellasephina.com|pokedi.xyz|unitythemovement.world|thebeautyboothe.com
+! Fix nationalgeographic.com forced signup to read articles 
+nationalgeographic.com##.EmailStickyFooter__Modal
+nationalgeographic.com##body:style(overflow: auto !important; position: initial !important;)
 ! globalnews.ca Anti-adblock
 @@||globalnews.ca^$ghide
 globalnews.ca##.l-headerAd__container


### PR DESCRIPTION
Fixes forced signin to read articles, tested in `https://www.nationalgeographic.com/science/article/what-families-can-do-now-that-kids-are-getting-the-vaccine`

![natgeo](https://user-images.githubusercontent.com/1659004/142156220-e557e122-52c3-4d0f-a8cf-7ee768449420.png)
 