### PR TITLE
Update uBO Annoyances for unbreak

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -246,6 +246,61 @@ reuters.com,hardwareluxx.de,formel1.de,golem.de,finanzen.net,autobild.de,gamesta
 ! Anti-adblock message codehelppro.com (ported from uBO Annoyances)
 @@||codehelppro.com^$ghide
 codehelppro.com##.adsbygoogle
+! https://github.com/AdguardTeam/AdguardFilters/issues/70801 (ported from uBO Annoyances)
+tusubtitulo.com###bannerAdBlock
+! 2iptv .com warning anti adb (ported from uBO Annoyances)
+2iptv.com##+js(nostif, google_jobrunner)
+! https://github.com/uBlockOrigin/uAssets/issues/7811 (ported from uBO Annoyances)
+keybr.com##+js(nostif, , 5000)
+keybr.com##+js(nostif, [native code])
+! edmontonjournal .com anti adb warning (ported from uBO Annoyances)
+@@||edmontonjournal.com^$ghide
+! gamebanana anti adblock notice (ported from uBO Annoyances)
+gamebanana.com##+js(aopr, adBlockDetected)
+! https://github.com/NanoMeow/QuickReports/issues/2767 (ported from uBO Annoyances)
+includehelp.com##+js(acis, document.getElementById, banner)
+! https://github.com/NanoMeow/QuickReports/issues/2787 (ported from uBO Annoyances)
+hedgeaccordingly.com##+js(aopw, ABD)
+! https://forums.lanik.us/viewtopic.php?f=62&t=44254 (ported from uBO Annoyances)
+@@||linux.org^$ghide
+! https://github.com/NanoMeow/QuickReports/issues/2981 (ported from uBO Annoyances)
+@@||queer.pl^$ghide
+queer.pl#@#[class^="ad-"]
+queer.pl##.box-adv
+! https://github.com/uBlockOrigin/uAssets/issues/6956 (ported from uBO Annoyances)
+mocospace.com##+js(nostif, adblocker)
+! bigten .org anti adb warning (ported from uBO Annoyances)
+@@||bigten.org^$xhr,1p
+! https://github.com/AdguardTeam/AdguardFilters/issues/50013 (ported from uBO Annoyances)
+strangermeetup.com##+js(set, adsEnabled, true)
+! https://www.reddit.com/r/uBlockOrigin/comments/f879lv/whathifi_antiadblock_not_blocked/ (ported from uBO Annoyances)
+@@||whathifi.com^$ghide
+whathifi.com##.ad-unit
+whathifi.com##.sponsored-post
+! mt07-forum/auto-treff anti-adb (ported from uBO Annoyances)
+mt07-forum.de,auto-treff.com##+js(acis, $, offsetHeight)
+! Steady anti adb warning (ported from uBO Annoyances)
+handball-world.news,mobiflip.de,titanic-magazin.de##+js(nostif, Delay)
+handball-world.news##small
+! fiscomania .com anti adb notice (ported from uBO Annoyances)
+@@||fiscomania.com^$ghide
+! playbill .com anti adb warning (ported from uBO Annoyances)
+playbill.com##+js(nostif, offsetHeight)
+! thegatewaypundit .com anti adb warning (ported from uBO Annoyances)
+thegatewaypundit.com##+js(aeld, , adtoniq)
+! https://github.com/uBlockOrigin/uAssets/issues/7396 (ported from uBO Annoyances)
+yaledailynews.com##+js(acis, $, undefined)
+! https://github.com/NanoMeow/QuickReports/issues/3846 (ported from uBO Annoyances)
+4x4earth.com##+js(set, adBlockDetected, false)
+4x4earth.com##+js(nostif, samOverlay)
+! https://github.com/uBlockOrigin/uAssets/issues/3877 (ported from uBO Annoyances)
+endorfinese.com.br##+js(nostif, google_jobrunner)
+! https://github.com/uBlockOrigin/uAssets/issues/7411 (ported from uBO Annoyances)
+ivoox.com##+js(set, getCookie, trueFunc)
+! https://github.com/AdguardTeam/AdguardFilters/issues/56652 (ported from uBO Annoyances)
+poedb.tw##+js(aopr, adBlockDetected)
+! https://github.com/NanoMeow/QuickReports/issues/3169 (ported from uBO Annoyances)
+malekal.com##+js(nostif, adb)
 ! warning message elitepvpers.com (ported from uBO Annoyances)
 elitepvpers.com##+js(nostif, $)
 elitepvpers.com##+js(acis, $, Promise)


### PR DESCRIPTION
Another import of Anti-adblock messages from https://github.com/uBlockOrigin/uAssets/blob/master/filters/annoyances.txt

All site specific filters, nothing generic.

Ref: https://github.com/brave/adblock-lists/pull/809
https://github.com/brave/adblock-lists/pull/810