### PR TITLE
Fix feedback issue with brave.search

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -14,7 +14,7 @@
 @@||ads.brave.com^$first-party
 @@||brave.com^$image,stylesheet,first-party
 ! https://github.com/uBlockOrigin/uAssets/blob/master/filters/privacy.txt#L260
-search.brave.com#@#+js(no-fetch-if, body:cohort)
+search.brave.com#@#+js(no-fetch-if, body:browser)
 ! stats.brave.com
 stats.brave.com#@#adsContent
 @@||stats.brave.com/local/img/publisher-icons/$domain=stats.brave.com


### PR DESCRIPTION
Not a recent commit, seems to affecting the feedback network. Update an existing filter we had previously.

1. Open `search.brave.com`
2. Search by feedback in the Dev Tools/Network.
3. Expect feedback. 

None is received.