### PR TITLE
Update shop-links.co link

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -25,7 +25,7 @@
       "*://track.effiliation.com/servlet/effi.redir*&url=*",
       "*://go.skimresources.com/?id=*&url=*",
       "*://go.redirectingat.com/?id=*&url=*",
-      "*://shop-links.co/link/?url=*"
+      "*://shop-links.co/link/*"
     ],
     "exclude": [
     ],


### PR DESCRIPTION
Update `shop-links.co` links,  debounce:

`https://shop-links.co/link/?publisher_slug=future&u1=tomsguide-us-9799394701951144000&exclusive=1&url=https%3A%2F%2Fwww.crutchfield.com%2FI-rNARc1BZH%2Fp_242ENDUROG%2FCleer-Enduro-ANC-Light-Grey.html&article_name=The%20best%20wireless%20headphones%20in%202021%20%7C%20Tom%27s%20Guide&article_url=https%3A%2F%2Fwww.tomsguide.com%2Fus%2Fbest-wireless-headphones%2Creview-5565.html`