### PR TITLE
Remove invalid f9tmep.net rule

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -56,15 +56,6 @@
   },
   {
     "include": [
-      "*://*.f9tmep.net/c/*"
-    ],
-    "exclude": [
-    ],
-    "action": "redirect",
-    "param": "srcref"
-  },
-  {
-    "include": [
       "*://*.zenaps.com/rclick.php*"
     ],
     "exclude": [


### PR DESCRIPTION
This rule is redirecting back to the referring site, not to the destination site:
```
$ curl --head 'https://bitdefender.f9tmep.net/c/338476/499160/4466?subtag=trd-nz-12659124619216761200&level=1&srcref=https%3A%2F%2Fwww.techradar.com%2F&brwsr=22221221-412c-21ec-b125-6fa12a2199af&brwsrsig=2Y1RI912PVraWUs12l2ePRiOx12U5V​​​​​'
HTTP/2 301 
date: Wed, 08 Jun 2022 16:08:42 GMT
content-length: 0
location: https://ad.doubleclick.net/ddm/trackclk/N256806.2461108IMPACTRADIUSROW/B20028980.225381237;dc_trk_aid=423322651;dc_trk_cid=90273781;dc_lat=;dc_rdid=;tag_for_child_directed_treatment=;tfua=?clickid=&irgwc=1&MPid=338476&cid=aff%7Cc%7CIR
```

- Debouncer takes me to https://www.techradar.com/
- Following the original URL takes me to https://www.bitdefender.com.au/media/html/consumer/new/security-trust-2022-opt/?cid=aff|c|ir

The destination URL is not visible in the URL and so we sadly can't debounce these.