### PR TITLE
Add clixgalore.com debounce

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -55,6 +55,15 @@
   },
   {
     "include": [
+      "*://*.clixgalore.com/Lead.aspx*"
+    ],
+    "exclude": [
+    ],
+    "action": "redirect",
+    "param": "AffDirectURL"
+  },
+  {
+    "include": [
       "*://amzn.to/*asc_refurl=*"
     ],
     "exclude": [


### PR DESCRIPTION
Fixes debounce from `clixgalore.com`

`http://www.clixgalore.com/Lead.aspx?BID=81260&AfID=221126&AdID=1261&OID=kwo7qz5naj12jh5y00vsi&AffDirectURL=hollywoodmegastore.com`