### PR TITLE
Add brave-fix.js snippet

### DIFF
--- a/brave-fix.js
+++ b/brave-fix.js
@@ -1,0 +1,4 @@
+/// brave-fix.js
+/// alias bf.js
+delete Navigator.prototype.brave
+delete window.navigator.brave


### PR DESCRIPTION
Initial landing of `brave-fix.js` snippet, this will remove brave variables on specific sites that break Brave users.