### PR TITLE
Remove consent domains, causes noscroll issues on some sites

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -80,12 +80,6 @@ twitter.com##[style]>div>div>[data-testid=placementTracking]
 @@||improving.duckduckgo.com^$~third-party
 ! Disable PDFJS which we include by default's telemetry
 ||pdfjs.robwu.nl
-! Consent trackers
-||opencmp.net^$script,third-party
-||privacy-mgmt.com^$third-party
-||sp-prod.net^$third-party
-@@||notice.sp-prod.net^$subdocument,domain=telegraph.co.uk
-@@||sp-spiegel-de.spiegel.de^$domain=spiegel.de
 ! Scroll bar-consent
 collegeconfidential.com##body:style(overflow: auto !important; max-height: 1px !important;)
 ! Fix preloader (facebook check)


### PR DESCRIPTION
Removing the consent domains, will be rolled out in Easyprivacy. Blocking these domains can cause no scroll issues on some sites.