### PR TITLE
Add track.webgains.com debounce

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -153,6 +153,15 @@
   },
   {
     "include": [
+      "*://track.webgains.com/click.html*"
+    ],
+    "exclude": [
+    ],
+    "action": "redirect",
+    "param": "wgtarget"
+  },
+  {
+    "include": [
       "*://*.maranhesduve.club/?*",
       "*://*.sparbuttantowa.pro/*?*"
     ],


### PR DESCRIPTION
Add debounce for `track.webgains.com`

`https://track.webgains.com/click.html?wgcampaignid=132485&wgprogramid=13245&clickref=t3-gb-2434114522404371000&wgtarget=https%3A%2F%2Fwww.box.co.uk%2F4H2B4EAABU-Victus-by-HP-16-AMD-Ryzen-7-16GB-RAM-512_3821919.html`