### PR TITLE
Fix app requirement on reddit.com

### DIFF
--- a/brave-lists/brave-android-specific.txt
+++ b/brave-lists/brave-android-specific.txt
@@ -6,3 +6,11 @@ fmovies.to##+js(acis, atob)
 fmovies.to##+js(acis, XMLHttpRequest)
 ! https://github.com/brave/brave-browser/issues/16629
 diariodocentrodomundo.com.br,01net.com,gizchina.com,pocketpc.ch##.mrf-adv__wrapper 
+! reddit (App requirements)
+reddit.com##.XPromoPopup
+reddit.com##.XPromoPill
+reddit.com##body:style(overflow: auto !important;)
+reddit.com##body.scroll-disabled:style(overflow: visible!important; position: static!important;)
+reddit.com##.XPromoInFeed
+amp.reddit.com##.AppSelectorModal__body
+amp.reddit.com##.upsell_banner

--- a/brave-lists/brave-android-specific.txt
+++ b/brave-lists/brave-android-specific.txt
@@ -7,6 +7,9 @@ fmovies.to##+js(acis, XMLHttpRequest)
 ! https://github.com/brave/brave-browser/issues/16629
 diariodocentrodomundo.com.br,01net.com,gizchina.com,pocketpc.ch##.mrf-adv__wrapper 
 ! reddit (App requirements)
+reddit.com##.XPromoBlockingModal
+reddit.com##.XPromoPopup__overlay
+reddit.com##.PreviewDrawer
 reddit.com##.XPromoPopup
 reddit.com##.XPromoPill
 reddit.com##body:style(overflow: auto !important;)


### PR DESCRIPTION
Imported from Fanboy Annoyances: https://github.com/easylist/easylist/blob/master/fanboy-addon/fanboy_annoyance_specific_uBO.txt#L7

Allow Brave users browsing reddit, to use Brave without a overlay forcing reddit app.  An easy pro-user win for Brave.

- [x] Still allows login/register to work
- [x] Fixes Scrollbar
- [x] Removes overlay

![reddit-appsreq](https://user-images.githubusercontent.com/1659004/155874690-59ecc955-bb48-41d0-a4ab-115a2ac44add.png)


Related, https://github.com/uBlockOrigin/uAssets/issues/10888