### PR TITLE
Fix audio on https://www.techradar.com/news/the-story-of-the-browser-wars-told-from-the-frontlines

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -24,6 +24,9 @@
 @@||app.appsflyer.com^$third-party
 ||appsflyer.com^$third-party,badfilter
 ||websdk.appsflyer.com^
+! https://www.techradar.com/news/the-story-of-the-browser-wars-told-from-the-frontlines
+! Used for audio playback
+@@||tags.remixd.com^
 ! coinmarketcap.com censor tracking https://www.reddit.com/r/brave_browser/comments/rip7ce/works_just_fine/
 /sensorsdata.min.js
 ||sensors.binance.cloud^


### PR DESCRIPTION
Removed filter in Easyprivacy; https://github.com/easylist/easylist/commit/3b44e71843a77babb5f74b67ad4e85d07ec4c80c

Audio playback fails on https://www.techradar.com/news/the-story-of-the-browser-wars-told-from-the-frontlines due to bad filter