### PR TITLE
Adjust https://github.com/brave/adblock-lists/pull/850

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -54,6 +54,7 @@ stats.brave.com#@#adsContent
 ||theatlantic.com/please-support-us^
 ! navigator.connection checks
 userlytics.com##+js(set, navigator.connection, {})
+userlytics.com##+js(set, navigator.connection.effectiveType, '')
 ! youtube ads
 youtubekids.com,youtube-nocookie.com,youtube.com##+js(json-prune, [].playerResponse.adPlacements)
 youtubekids.com,youtube-nocookie.com,youtube.com##+js(json-prune, [].playerResponse.playerAds)

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -53,7 +53,7 @@ stats.brave.com#@#adsContent
 ||theatlantic.blueconic.net$domain=theatlantic.com
 ||theatlantic.com/please-support-us^
 ! navigator.connection checks
-userlytics.com##+js(set, navigator.connection, true)
+userlytics.com##+js(set, navigator.connection, {})
 ! youtube ads
 youtubekids.com,youtube-nocookie.com,youtube.com##+js(json-prune, [].playerResponse.adPlacements)
 youtubekids.com,youtube-nocookie.com,youtube.com##+js(json-prune, [].playerResponse.playerAds)

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -54,7 +54,6 @@ stats.brave.com#@#adsContent
 ||theatlantic.com/please-support-us^
 ! navigator.connection checks
 userlytics.com##+js(set, navigator.connection, {})
-userlytics.com##+js(set, navigator.connection.effectiveType, '')
 ! youtube ads
 youtubekids.com,youtube-nocookie.com,youtube.com##+js(json-prune, [].playerResponse.adPlacements)
 youtubekids.com,youtube-nocookie.com,youtube.com##+js(json-prune, [].playerResponse.playerAds)


### PR DESCRIPTION
Further refinement of https://github.com/brave/adblock-lists/pull/850

> since {} will behave a bit more like the actual navigator.connection object than true, so might be slightly less risky