### PR TITLE
Fixes redirect on sportsguild.net

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -448,6 +448,8 @@ akwam.cc##+js(acis, eval, ignielAdBlock)
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,domain=rockmods.net
 ! uBO-redirect work around paraphraser.io
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,domain=paraphraser.io
+! uBO-redirect work around sportsguild.net
+@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=sportsguild.net
 ! uBO-redirect work around imperfectcomic.com
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=imperfectcomic.com
 ! uBO-redirect work around, Fixes Blank page 


### PR DESCRIPTION
Fixes anti-adblock; `http://www.sportsguild.net/` due to uBO-redirect.


Reported: https://community.brave.com/t/sportsguild-net-ad-block-detected/384192