### PR TITLE
Add subdocument blocks for debounce fixes

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -646,14 +646,14 @@ mycima.me##+js(acis, Math, zfgloaded)
 ||linksynergy.com^$third-party,badfilter
 ||clickserve.dartsearch.net^$badfilter
 ! Debounce fixes (image,script,xml) Which will allow the debounce.
-||tradedoubler.com^$image,script,xmlhttprequest,third-party
-||doubleclick.net^$image,script,xmlhttprequest,third-party
-||atdmt.com^$image,script,xmlhttprequest
-||demdex.net^$image,script,xmlhttprequest
-||awin1.com^$image,script,xmlhttprequest,third-party
-||shareasale.com^$image,script,xmlhttprequest,third-party
-||valuecommerce.com^$image,script,xmlhttprequest,third-party
-||linksynergy.com^$image,script,xmlhttprequest,third-party
+||tradedoubler.com^$image,script,subdocument,xmlhttprequest,third-party
+||doubleclick.net^$image,subdocument,script,subdocument,xmlhttprequest,third-party
+||atdmt.com^$image,script,subdocument,xmlhttprequest
+||demdex.net^$image,script,subdocument,xmlhttprequest
+||awin1.com^$image,script,xmlhttprequest,subdocument,third-party
+||shareasale.com^$image,script,xmlhttprequest,subdocument,third-party
+||valuecommerce.com^$image,script,xmlhttprequest,subdocument,third-party
+||linksynergy.com^$image,script,xmlhttprequest,subdocument,third-party
 !
 ! Peter Lowe fixes
 ||blockthrough.com^$badfilter

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -644,7 +644,6 @@ mycima.me##+js(acis, Math, zfgloaded)
 ||shareasale.com^$third-party,badfilter
 ||valuecommerce.com^$third-party,badfilter
 ||linksynergy.com^$third-party,badfilter
-||clickserve.dartsearch.net^$badfilter
 ! Debounce fixes (image,script,xml) Which will allow the debounce.
 ||tradedoubler.com^$image,script,subdocument,xmlhttprequest,third-party
 ||doubleclick.net^$image,subdocument,script,subdocument,xmlhttprequest,third-party


### PR DESCRIPTION
Just a debounce fix, also block subdocument (iframes).

Update from: https://github.com/brave/adblock-lists/pull/828