### PR TITLE
Fix Foxnews video playback

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -15,6 +15,9 @@
 ! Anti-adblock: concert.io (vox sites)
 @@||vox-cdn.com/packs/concert_ads-$script,domain=chicago.suntimes.com|theverge.com|eater.com|polygon.com|vox.com|sbnation.com|curbed.com|theringer.com|mmafighting.com|racked.com|mmamania.com|funnyordie.com|riftherald.com
 
+! Foxnews/business
+@@||js.taplytics.com/jssdk/$domain=foxnews.com|foxbusiness.com
+@@||static.foxnews.com/static/$domain=foxnews.com|foxbusiness.com
 ! https://github.com/brave/brave-browser/issues/16629
 diariodocentrodomundo.com.br,01net.com,gizchina.com,pocketpc.ch##.mrf-adv__wrapper 
 ! tn.com.ar 


### PR DESCRIPTION
Fix video playback on Foxnews/business on IOS. Currently unabled to play videos on `foxnews.com` & `foxbusiness.com`

Imported fixes from Easyprivacy in Brave iOS