### PR TITLE
Trim some youtube filters (included in uBO)

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -42,15 +42,15 @@ stats.brave.com#@#adsContent
 ||theatlantic.blueconic.net$domain=theatlantic.com
 ||theatlantic.com/please-support-us^
 ! youtube ads
-youtube.com,youtube-nocookie.com##+js(json-prune, 2.playerResponse.adPlacements playerResponse.adPlacements playerResponse.playerAds adPlacements playerAds)
+! youtube.com,youtube-nocookie.com##+js(json-prune, 2.playerResponse.adPlacements playerResponse.adPlacements playerResponse.playerAds adPlacements playerAds)
 youtube.com,youtube-nocookie.com##+js(json-prune, [].playerResponse.adPlacements)
 youtube.com,youtube-nocookie.com##+js(json-prune, [].playerResponse.playerAds)
 youtube.com,youtube-nocookie.com##+js(json-prune, 2.playerResponse.adPlacements)
 youtube.com,youtube-nocookie.com##+js(json-prune, playerResponse.adPlacements)
 youtube.com,youtube-nocookie.com##+js(json-prune, playerResponse.playerAds)
-youtube.com,youtube-nocookie.com##+js(json-prune, adPlacements)
-youtube.com,youtube-nocookie.com##+js(json-prune, playerAds)
-youtube.com##+js(set, ytInitialPlayerResponse.adPlacements, null)
+! youtube.com,youtube-nocookie.com##+js(json-prune, adPlacements)
+! youtube.com,youtube-nocookie.com##+js(json-prune, playerAds)
+! youtube.com##+js(set, ytInitialPlayerResponse.adPlacements, null)
 ! Fix browser lockup on skepticalscience.com (https://github.com/brave/brave-browser/issues/5406)
 ||skepticalscience.net/widgets/heat_widget/js/heat_content.js$script,domain=skepticalscience.com
 ! adops.com unusable without this


### PR DESCRIPTION
Will stagger these out, to ensure it doesn't cause issues (causing video ads). Many youtube filters are already included with uBO/uAssets. We can revert if it causes issues.

The other youtube filters can be addressed, when we know this patch is safe