### PR TITLE
A fix for https://app.starbucks.com/account/cards

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -37,6 +37,8 @@ theblockcrypto.com##body:style(overflow: auto !important;)
 /sensorsdata.min.js
 ||sensors.binance.cloud^
 ! https://app.starbucks.com/account/cards (Blank page)
+@@||cdn.optimizely.com/datafiles/$domain=starbucks.com
+@@||starbucks.com/app-assets/
 @@||app.starbucks.com/weblx/static/$domain=starbucks.com
 ! google fixes
 @@||googletagmanager.com/gtm.js$domain=rednoseday.org|verygoodvault.com


### PR DESCRIPTION
Further fixes on `https://app.starbucks.com/account/cards`  Addition too https://github.com/brave/adblock-lists/pull/797

I believe its related to optimizely (similar fix in EP), 2nd time lucky.