### PR TITLE
Add shareasale.com debounce

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -65,6 +65,16 @@
   },
   {
     "include": [
+      "*://*.shareasale.com/r.cfm?*",
+      "*://shareasale.com/r.cfm?*"
+   ],
+   "exclude": [
+   ],
+   "action": "redirect",
+   "param": "urllink"
+  },
+  {
+    "include": [
       "*://*.maranhesduve.club/?*",
       "*://*.sparbuttantowa.pro/*?*"
     ],


### PR DESCRIPTION
Add a debounce for `https://www.shareasale.com/r.cfm?b=999&u=514792&m=82053&afftrack=cn-d5ca416eae6a4a89b1b3e50d8fc55d6c-dtp&urllink=ooni.com%2F` 