### PR TITLE
Add narrativ.com debounce

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -27,7 +27,8 @@
       "*://go.redirectingat.com/?id=*&url=*",
       "*://shop-links.co/link/*",
       "*://*.jdoqocy.com/click-*",
-      "*://*.kqzyfj.com/click-*"
+      "*://*.kqzyfj.com/click-*",
+      "*://*.narrativ.com/*client_redirect/*"
     ],
     "exclude": [
     ],


### PR DESCRIPTION
Add `narrativ.com` debounce:

`​https://api.narrativ.com/api/v0/client_redirect/?url=https%3A%2F%2Fbestbuy.7tiv.net%2Fc%2F376373%2F633495%2F10014%3Fprodsku%3D6422933%26u%3Dhttp%253A%252F%252Fwww.bestbuy.com%252Fsite%252F-%252F6422933.p%253Fcmp%253DRMX%26nrtv_cid%3D.nrtv_plchldr.%26subId2%3Darstechnica%26subId3%3D1758211233439669677%26subId1%3Dtop-deals%26nrtv_as_src%3D1&a=17583266707433412227&uuid=97212723-0ead-4f70-910a-c19cea401b1e&uid_bam=1712740821248740580&ar=1758861233439661277​​​​​`