### PR TITLE
Debounce for doubleclick not working currently

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -45,15 +45,6 @@
   },
   {
     "include": [
-      "*://*.doubleclick.net/ddm/clk/*"
-     ],
-     "exclude": [
-     ],
-     "action": "redirect",
-     "param": "l"
-  },
-  {
-    "include": [
       "*://*.spaste.com/r/*link=*"
     ],
     "exclude": [


### PR DESCRIPTION
Removing the doubleclick debounce, not currently working. can be addressed again in the future.