### PR TITLE
Update filters for ign.com (ios)

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -36,6 +36,9 @@ diariodocentrodomundo.com.br,01net.com,gizchina.com,pocketpc.ch##.mrf-adv__wrapp
 @@||cdn.cxense.com^$domain=tn.com.ar
 @@||api.cxense.com/public/widget/$domain=tn.com.ar
 @@||player.vodgc.net^
+! ign.com
+||ign.com/zdadkit2.js
+||ign.com/s/js/zad.js
 ! Invideo ads
 ||api.fw.tv^
 ||avantisvideo.com/avm/js/video-loader.js$script,third-party


### PR DESCRIPTION
From: `https://me.ign.com/en/movies/193030/news/morbius-delayed-to-april-2022`   the site is bought up for testing in https://community.brave.com/t/is-brave-even-blocking-ads-on-ios/321356/3  

Already included in EL:
```
https://me.ign.com/s/js/zad.js
https://sm.ign.com/zdadkit2.js
```

Just to clean up for IOS, should help with some empty spaces on ign.