### PR TITLE
Remove reddit.com app filters

### DIFF
--- a/brave-lists/brave-android-specific.txt
+++ b/brave-lists/brave-android-specific.txt
@@ -6,14 +6,3 @@ fmovies.to##+js(acis, atob)
 fmovies.to##+js(acis, XMLHttpRequest)
 ! https://github.com/brave/brave-browser/issues/16629
 diariodocentrodomundo.com.br,01net.com,gizchina.com,pocketpc.ch##.mrf-adv__wrapper 
-! reddit (App requirements)
-reddit.com##.XPromoBlockingModal
-reddit.com##.XPromoPopup__overlay
-reddit.com##.PreviewDrawer
-reddit.com##.XPromoPopup
-reddit.com##.XPromoPill
-reddit.com##body:style(overflow: auto !important;)
-reddit.com##body.scroll-disabled:style(overflow: visible!important; position: static!important;)
-reddit.com##.XPromoInFeed
-amp.reddit.com##.AppSelectorModal__body
-amp.reddit.com##.upsell_banner


### PR DESCRIPTION
I expected android filters, to be android only. But they were also being applied on the desktop.

Resolves https://old.reddit.com/r/brave_browser/comments/th04qw/braves_shields_creates_another_scroll_bar_in/