### PR TITLE
Fixes ubo-redirect on lineups.fun,13tv.co.il

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -446,6 +446,8 @@ sportsnet.ca##+js(aopr, uxGuid)
 chicago.suntimes.com,theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com,mmafighting.com,racked.com,mmamania.com,funnyordie.com,riftherald.com##+js(nostif, adsBlocked)
 chicago.suntimes.com,theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com,mmafighting.com,racked.com,mmamania.com,funnyordie.com,riftherald.com##.adblock-allowlist-messaging__wrapper
 ||concert.io/lib/adblock/$subdocument
+! uBO-redirect work around (www3.doubleclick.net)
+@@||www3.doubleclick.net^$xhr,domain=lineups.fun|13tv.co.il
 ! uBO-redirect work around simon.com
 @@||google-analytics.com/analytics.js$script,domain=simon.com
 @@||googletagmanager.com/gtm.js$script,domain=simon.com


### PR DESCRIPTION
Fixes the following:

```
filters/filters-2022.txt:! lineups.fun anti-adb
filters/filters-2022.txt:||www3.doubleclick.net^$xhr,redirect-rule=noop.txt,domain=lineups.fun
```

Also another ubo-redirect bait; `https://13tv.co.il/item/featured-series/1990s/season-01/episodes/ip4ti-902950173/?pid=902846142&cid=902950173`   (was reported in webcompat reports)