### PR TITLE
Add more threatmetrix sites

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -216,7 +216,7 @@ livemint.com##+js(aeld, DOMContentLoaded)
 uptostream.com,tirexo.lol##+js(acis, window.a)
 @@||tirexo.lol^$generichide
 ! portscanning script
-cibc.com,fidelity.com,homedepot.com,sciencedirect.com,ebay.com,ebay-kleinanzeigen.de,tdbank.com,walmart.com##+js(acis, tmx_post_session_params_fixed)
+ameriprise.com,cibc.com,citi.com,discover.com,fidelity.com,homedepot.com,sciencedirect.com,ebay.com,ebay-kleinanzeigen.de,tdbank.com,walmart.com##+js(acis, tmx_post_session_params_fixed)
 ! megaup.net
 megaup.net#@#.adBanner
 ! slate.com Anti-adblock workaround https://github.com/brave/brave-browser/issues/15702


### PR DESCRIPTION
Domains `ameriprise.com`, `citi.com` and `discover.com` causing higher cpu issues due to threatmetrix tracking/fingerprinting.

Reported in https://community.brave.com/t/brave-lockup-on-two-financial-sites/306136