### PR TITLE
Fix https://uqr.to/abelardoj

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -41,7 +41,7 @@ theblockcrypto.com##body:style(overflow: auto !important;)
 @@||starbucks.com/app-assets/
 @@||app.starbucks.com/weblx/static/$domain=starbucks.com
 ! google fixes
-@@||googletagmanager.com/gtm.js$domain=rednoseday.org|verygoodvault.com
+@@||googletagmanager.com/gtm.js$domain=rednoseday.org|verygoodvault.com|uqr.to
 @@||googletagmanager.com/gtag/$domain=rednoseday.org|verygoodvault.com
 ! Foxnews/business
 @@||js.taplytics.com/jssdk/$domain=foxnews.com|foxbusiness.com


### PR DESCRIPTION
Visiting `https://uqr.to/abelardoj` will hang on Desktop/IOS. 

Fixed on desktop via https://github.com/easylist/easylist/commit/eb62397e6f223a5fa17378eadcf7a91ee6405d93  this fix is for IOS/Slim list.  Affects Brave/uBO.