### PR TITLE
Fix ad clicks on google.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -484,6 +484,8 @@ mycima.me##+js(acis, Math, zfgloaded)
 ! Fix abcnews.go.com video playback
 @@||akamaihd.net/player/2.106.5/akamai/amp/chartbeatanalytics/Chartbeatanalytics.min.js$domain=abcnews.go.com
 ! Peter Lowe fixes
+||doubleclick.net^$badfilter
+||googleadservices.com^$badfilter
 ||blockthrough.com^$badfilter
 ||criteo.com^$badfilter
 ||pubmatic.com^$badfilter


### PR DESCRIPTION
Peter Lowes list includes blocks on:

```
127.0.0.1 googleadservices.com
127.0.0.1 doubleclick.net
```

If user intentionally clicks on a Advert on google.com, they'll be presented with an error message. In Easylist we're blocking both of these servers in a 3p context, when it's 1p it'll generate this error.  This issue was previously addressed in IOS and has the same affect on Desktop: https://github.com/brave/adblock-lists/pull/584

Doubleclick and googleadservices.com scripts are still blocked after this change, just addresses people intentionally clicking on ads with Shields up (on standard).

![image (15)](https://user-images.githubusercontent.com/1659004/159795977-5f20d039-681c-476d-bdae-272fa156d73d.png)

