### PR TITLE
Update debounce for redirect.viglink.com

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -342,7 +342,8 @@
   },
   {
     "include": [
-      "*://*.linksynergy.com/*"
+      "*://*.linksynergy.com/*",
+      "://redirect.viglink.com/*"
     ],
     "exclude": [
     ],


### PR DESCRIPTION
Another `redirect.viglink.com` debounce, we have 2 for this domain.

`https://redirect.viglink.com/?u=https%3A%2F%2Fclick.linksynergy.com%2Fdeeplink%3Fid%3Dfl7OML4te6w%26mid%3D24542%26u1%3Ddealmaster031622%26murl%3Dhttps%253A%252F%252Fwww.xbox.com%252Fen-us%252Fgames%252Fstore%252Fnier-replicant-ver122474287139%252F9nmbk4v30xjr&key=a7e27b5f6ff1de9cb412158b1013e54a&prodOvrd=RAC&opt=false`