### PR TITLE
Block sensor tracking on ios

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -20,6 +20,9 @@
 @@||app.appsflyer.com^$third-party
 ||appsflyer.com^$third-party,badfilter
 ||websdk.appsflyer.com^
+! coinmarketcap.com censor tracking https://www.reddit.com/r/brave_browser/comments/rip7ce/works_just_fine/
+/sensorsdata.min.js
+||sensors.binance.cloud^
 ! google fixes
 @@||googletagmanager.com/gtm.js$domain=rednoseday.org|verygoodvault.com
 @@||googletagmanager.com/gtag/$domain=rednoseday.org|verygoodvault.com


### PR DESCRIPTION
Visiting `https://coinmarketcap.com/` in ios will start causing the shields counter to increase. Doesn't affect desktop or android, I suspect the sensor data is causing the fingerprinting to increase.

Was reported https://www.reddit.com/r/brave_browser/comments/rip7ce/works_just_fine/

We're blocking `https://cdn.jsdelivr.net/npm/sa-sdk-javascript@1.15.26/sensorsdata.min.js` (script) & `https://sensors.binance.cloud/sa.gif?project=cmc` (ping)