### PR TITLE
add additional localhost alias rules

### DIFF
--- a/brave-lists/brave-specific.txt
+++ b/brave-lists/brave-specific.txt
@@ -1,7 +1,11 @@
 ! Specific filters (Tracking or ads) for Brave
-||localhost^$third-party,domain=~127.0.0.1|~[::1]
-||127.0.0.1^$third-party,domain=~localhost|~[::1]
-||[::1]^$third-party,domain=~localhost|~127.0.0.1
+||0.0.0.0^$third-party,domain=~[::]|~[::ffff:0:0]
+||[::]^$third-party,domain=~0.0.0.0|~[::ffff:0:0]
+||[::ffff:0:0]^$third-party,domain=~0.0.0.0|~[::]
+||localhost^$third-party,domain=~127.0.0.1|~[::1]|~[::ffff:7f00:1]
+||127.0.0.1^$third-party,domain=~localhost|~[::1]|~[::ffff:7f00:1]
+||[::1]^$third-party,domain=~localhost|~127.0.0.1|~[::ffff:7f00:1]
+||[::ffff:7f00:1]^$third-party,domain=~localhost|~127.0.0.1|~[::1]
 
 ! Re-enable scripts for Yandex after finding no privacy concerns (given
 ! other Brave privacy protections)

--- a/tools/gen_localhost_rules.py
+++ b/tools/gen_localhost_rules.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+"""Silly helper script to generate all the permutations of localhost aliases."""
+
+LOCALHOST_ALIASES = [
+    "localhost",
+    "127.0.0.1",
+    "[::1]",
+    "[::ffff:7f00:1]",
+]
+
+NON_ROUTEABLE_ALIASES = [
+    "0.0.0.0",
+    "[::]",
+    "[::ffff:0:0]",
+]
+
+def format_domain_filter(origins):
+    prefix = "domain="
+    origins_with_exception_indication = []
+    for origin in origins:
+        origins_with_exception_indication.append(f"~{origin}")
+    return prefix + "|".join(origins_with_exception_indication)
+
+
+def create_rule_for_alias(an_alias, all_aliases):
+    all_other_aliases = all_aliases.copy()
+    all_other_aliases.remove(an_alias)
+    domain_filter = format_domain_filter(all_other_aliases)
+    filter_rule = f"||{an_alias}^$third-party,{domain_filter}"
+    return filter_rule
+
+for alias_group in [NON_ROUTEABLE_ALIASES, LOCALHOST_ALIASES]:
+    for alias in alias_group:
+        print(create_rule_for_alias(alias, alias_group))


### PR DESCRIPTION
Added additional filter list rules to handle additional localhost aliases (along with a handy-to-me script to generate all the permutations of different localhost aliases)

Partially addresses https://github.com/brave/brave-browser/issues/9860#issuecomment-1006216069