### PR TITLE
Add mediamarkt.de & saturn.de debounce

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -37,7 +37,9 @@
       "*://*.pntrs.com/t/*",
       "*://*.nordstrom.com/Linkshare?*",
       "*://*.nutribullet.com/t/*",
-      "*://*.gopjn.com/t/*"
+      "*://*.gopjn.com/t/*",
+      "*://*.mediamarkt.de/trck/*",
+      "*://*.saturn.de/trck/*"
     ],
     "exclude": [
     ],


### PR DESCRIPTION
Debounce for: `.mediamarkt.de/trck/`:

`https://pvn.mediamarkt.de/trck/eclick/04d67290ba53e120489108085d3aa712&url=https%3A%2F%2Fwww.mediamarkt.de%2Fde%2Fproduct%2F_switch-oled-modell-neon-rot-neon-blau-nintendo-switch-konsolen-2749171.html%3Futm_source%3Deasymarketing%26utm_medium%3Daff-content%26utm_term%3D50004%26utm_campaign%3DDeeplinkgenerator-AO%26emid%3D60ed93c276d47c6c52737d7e`

Debounce for: `.saturn.de/trck/`:
`https://pvn.saturn.de/trck/eclick/54e884097ea412946d127dda2bdb06ba&url=https%3A%2F%2Fwww.saturn.de%2Fde%2Fsearch.html%3Fquery%3Dnintendo%2520switch%2520oled%26t%3D1626185591945`