### PR TITLE
Update instagram debounce filter

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -183,6 +183,7 @@
     "include": [
       "*://*.facebook.com/1.php*",
       "*://*.facebook.com/l.php*",
+      "*://l.instagram.com/?u=*",
       "*://goto.target.com/c/*",
       "*://goto.walmart.com/c/*",
       "*://*.sjv.io/c/*",


### PR DESCRIPTION
Update `instagram.com` filter to be more specific. 

From sample page: https://www.instagram.com/billieeilish/  
`https://l.instagram.com/?u=https%3A%2F%2Fbillieeilish.lnk.to%2FHappierThanEver&e=ATOEztj02u4lQFArmchjYi41a1JNyajAeoQeRNkTVOvVRj1_0ACcTuHLjF__SuCv3LaI1nNVLfGT4oHjLREi&s=1`

Filtering `l.instagram.com/?u=` should cause a lot less issues, and is much more specific.