### PR TITLE
Fix video playback on bloomber.com/jp

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -306,6 +306,8 @@ akwam.cc##+js(acis, eval, ignielAdBlock)
 @@||google-analytics.com/analytics.js$domain=invisibleoranges.com|nj1015.com|tasteofcountry.com|wyrk.com|xxlmag.com|ultimateclassicrock.com
 ! uBO-redirect work around Fixes Anti-Adblock detection in player
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=invisibleoranges.com|nj1015.com|tasteofcountry.com|wyrk.com|xxlmag.com|ultimateclassicrock.com
+! uBO-domain wildcard workaround
+@@||cdn.gotraffic.net^$domain=bloomberg.com|bloomberg.co.jp
 ! Potential Tracker, Annoyance
 ||govdelivery.com^$third-party
 ! Whatleaks nullifer


### PR DESCRIPTION
Fixes blocking on `https://www.bloomberg.com/news/articles/2021-11-22/merkel-says-german-covid-spike-worse-than-anything-we-ve-seen`

Only two domains. `bloomberg.com` & `bloomberg.co.jp` I found

Fix in Unbreal: `@@||cdn.gotraffic.net^$domain=bloomberg.*`