### PR TITLE
Temporarily remove rules that require extracting the full URL past one parameter

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -40,8 +40,7 @@
       "*://*.gopjn.com/t/*",
       "*://*.mediamarkt.de/trck/*",
       "*://*.saturn.de/trck/*",
-      "*://*.tradedoubler.com/click?*",
-      "*://*.xg4ken.com/trk/*"
+      "*://*.tradedoubler.com/click?*"
     ],
     "exclude": [
     ],
@@ -112,15 +111,6 @@
     ],
     "action": "redirect",
     "param": "red"
-  },
-  {
-    "include": [
-      "*://*.dartsearch.net/link/*"
-    ],
-    "exclude": [
-    ],
-    "action": "redirect",
-    "param": "ds_dest_url"
   },
   {
     "include": [


### PR DESCRIPTION
As per https://bravesoftware.slack.com/archives/C3GNZANPR/p1650478357932599?thread_ts=1650399046.159179&cid=C3GNZANPR, let's remove these rules until we support handling them in brave-core (https://github.com/brave/brave-browser/issues/22429)