### PR TITLE
Fixes anti-adblock on rockmods.net

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -301,6 +301,8 @@ akwam.cc##+js(acis, eval, ignielAdBlock)
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=player.abacast.net
 ! uBO-redirect work around filecr.com
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,domain=filecr.com
+! uBO-redirect work around rockmods.net
+@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,domain=rockmods.net
 ! uBO-redirect work around, Fixes Blank page 
 @@||googletagservices.com/tag/js/gpt.js$domain=invisibleoranges.com|nj1015.com|tasteofcountry.com|wyrk.com|xxlmag.com|ultimateclassicrock.com
 @@||googletagmanager.com/gtm.js$domain=invisibleoranges.com|nj1015.com|tasteofcountry.com|wyrk.com|xxlmag.com|ultimateclassicrock.com


### PR DESCRIPTION
Reported: https://community.brave.com/t/ad-blocker-detected-in-www-rockmods-net/303660

Anti-adblock due to uBO redirect rule
![a09d017b083c74c3ede708cb504583c9031f7c4d](https://user-images.githubusercontent.com/1659004/142699998-2b4ec499-38c0-4b08-8812-4429ff401e17.png)