### PR TITLE
Fix fingerprinting on 53.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -223,7 +223,7 @@ livemint.com##+js(aeld, DOMContentLoaded)
 uptostream.com,tirexo.lol##+js(acis, window.a)
 @@||tirexo.lol^$generichide
 ! portscanning script
-ameriprise.com,cibc.com,citi.com,discover.com,fidelity.com,homedepot.com,sciencedirect.com,ebay.com,ebay-kleinanzeigen.de,tdbank.com,walmart.com##+js(acis, tmx_post_session_params_fixed)
+53.com,ameriprise.com,cibc.com,citi.com,discover.com,fidelity.com,homedepot.com,sciencedirect.com,ebay.com,ebay-kleinanzeigen.de,tdbank.com,walmart.com##+js(acis, tmx_post_session_params_fixed)
 ! megaup.net
 megaup.net#@#.adBanner
 ! slate.com Anti-adblock workaround https://github.com/brave/brave-browser/issues/15702


### PR DESCRIPTION
Reported https://community.brave.com/t/broken-website-when-using-website-version-of-brave/381808/3

CPU usage by metrix fingerprinting (same used on ebay etc), we have our own counters (included also is Easyprivacy).