### PR TITLE
Remove livemint snippet filter

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -220,7 +220,6 @@ startpage.com###gcsa-top
 canyoublockit.com##+js(aopr, atob)
 canyoublockit.com##+js(acis, atob, decodeURIComponent)
 ! Fix livemint.com (anti-adblock)
-livemint.com##+js(aeld, DOMContentLoaded)
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$xmlhttprequest,domain=livemint.com
 ! Broken video playback on tn.com.ar (https://community.brave.com/t/the-blocker-does-not-allow-you-to-watch-the-video/76691)
 @@||googletagmanager.com/gtm.js$script,domain=tn.com.ar


### PR DESCRIPTION
livemint.com snippet no longer needed, also fixes some webcompat issue on the site.