### PR TITLE
Fixes rnbxclusive1.biz wildcard

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -459,6 +459,8 @@ akwam.cc##+js(acis, eval, ignielAdBlock)
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=invisibleoranges.com|nj1015.com|tasteofcountry.com|wyrk.com|xxlmag.com|ultimateclassicrock.com
 ! uBO-redirect work around (https://community.brave.com/t/kindly-remove-disable-adblock-and-reload-the-page/308756)
 @@||v1sts.me^$image
+! uBO-domain wildcard workaround rnbxclusive1.* https://github.com/uBlockOrigin/uAssets/pull/12579
+rnbxclusive1.biz##+js(aopw, _pop)
 ! uBO-domain wildcard workaround crichd
 crichd.tv,crichd.ac,crichd.com,crichd.vip##+js(aopr, AaDetector)
 crichd.tv,crichd.ac,crichd.com,crichd.vip##+js(acis, JSON.parse, break;case $.)


### PR DESCRIPTION
Fixes uBO wildcard; `rnbxclusive1.* -> rnbxclusive1.biz`  

Lands a fix into uAssets, https://github.com/uBlockOrigin/uAssets/pull/12579