### PR TITLE
Fixes ad popups on crichd.*

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -459,6 +459,10 @@ akwam.cc##+js(acis, eval, ignielAdBlock)
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=invisibleoranges.com|nj1015.com|tasteofcountry.com|wyrk.com|xxlmag.com|ultimateclassicrock.com
 ! uBO-redirect work around (https://community.brave.com/t/kindly-remove-disable-adblock-and-reload-the-page/308756)
 @@||v1sts.me^$image
+! uBO-domain wildcard workaround crichd
+crichd.tv,crichd.ac,crichd.com,crichd.vip##+js(aopr, AaDetector)
+crichd.tv,crichd.ac,crichd.com,crichd.vip##+js(acis, JSON.parse, break;case $.)
+crichd.tv,crichd.ac,crichd.com,crichd.vip##+js(aopw, _pop)
 ! uBO-domain wildcard workaround kissanime
 kissanime.com.ru,kissanime.fr,kissanime.org.ru,kissanime.co,kissanime.mx##+js(acis, String.fromCharCode, /btoa|break/)
 kissanime.com.ru,kissanime.fr,kissanime.org.ru,kissanime.co,kissanime.mx##+js(acis, JSON.parse, break;case $.)


### PR DESCRIPTION
Reported `https://community.brave.com/t/opens-pop-up-tab-might-by-ad-block-issue/365256`

2 Fixes needed;

Issued a PR on uAssets: https://github.com/uBlockOrigin/uAssets/pull/12577  

This patch covers various crichd.* domains, also include a common block for popads. (_pop).