### PR TITLE
Update debounce for Lenovo urls

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -305,6 +305,7 @@
       "://*.rrmo.net/c/*",
       "://*.i308314.net/c/*",
       "://*.uqhv.net/c/*",
+      "://*.vzew.net/c/*",
       "://redirect.viglink.com/*"
     ],
     "exclude": [


### PR DESCRIPTION
Update debounce for 

https://lenovo.vzew.net/c/1305116/211864/3128?u=https%3A%2F%2Fwww.lenovo.com%2Fus%2Fen%2Fp%2Flaptops%2Fthinkpad%2Fthinkpadx1%2Fx1-titanium-g1%2F20qa020gus&subid1=dealmaster031922&level=1&srcref=https%3A%2F%2Farstechnica.com%2F&brwsr=6184c614-9434-11ec-87d7-57389425888f&brwsrsig=yI2WqCX9wXmn0SZWC72wpzqkxxgXUI