### PR TITLE
Fix ads and tracking on 5ch.net (ios)

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -35,6 +35,8 @@
 @@||static.foxnews.com/static/$domain=foxnews.com|foxbusiness.com
 ! https://github.com/brave/brave-browser/issues/16629
 diariodocentrodomundo.com.br,01net.com,gizchina.com,pocketpc.ch##.mrf-adv__wrapper 
+! 5ch.net (japanese)
+||thench.net^$third-party
 ! tn.com.ar 
 @@||scdn.cxense.com^$domain=tn.com.ar
 @@||cdn.cxense.com^$domain=tn.com.ar


### PR DESCRIPTION
Reported by a user in Japan, not blocking 5channel ads. (same domain also tracks). 

Fixed in EP: https://github.com/easylist/easylist/commit/058aac1655cf59a1d1ca8271e79c2f65af79b434   