### PR TITLE
Fix anti-adblock on games-manuals.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -301,6 +301,8 @@ akwam.cc##+js(acis, eval, ignielAdBlock)
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$xmlhttprequest,domain=onlinefreecourse.net
 ! uBO-redirect work around shineads.in
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=shineads.in
+! uBO-redirect work around games-manuals.com
+@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=games-manuals.com
 ! uBO-redirect work around photopea.com
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=photopea.com
 ! uBO-redirect work around bluedrake42.com (https://drakelings.bluedrake42.com/)


### PR DESCRIPTION
Anti-adblock on `https://www.games-manuals.com/` due to lack of uBO-redirect