### PR TITLE
Remove unused facebook debounce

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -256,7 +256,6 @@
   },
   {
     "include": [
-      "*://*.facebook.com/1.php*",
       "*://*.facebook.com/l.php*",
       "*://l.instagram.com/?u=*",
       "*://goto.target.com/c/*",


### PR DESCRIPTION
Facebook is using "L.php", not 1.php, safe to remove