### PR TITLE
Fix dobounce myvisualiq.net

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -53,6 +53,15 @@
   },
   {
     "include": [
+      "*://t.myvisualiq.net/*"
+    ],
+    "exclude": [
+    ],
+    "action": "redirect",
+    "param": "red"
+  },
+  {
+    "include": [
       "*://*.demdex.net/event?*"
     ],
     "exclude": [


### PR DESCRIPTION
Fixes debounce by `t.myvisualiq.net`

`https://t.myvisualiq.net/ul_cb/click_pixel?et=c&ago=212&ao=871&aca=23231182&si=5230457&ci=127823515&pi=265923609&ad=461142352&sv1=[keyword_id]&advt=9614231&chnl=-7&vndr=123&sz=7237&u=12238053-8923087-ArsCM2321-Cond%C3%A9%20Nast&viq_did=&red=https://www.dell.com/en-us/shop/dell-27-gaming-monitor-s2721dgf/apd/210-axeh/monitors-monitor-accessories?AID=8984237&cjevent=4e7b4723540911ec23f3018f0a1c0e13&publisher=&cjdata=MXxOfDB8WXww&gacd=9234781-22361182-5750457-265923609-127882315&dgc=af&VEN1=1257233-8982387-ArsCM2021-Cond%C3%A9%20Nast`