### PR TITLE
Include google.com/log blocking on IOS

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -81,6 +81,7 @@ diariodocentrodomundo.com.br,01net.com,gizchina.com,pocketpc.ch##.mrf-adv__wrapp
 ||revcontent.com^$third-party
 ! Trackers
 ||pagefair.com^
+||google.com/log?format=
 ||pagefair.net^
 ! Admiral
 ||2znp09oa.com^


### PR DESCRIPTION
Blocking `https://play.google.com/log?format=json&hasfast=true&authuser=2` & `https://play.google.com/log?format=json&hasfast=true`.

Which is used on various google domains. Same filter is blocked on Easyprivacy.

