### PR TITLE
Fix f9tmep.net from https://github.com/brave/adblock-lists/pull/736

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -46,6 +46,15 @@
   },
   {
     "include": [
+      "*://*.f9tmep.net/c/*"
+    ],
+    "exclude": [
+    ],
+    "action": "redirect",
+    "param": "srcref"
+  },
+  {
+    "include": [
       "*://amzn.to/*asc_refurl=*"
     ],
     "exclude": [
@@ -217,7 +226,6 @@
       "://*.uvwgb9.net/c/*",
       "://*.3anx.net/c/*",
       "://*.rrmo.net/c/*",
-      "://*.f9tmep.net/c/*",
       "://*.i308314.net/c/*",
       "://*.uqhv.net/c/*",
       "://redirect.viglink.com/*"


### PR DESCRIPTION
Fixes https://github.com/brave/adblock-lists/pull/736 with corrected param.

1. `f9tmep.net/c/`
`https://bitdefender.f9tmep.net/c/338476/499160/4466?subtag=trd-nz-12659124619216761200&level=1&srcref=https%3A%2F%2Fwww.techradar.com%2F&brwsr=22221221-412c-21ec-b125-6fa12a2199af&brwsrsig=2Y1RI912PVraWUs12l2ePRiOx12U5V​​​​​`