### PR TITLE
Fix anti-adblock on https://www.planetf1.com/

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -16,7 +16,9 @@
 @@||vox-cdn.com/packs/concert_ads-$script,domain=chicago.suntimes.com|theverge.com|eater.com|polygon.com|vox.com|sbnation.com|curbed.com|theringer.com|mmafighting.com|racked.com|mmamania.com|funnyordie.com|riftherald.com
 ! uBO-redirect work around imperfectcomic.com
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=imperfectcomic.com
-
+! Bait (anti-adblock)
+! https://cmp.uniconsent.mgr.consensu.org/ads.js?a=1&ad_block=1
+@@||uniconsent.mgr.consensu.org/ads.js
 ! appsflyer.com adjustment https://github.com/easylist/easylist/commit/c608be1
 @@||appsflyer.com^$third-party
 @@||app.appsflyer.com^$third-party


### PR DESCRIPTION
On `https://www.planetf1.com/news/karun-chandhok-michael-masi-screwed-over` a Bait filename is used to detect and display an  Anti-adblock message.
![img_3773_720](https://user-images.githubusercontent.com/1659004/152484974-b1b74848-db1e-4450-8cfa-28d1bc24d9b3.png)

`http://cmp.uniconsent.mgr.consensu.org/ads.js?a=1&ad_block=1`

Removed in EL: https://github.com/easylist/easylist/commit/b284b3bb48bea1ac4fd57d779c3bbb5a394e57d2