### PR TITLE
uBO workaround for pahe.li,mmkvcage.site,animepahe.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -339,6 +339,14 @@ pornhub.com##.realsex
 pornhub.com,pornhubthbh7ap3u.onion##.premiumPromoBanner
 pornhub.com,pornhubthbh7ap3u.onion###pb_template
 pornhub.com##+js(set, page_params.holiday_promo, true)
+! uBO-domain wildcard workaround animepahe.com/mmkvcage.site/pahe.li
+animepahe.com,mmkvcage.site,pahe.li##+js(aopw, _pop)
+animepahe.com,kwik.cx##+js(acis, String.fromCharCode, 'shift')
+animepahe.com,kwik.cx##+js(aopr, open)
+animepahe.com,kwik.cx##+js(aopr, PopAds)
+pahe.li##+js(acis, JSON.parse, break;case $.)
+pahe.li##+js(aeld, , _0x)
+@@||pahe.li^$ghide
 ! uBO-domain wildcard workaround (https://community.brave.com/t/kindly-remove-disable-adblock-and-reload-the-page/308756)
 vipbox.lc,v1sts.me##+js(acis, JSON.parse, break;case)
 vipbox.lc,tvply.me,v1sts.me,vipboxtv.se##+js(aopw, _pop)


### PR DESCRIPTION
Converted over the following filters to non-wildcard from uBO. Was repoorted in the forums https://community.brave.com/t/ad-block-not-working-on-pahe-li/331772/7  Seems pretty active, and should be an easy win for us.

```
animepahe.* -> animepahe.com
mkvcage.* -> mmkvcage.site
pahe.* -> pahe.li

```

From the existing uBO filters:
```
filters-2020.txt:animepahe.*##+js(aopw, _pop)
filters-2020.txt:! rule34.paheal.net PH
filters-2020.txt:rule34.paheal.net##script[src$="ads.js"]:upward(section[id])
filters-2021.txt:pahe.ph##+js(acis, JSON.parse, break;case $.)
filters.txt:mkvcage.*,pahe.*,psarips.*##+js(aopw, _pop)
filters.txt:animepahe.com,kwik.*##^script:has-text('shift')
filters.txt:animepahe.com,kwik.*##+js(acis, String.fromCharCode, 'shift')
filters.txt:animepahe.com,kwik.*##+js(aopr, open)
filters.txt:animepahe.com,kwik.*##+js(aopr, PopAds)
filters.txt:! https://forums.lanik.us/viewtopic.php?f=62&t=44940 pahe .in / .ph
filters.txt:pahe.*##+js(acis, JSON.parse, break;case $.)
filters.txt:pahe.*##+js(aeld, , _0x)
filters.txt:@@||pahe.*^$ghide
```