### PR TITLE
Add adservers from https://animixplay.to/

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -98,6 +98,8 @@ theblockcrypto.com##body:style(overflow: auto !important;)
 ! Random adservers
 ||closureevaporatefume.com^
 ||pub.network^
+||d2o03z2xnyxlz5.cloudfront.net^
+||papayads.net^$third-party
 ||revcontent.com^$third-party
 ! Trackers
 ||pagefair.com^


### PR DESCRIPTION
Reported: https://community.brave.com/t/brave-suddenly-stopped-blocking-pop-up-ads-on-animixplay-on-ios/397553

Should help with the site, hopefully improve the popup issues.