### PR TITLE
Add zoom.us debounce

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -67,6 +67,15 @@
   },
   {
     "include": [
+      "*://*.zoom.us/web_client/*"
+    ],
+    "exclude": [
+    ],
+    "action": "redirect",
+    "param": "ref"
+  },
+  {
+    "include": [
       "*://*.zenaps.com/rclick.php*"
     ],
     "exclude": [


### PR DESCRIPTION
Address zoom debounce: `https://st1.zoom.us/web_client/zsc0psq/html/externalLinkPage.html?ref=<url>`