### PR TITLE
Temporarily remove unsupported rules

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -20,7 +20,6 @@
       "*://gate.sc/?url=*",
       "*://freetutsdownload.net/redirect-to/?url=*",
       "*://mcpedl.com/leaving/?url=*",
-      "*://track.adtraction.com/t/*&url=*",
       "*://track.effiliation.com/servlet/effi.redir*&url=*",
       "*://go.skimresources.com/?id=*&url=*",
       "*://go.redirectingat.com/?id=*&url=*",

--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -84,7 +84,6 @@
   },
   {
     "include": [
-      "*://*.dartsearch.net/link/*",
       "*://*.doubleclick.net/ddm/clk/*"
     ],
     "exclude": [

--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -84,7 +84,6 @@
   },
   {
     "include": [
-      "*://t.myvisualiq.net/*",
       "*://*.dartsearch.net/link/*",
       "*://*.doubleclick.net/ddm/clk/*"
     ],

--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -84,15 +84,6 @@
   },
   {
     "include": [
-      "*://*.doubleclick.net/ddm/clk/*"
-    ],
-    "exclude": [
-    ],
-    "action": "redirect",
-    "param": "red"
-  },
-  {
-    "include": [
       "*://rd.bizrate.com/rd?*"
     ],
     "exclude": [


### PR DESCRIPTION
A few more rules that should have been included as part of https://github.com/brave/adblock-lists/pull/829.

See these issues for the full rationale:

- https://github.com/brave/adblock-lists/issues/866
- https://github.com/brave/adblock-lists/issues/867
- https://github.com/brave/adblock-lists/issues/868
- https://github.com/brave/adblock-lists/issues/870