### PR TITLE
Fix https://github.com/brave/brave-browser/issues/22248

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -105,10 +105,6 @@ igniteunmc.com##.preloader
 ! Twitter
 ||api.twitter.com^$third-party,domain=~tweetdeck.com|~twitter.com|~twitter.jp
 ||platform.twitter.com^$third-party,domain=~tweetdeck.com|~twitter.com|~twitter.jp
-! Linkedin
-||platform.linkedin.com^$third-party
-||licdn.com^$third-party,domain=~linkedin.com
-@@||licdn.com^$domain=linkedin.com
 ! Outbrain elements
 ###around-the-web
 ###g-outbrain


### PR DESCRIPTION
Redundant filters,  (and resolves https://github.com/brave/brave-browser/issues/22248) Since we have:

```
! LinkedIn in embeds
@@||licdn.com^$tag=linked-in-embeds
@@||platform.linkedin.com^$tag=linked-in-embeds
```

These Linkedin additions were holdovers from the disconnect list days. We're still blocking the licdn trackers in EP also.