### PR TITLE
Counter clickserve.dartsearch.net in badware.txt

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -634,6 +634,7 @@ mycima.me##+js(acis, Math, zfgloaded)
 ||shareasale.com^$third-party,badfilter
 ||valuecommerce.com^$third-party,badfilter
 ||linksynergy.com^$third-party,badfilter
+||clickserve.dartsearch.net^$badfilter
 ! Debounce fixes (image,script,xml) Which will allow the debounce.
 ||tradedoubler.com^$image,script,xmlhttprequest,third-party
 ||doubleclick.net^$image,script,xmlhttprequest,third-party


### PR DESCRIPTION
Missed a badware.txt for `filters/badware.txt:||clickserve.dartsearch.net^`  which will also cause issues with debouncing.

Addition too https://github.com/brave/adblock-lists/pull/828