### PR TITLE
Add tradedoubler.com debounce

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -39,12 +39,22 @@
       "*://*.nutribullet.com/t/*",
       "*://*.gopjn.com/t/*",
       "*://*.mediamarkt.de/trck/*",
-      "*://*.saturn.de/trck/*"
+      "*://*.saturn.de/trck/*",
+      "*://*.tradedoubler.com/click?*"
     ],
     "exclude": [
     ],
     "action": "redirect",
     "param": "url"
+  },
+  {
+    "include": [
+      "*://redir.tradedoubler.com/*"
+    ],
+    "exclude": [
+    ],
+    "action": "redirect",
+    "param": "_td_deeplink"
   },
   {
     "include": [


### PR DESCRIPTION
2 tradedoubler debouncing domains:

Debouce: `/redir.tradedoubler.com/`

`https://redir.tradedoubler.com/projectr/?tduid=fb01290b35517bbd9512941b9415712c&utm_medium=affiliate*_td_*KEEP_NEWEST&utm_source=2342040*_td_*KEEP_NEWEST&utm_campaign=TradeDoubler_DE*_td_*KEEP_NEWEST&_td_deeplink=https://www.gamestop.de/Switch/Games/62789/nintendo-switch-oled-model-wei`

Debounce: `.tradedoubler.com/click?`
`https://clkuk.tradedoubler.com/click?p=304128&a=2342012&epi=fm_14411273&url=https%3A%2F%2Fwww.gamestop.de%2FSwitch%2FGames%2F62789%2Fnintendo-switch-oled-model-wei`