### PR TITLE
Fixes userlytics.com navigator.connection checks

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -52,6 +52,8 @@ stats.brave.com#@#adsContent
 ! theatlantic.com anti-blocker filters
 ||theatlantic.blueconic.net$domain=theatlantic.com
 ||theatlantic.com/please-support-us^
+! navigator.connection checks
+userlytics.com##+js(set, navigator.connection, true)
 ! youtube ads
 youtubekids.com,youtube-nocookie.com,youtube.com##+js(json-prune, [].playerResponse.adPlacements)
 youtubekids.com,youtube-nocookie.com,youtube.com##+js(json-prune, [].playerResponse.playerAds)


### PR DESCRIPTION
userlytics.com fails to load, will getting endless page loading. Due it's checking navigator.connection.* 

`https://www.userlytics.com/moderated-test/observer/?code=obsba5ef112&user_type=observer` (adjusted url for privacy) Reported internally.

```
    this.browserName = this.helpers.getBrowserData().browserName;    
if (this.browserName === 'Chrome') {
      this.prevConnectionType = navigator.connection.effectiveType;
    }
```

