### PR TITLE
Update youtube filters

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -53,15 +53,10 @@ stats.brave.com#@#adsContent
 ||theatlantic.blueconic.net$domain=theatlantic.com
 ||theatlantic.com/please-support-us^
 ! youtube ads
-! youtube.com,youtube-nocookie.com##+js(json-prune, 2.playerResponse.adPlacements playerResponse.adPlacements playerResponse.playerAds adPlacements playerAds)
-youtube.com,youtube-nocookie.com##+js(json-prune, [].playerResponse.adPlacements)
-youtube.com,youtube-nocookie.com##+js(json-prune, [].playerResponse.playerAds)
-youtube.com,youtube-nocookie.com##+js(json-prune, 2.playerResponse.adPlacements)
-youtube.com,youtube-nocookie.com##+js(json-prune, playerResponse.adPlacements)
-youtube.com,youtube-nocookie.com##+js(json-prune, playerResponse.playerAds)
-! youtube.com,youtube-nocookie.com##+js(json-prune, adPlacements)
-! youtube.com,youtube-nocookie.com##+js(json-prune, playerAds)
-! youtube.com##+js(set, ytInitialPlayerResponse.adPlacements, null)
+youtubekids.com,youtube-nocookie.com,youtube.com##+js(set, ytInitialPlayerResponse.adPlacements, null)
+youtubekids.com,youtube-nocookie.com,youtube.com##+js(set, playerResponse.adPlacements, undefined)
+youtubekids.com,youtube-nocookie.com,youtube.com##+js(json-prune, playerResponse.adPlacements)
+youtubekids.com,youtube-nocookie.com,youtube.com##+js(json-prune, playerResponse.playerAds)
 ! Fix browser lockup on skepticalscience.com (https://github.com/brave/brave-browser/issues/5406)
 ||skepticalscience.net/widgets/heat_widget/js/heat_content.js$script,domain=skepticalscience.com
 ! adops.com unusable without this


### PR DESCRIPTION
Remove unused and disabled filters, and also include `youtubekids.com`.   Syncs with recent Adguard update. https://github.com/AdguardTeam/AdguardFilters/commit/94533407db77706f2be6177eb867a296ac5889bf

