### PR TITLE
Block fake site basicattentiontoken.claims

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -15,6 +15,8 @@
 @@||brave.com^$image,stylesheet,first-party
 ! https://github.com/uBlockOrigin/uAssets/blob/master/filters/privacy.txt#L260
 search.brave.com#@#+js(no-fetch-if, body:browser)
+! Fake BAT site
+||basicattentiontoken.claims^
 ! stats.brave.com
 stats.brave.com#@#adsContent
 @@||stats.brave.com/local/img/publisher-icons/$domain=stats.brave.com


### PR DESCRIPTION
A fake BAT site, just to avoid users inadvertently handing over private details, we should block this.

Domain has also been reported to google safe browsing.