### PR TITLE
Add Amazon debounce

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -36,6 +36,15 @@
   },
   {
     "include": [
+      "*://amzn.to/*asc_refurl=*"
+    ],
+    "exclude": [
+    ],
+    "action": "redirect",
+    "param": "asc_refurl"
+  },
+  {
+    "include": [
       "*://*.demdex.net/event?*"
     ],
     "exclude": [


### PR DESCRIPTION
Fixes Amazon debounce:

`https://amzn.to/3ABKwF7?asc_source=web&asc_campaign=web&asc_refurl=https%3A%2F%2Fwww.artnews.com%2Fart-news%2Fproduct-recommendations%2Fblack-friday-deals-on-artists-tools-and-studio-supplies-1131576738%2F`