### PR TITLE
Update Instagram first-party

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -33,6 +33,9 @@
 ||facebook.com/search/web/instrumentation.php?
 ||facebook.com/xti.php?
 ||pixel.facebook.com^
+! Instagram
+||instagram.com/logging/
+||instagram.com/logging_client_events
 ||instagram.com/ajax/bz
 # Youtube
 ||youtube-nocookie.com/api/stats/delayplay?


### PR DESCRIPTION
Add some missing instagram trackers. and separate from Facebook into its own section.

Filters are included in EP, safe to block.