### PR TITLE
Update shareasale-analytics.com domain

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -134,7 +134,8 @@
     "include": [
       "*://*.shareasale.com/r.cfm?*",
       "*://shareasale.com/r.cfm?*",
-      "*://*.shareasale-analytics.com/r.cfm?*"
+      "*://*.shareasale-analytics.com/r.cfm?*",
+      "*://shareasale-analytics.com/r.cfm?*"
    ],
    "exclude": [
    ],


### PR DESCRIPTION
Include without a subdomain `hareasale-analytics.com`

`https://shareasale-analytics.com/r.cfm?b=1671220&m=103724&u=2132220&afftrack=&urllink=nicks%2Ecom%2Fproducts%2Fpeanot%2Dbutter%2Dkaramell%3F&lplid=hMQe09o%2B4i2AzGzIBlt2E22ykJM9vZLOfnVgIlpgUpcS85E%22kBVtf8zUzHzWXYTC&shrsl_analytics_sscid=c1k2%5Fu3i12&shrsl_analytics_sstid=c1k2%5Fu3i16`
