### PR TITLE
Fixes quiz on https://slate.com/news-and-politics/2022/04/slate-quiz-greek-history-media-comics.html

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -237,7 +237,7 @@ sofi.com,53.com,ameriprise.com,cibc.com,citi.com,discover.com,fidelity.com,homed
 ! megaup.net
 megaup.net#@#.adBanner
 ! slate.com Anti-adblock workaround https://github.com/brave/brave-browser/issues/15702
-||tinypass.com^$domain=slate.com
+||buy.tinypass.com^$domain=slate.com
 @@||id.tinypass.com^$domain=slate.com
 ! Anti-adblock: dianomi-anti-adblock
 @@||pcwelt.de^$generichide


### PR DESCRIPTION
Reported by a user, fine tune the existing tinypass block. This will let the quiz on `https://slate.com/news-and-politics/2022/04/slate-quiz-greek-history-media-comics.html`