### PR TITLE
Attempted fix https://app.starbucks.com/account/cards

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -36,6 +36,8 @@ theblockcrypto.com##body:style(overflow: auto !important;)
 ! coinmarketcap.com censor tracking https://www.reddit.com/r/brave_browser/comments/rip7ce/works_just_fine/
 /sensorsdata.min.js
 ||sensors.binance.cloud^
+! https://app.starbucks.com/account/cards (Blank page)
+@@||app.starbucks.com/weblx/static/$domain=starbucks.com
 ! google fixes
 @@||googletagmanager.com/gtm.js$domain=rednoseday.org|verygoodvault.com
 @@||googletagmanager.com/gtag/$domain=rednoseday.org|verygoodvault.com


### PR DESCRIPTION
Loading `https://app.starbucks.com/account/cards`  leads to a non-loading page. I suspect ios is getting hung up on loading ​`https://app.starbucks.com/weblx/static/optimizely.ada8bd31f0bc5ea754fc.js` 

Doesn't seem to affect Desktop/Android, standard or aggressive mode.  Will recheck this in a few days to confirm this is resolved.