### PR TITLE
Add commision junction debounce

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -25,7 +25,9 @@
       "*://track.effiliation.com/servlet/effi.redir*&url=*",
       "*://go.skimresources.com/?id=*&url=*",
       "*://go.redirectingat.com/?id=*&url=*",
-      "*://shop-links.co/link/*"
+      "*://shop-links.co/link/*",
+      "*://*.jdoqocy.com/click-*",
+      "*://*.kqzyfj.com/click-*"
     ],
     "exclude": [
     ],


### PR DESCRIPTION
Debounce for `https://www.jdoqocy.com/click-8900245-13502820?url=https%3A%2F%2Fwww.dell.com%2Fen-us%2Fshop%2Fgo-air-pop-true-wireless-earbuds%2Fapd%2Fab882137%2Faudio&cjsku=ab882137&sid=tomsguide-us-8010762289678577000` and `https://www.kqzyfj.com/click-100043417-14437826?sid=86584X1539181X341c9804de6af85d5745fec07346d80b&url=https%3A%2F%2Fwww.cyberghostvpn.com%2Fen_US%2Foffer%2Fflash-night%3Faff_id%3D4169%26coupon%3DFlashSale2%26aff_sub4%3DFlashSale2%26source%3Dgeneral%26brand%3DFOSSBYTES%26`