### PR TITLE
Fixes filecr.com anti-adblock

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -299,6 +299,8 @@ akwam.cc##+js(acis, eval, ignielAdBlock)
 ! Fix Playback on http://v6.player.abacast.net/6508 (https://community.brave.com/t/problem-loading-http-v6-player-abacast-net-6508/71822)
 @@||imasdk.googleapis.com/js/core/$subdocument,domain=player.abacast.net
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=player.abacast.net
+! uBO-redirect work around filecr.com
+@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,domain=filecr.com
 ! uBO-redirect work around, Fixes Blank page 
 @@||googletagservices.com/tag/js/gpt.js$domain=invisibleoranges.com|nj1015.com|tasteofcountry.com|wyrk.com|xxlmag.com|ultimateclassicrock.com
 @@||googletagmanager.com/gtm.js$domain=invisibleoranges.com|nj1015.com|tasteofcountry.com|wyrk.com|xxlmag.com|ultimateclassicrock.com


### PR DESCRIPTION
Fixes `https://filecr.com/windows/kms-2038/?id=47538041789` Anti-adblock on Download.

Reported here: https://community.brave.com/t/ad-blocker-detected-in-www-filecr-com/303733

Due to redirect rule issues.