### PR TITLE
Add more debounce urls

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -30,7 +30,12 @@
       "*://*.kqzyfj.com/click-*",
       "*://*.pjtra.com/t/*",
       "*://*.narrativ.com/*client_redirect/*",
-      "*://c.pepperjamnetwork.com/*"
+      "*://c.pepperjamnetwork.com/*",
+      "*://*.avantlink.com/click.php?*",
+      "*://t.cfjump.com/*",
+      "*://*.pjatr.com/t/*",
+      "*://*.pntrs.com/t/*",
+      "*://*.nordstrom.com/Linkshare?*"
     ],
     "exclude": [
     ],


### PR DESCRIPTION
Added more debounce url's;
1. avantlink.com
`https://www.avantlink.com/click.php?tt=app&ti=1041&mi=13511&pw=261161&ctc=cn-0fcd3368378c12eebce64b05bc31bc13-dtp&url=https%3A%2F%2Fwww.bioliteenergy.com%2Fproducts%2Ftravelight-`

2. cfjump.com
`https://t.cfjump.com/31042/t/61296?UniqueId=trd-nz-6600121286181612000&Url=https%3A%2F%2Fthemarket.com%2Fnz%2F`

3. pjatr.com
`https://www.pjatr.com/t/TUJGR0lNTkJHRU12TkZCR0ZM12VN?url=https%3A%2F%2Ffromourplace.com%2Fproducts%2Fperfect-pot&sid=1129cmdeals|xid:fr163827212225012c&website=312541
`
4. shop.nordstrom.com
`https://shop.nordstrom.com/Linkshare?siteid=FH3S12KQdp0-SicZ612A1L.k.TKJGGiIwg&url=https%3A%2F%2Fwww.nordstrom.com%2Fs%2Fbala%2Dsilicone%2Drecycled%2Dsteel%2Dpower%2Dring%2F5752433%3Futm_source%3Drakuten%26utm_medium%3Daffiliate%26utm_campaign%3DFH3SVbKQdp0%26utm_content%3D1%26utm_term%3D1018624%26utm_channel%3Dlow_nd_affiliates%26sp_source%3Drakuten%26sp_campaign%3DFH3SVbKQdp0`

5. pntrs.com
`https://www.pntrs.com/t/8-9711-191283-104129?url=https%3A%2F%2Fwww.everlane.com%2Fproducts%2Fmens-organic-cotton-crew-tee-khaki%3Fcollection%3Dmens-black-friday-sale&sid=5ddc14bbf12a7100418924e1%7C`