### PR TITLE
Fix mixpanel 1p issues in https://github.com/easylist/easylist/issues/9920

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -377,6 +377,8 @@ blockadblock.com##+js(nobab)
 @@||geoguessr.com/_ads/$script,xmlhttprequest,domain=geoguessr.com
 ! ssrn.com login fix
 @@||assets.adobedtm.com^$script,domain=ssrn.com
+! Mixpanel 1p issues (due to peter lowes). https://github.com/easylist/easylist/issues/9920
+||mixpanel.com^$badfilter
 ! thehindu.com (https://github.com/brave/brave-browser/issues/4808)
 @@||thgim.com/static/js/ads.min.js$script,domain=thehindu.com
 ! gifycat.com ads (https://community.brave.com/t/pages-loads-3rd-party-ads-after-page-loads/71472/10)


### PR DESCRIPTION
Fixes https://github.com/easylist/easylist/issues/9920

Due to a policy change, uBO isn't fixing false positives regarding Peter Lowes list.  For the sake of webcompat, this is better for privacy than completely disabling shields and allowing more trackers.

This counters the `127.0.0.1 mixpanel.com` in Peter Lowes list. Easyprivacy is blocking mixpanel domain via a third-party, no privacy issues and allows mixpanel users to use Brave without overblocking or disabling shields.