### PR TITLE
Fix for https://rednoseday.org/donation/ (ios)

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -20,6 +20,9 @@
 @@||app.appsflyer.com^$third-party
 ||appsflyer.com^$third-party,badfilter
 ||websdk.appsflyer.com^
+! google fixes
+@@||googletagmanager.com/gtm.js$domain=rednoseday.org|verygoodvault.com
+@@||googletagmanager.com/gtag/$domain=rednoseday.org|verygoodvault.com
 ! Foxnews/business
 @@||js.taplytics.com/jssdk/$domain=foxnews.com|foxbusiness.com
 @@||static.foxnews.com/static/$domain=foxnews.com|foxbusiness.com


### PR DESCRIPTION
Attempted fix for donation failing on `https://rednoseday.org/donation/main?am=25&rnd_usa_freq=onetime&step=1-2`

Page would endless load after attempting to process payment (not actually process payment)