### PR TITLE
Fixes https://brave.com/blog/page/3/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -12,6 +12,7 @@
 @@||ads-admin.brave.com^$first-party
 @@||ads-admin.brave.software^$first-party
 @@||ads.brave.com^$first-party
+@@||brave.com^$image,stylesheet,first-party
 ! https://github.com/uBlockOrigin/uAssets/blob/master/filters/privacy.txt#L260
 search.brave.com#@#+js(no-fetch-if, body:cohort)
 ! stats.brave.com


### PR DESCRIPTION
Fixes https://brave.com/blog/page/3/    Was addressed in https://github.com/easylist/easylist/commit/30926c302fed806dc44acdbc48e08c5c7a63a4ad  since we blocked `https://brave.com/static-assets/images/optimized/ad-choosers/images/ad-choosers-featured.webp` inadvertently.  


But also include CSS, and make a little more generic for `brave.com` domain. Cover any potential false positives in the future.