### PR TITLE
Fixes Anti-wyse warnings

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -304,6 +304,8 @@ akwam.cc##+js(acis, eval, ignielAdBlock)
 @@||googletagservices.com/tag/js/gpt.js$domain=invisibleoranges.com|nj1015.com|tasteofcountry.com|wyrk.com|xxlmag.com|ultimateclassicrock.com
 @@||googletagmanager.com/gtm.js$domain=invisibleoranges.com|nj1015.com|tasteofcountry.com|wyrk.com|xxlmag.com|ultimateclassicrock.com
 @@||google-analytics.com/analytics.js$domain=invisibleoranges.com|nj1015.com|tasteofcountry.com|wyrk.com|xxlmag.com|ultimateclassicrock.com
+! uBO-redirect work around wyse.com (https://github.com/uBlockOrigin/uAssets/commit/7ee72dd4d6a641c040b9098f11006cb6c53b05ba)
+@@||wyze.com^$script,first-party
 ! uBO-redirect work around Fixes Anti-Adblock detection in player
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=invisibleoranges.com|nj1015.com|tasteofcountry.com|wyrk.com|xxlmag.com|ultimateclassicrock.com
 ! uBO-redirect work around (https://community.brave.com/t/kindly-remove-disable-adblock-and-reload-the-page/308756)


### PR DESCRIPTION
Anit-adblock issues on `wyse.com` reported in the forums. https://community.brave.com/t/cant-log-in-to-wyze/308958/4


![6ff8111c45354ed4183ccbc4bba128ce9ef8cccd_2_456x500](https://user-images.githubusercontent.com/1659004/144739869-96de3bf8-618f-401f-8c85-8dad87b44015.jpeg)

Addresses the redirect rule only. No privacy issues, just first-party.