### PR TITLE
Update fix on appsflyer.com/ios

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -16,7 +16,8 @@
 @@||vox-cdn.com/packs/concert_ads-$script,domain=chicago.suntimes.com|theverge.com|eater.com|polygon.com|vox.com|sbnation.com|curbed.com|theringer.com|mmafighting.com|racked.com|mmamania.com|funnyordie.com|riftherald.com
 
 ! appsflyer.com adjustment https://github.com/easylist/easylist/commit/c608be1
-||appsflyer.com^$badfilter
+@@||appsflyer.com^$third-party
+@@||app.appsflyer.com^$third-party
 ||appsflyer.com^$third-party,badfilter
 ||websdk.appsflyer.com^
 ! Foxnews/business


### PR DESCRIPTION
From the fix https://github.com/brave/adblock-lists/pull/708  This didn't work as intended, From the latest.json. appsflyer.com is still being blocked on ios. Blocking appsflyer.com breaks a mobile app redirection 

```
{
  "action": {
   "type": "block"
  },
  "trigger": {
   "url-filter": "^[^:]+:(//)?([^/]+\\.)?appsflyer\\.com",
   "load-type": [
    "third-party"]
  }
```