### PR TITLE
Fix CNAME issue with https://don.unicef.fr/don-ponctuel/~mon-don

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -41,6 +41,9 @@ stats.brave.com#@#adsContent
 @@||cloudfront.net^$domain=imdb.com|media-imdb.com
 ! CNAME: xing.com
 @@||cloudfront.net^$domain=xing.com
+! CNAME: iraiser.eu
+@@||iraiser.eu^$image,stylesheet,subdocument
+@@||cdn.iraiser.eu^
 ! CNAME: https://darknetdiaries.com/episode/78/
 @@||traffic.megaphone.fm^$domain=megaphone.fm|darknetdiaries.com
 @@||adserver.va3.megaphone.cloud.$domain=megaphone.fm|darknetdiaries.com


### PR DESCRIPTION
Reported CNAME issue on https://don.unicef.fr/don-ponctuel/~mon-don

We're still blocking the tracking scripts, but will need further testing if this doesn't fix it.

```
easyprivacy/easyprivacy_thirdparty.txt:||analytics.iraiser.eu^
easyprivacy/easyprivacy_thirdparty.txt:||iraiser.eu/analytics.js
```

https://community.brave.com/t/brave-shields-blocks-one-of-the-main-payment-system-for-charities/360740