### PR TITLE
Fix https://www.arkadium.com/games/word-wipe/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -309,6 +309,8 @@ akwam.cc##+js(acis, eval, ignielAdBlock)
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=player.abacast.net
 ! uBO-redirect work around filecr.com
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,domain=filecr.com
+! uBO-redirect work around arkadium.com
+@@||googlesyndication.com/pagead/js/adsbygoogle.js$domain=arkadium.com
 ! uBO-redirect work around rockmods.net
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,domain=rockmods.net
 ! uBO-redirect work around paraphraser.io


### PR DESCRIPTION
Fixes playback on `https://www.arkadium.com/games/word-wipe/` due to uBO redirect-rule.