### PR TITLE
Fixes Anti-adblock on cnn.com (First-party workaround)

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -250,7 +250,7 @@ topspeed.com##.txt-ad
 topspeed.com##.daily-vid-ad
 topspeed.com##.top-horizontal-ad-content
 ! 1st-party fix for cnn.com
-cnn.com##+js(aopr, window._sp_)
+cnn.com##+js(aopw, window._sp_.writeCookie)
 ! Anti-adblock message suncalc.org (ported from uBO Annoyances)
 ###adsGross1
 ###adsKlein

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -249,6 +249,8 @@ cinemablend.com##+js(abort-on-property-read, __cmpGdprAppliesGlobally)
 topspeed.com##.txt-ad
 topspeed.com##.daily-vid-ad
 topspeed.com##.top-horizontal-ad-content
+! 1st-party fix for cnn.com
+cnn.com##+js(aopr, window._sp_)
 ! Anti-adblock message suncalc.org (ported from uBO Annoyances)
 ###adsGross1
 ###adsKlein


### PR DESCRIPTION
Blocked in Easyprivacy thanks too `||mms.cnn.com^` due to allowing 1p in standard mode, user will be presented with an Anti-adblock. `||mms.cnn.com^ filter is included in our first-party blocks https://github.com/brave/adblock-lists/blob/master/brave-lists/brave-firstparty.txt when this will be enabled, we can remove this.


![cnn-err](https://user-images.githubusercontent.com/1659004/158045585-bd0dfc99-09cf-4071-9f0c-577198a33b46.png)

Tested https://edition.cnn.com/style/article/man-ray-photo-christies-auction-intl-scli/index.html  

- [x] Page load
- [x] No warning
- [x] Embedded Video played
