### PR TITLE
Fix localhost port scans on homedepot.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -216,7 +216,7 @@ livemint.com##+js(aeld, DOMContentLoaded)
 uptostream.com,tirexo.lol##+js(acis, window.a)
 @@||tirexo.lol^$generichide
 ! portscanning script
-cibc.com,sciencedirect.com,ebay.com,ebay-kleinanzeigen.de,tdbank.com,walmart.com##+js(acis, tmx_post_session_params_fixed)
+cibc.com,homedepot.com,sciencedirect.com,ebay.com,ebay-kleinanzeigen.de,tdbank.com,walmart.com##+js(acis, tmx_post_session_params_fixed)
 ! megaup.net
 megaup.net#@#.adBanner
 ! slate.com Anti-adblock workaround https://github.com/brave/brave-browser/issues/15702


### PR DESCRIPTION
Fixes performance issues due to online-metrix.net tracking/fingerprinting scripts on homedepot.com. Same script used on other sites we've previously blocked.

Tested login on site, and adding/removing items from the cart to ensure it has no adverse effect.