### PR TITLE
Add debounce for redirectingat.com

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -23,7 +23,8 @@
       "*://mcpedl.com/leaving/?url=*",
       "*://track.adtraction.com/t/*&url=*",
       "*://track.effiliation.com/servlet/effi.redir*&url=*",
-      "*://go.skimresources.com/?id=*&url=*"
+      "*://go.skimresources.com/?id=*&url=*",
+      "*://go.redirectingat.com/?id=*&url=*"
     ],
     "exclude": [
     ],


### PR DESCRIPTION
Add debounce for `https://go.redirectingat.com/?id=66960X1514304&xs=1&url=https://www.yubico.com/us/product/pivot2/&referrer=theverge.com&sref=https://www.theverge.com/2021/11/19/22791271/yubico-x-keyport-pivot-2-0-key-organizer-yubikey-security-key&xcust=___vg__p_22155112__m_social__s_twitter__t_w__c_the`

As seen on `https://www.theverge.com/2021/11/19/22791271/yubico-x-keyport-pivot-2-0-key-organizer-yubikey-security-key`