### PR TITLE
Add shop-links.co debounce

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -24,7 +24,8 @@
       "*://track.adtraction.com/t/*&url=*",
       "*://track.effiliation.com/servlet/effi.redir*&url=*",
       "*://go.skimresources.com/?id=*&url=*",
-      "*://go.redirectingat.com/?id=*&url=*"
+      "*://go.redirectingat.com/?id=*&url=*",
+      "*://shop-links.co/link/?url=*"
     ],
     "exclude": [
     ],


### PR DESCRIPTION
Fixes the following shop-links.co; `https://shop-links.co/link/?url=https%3A%2F%2Fwww.bestbuy.com%2Fsite%2Ftcl-65-class-6-series-mini-led-qled-4k-uhd-smart-google-tv%2F6470277.p%3FskuId%3D6470277&publisher_slug=cnet&article_name=57%20best%20black%20friday%20deals%20that%20are%20still%20available%20ahead%20of%20cyber%20monday&article_url=https%3A%2F%2Fwww.cnet.com%2Fnews%2F53-best-black-friday-deals-that-are-still-available-ahead-of-cyber-monday%2F&exclusive=1&u1=cn-___COM_CLICK_ID___-dtp`