### PR TITLE
Fix anti-adblock on paraphraser

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -300,6 +300,8 @@ akwam.cc##+js(acis, eval, ignielAdBlock)
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,domain=filecr.com
 ! uBO-redirect work around rockmods.net
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,domain=rockmods.net
+! uBO-redirect work around paraphraser.io
+@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,domain=paraphraser.io
 ! uBO-redirect work around, Fixes Blank page 
 @@||googletagservices.com/tag/js/gpt.js$domain=invisibleoranges.com|nj1015.com|tasteofcountry.com|wyrk.com|xxlmag.com|ultimateclassicrock.com
 @@||googletagmanager.com/gtm.js$domain=invisibleoranges.com|nj1015.com|tasteofcountry.com|wyrk.com|xxlmag.com|ultimateclassicrock.com


### PR DESCRIPTION
Anti-adblock on `https://www.paraphraser.io/` 

Enter details on the site, then click on button `Paraphrase Now`. Anti-adblock will show.  

Reported: https://community.brave.com/t/ad-blocker-detected-in-www-paraphraser-io/309448