### PR TITLE
Fixes anti-adblock faucetbtc.net

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -484,6 +484,8 @@ akwam.cc##+js(acis, eval, ignielAdBlock)
 ! uBO-redirect work around, Fixes BlockAdblock blocked via ||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,redirect-rule=googlesyndication_adsbygoogle.js:5
 @@||havoc-os.com^$ghide
 @@||fluttercampus.com^$ghide
+! uBO-redirect work around faucetbtc.net 
+faucetbtc.net##+js(aopr, TestAd)
 ! uBO-redirect work around streamingcommunity.bar
 @@||googletagmanager.com/gtag/js$domain=streamingcommunity.bar
 @@||google-analytics.com/analytics.js$domain=streamingcommunity.bar


### PR DESCRIPTION
This is an alternative rule too https://github.com/uBlockOrigin/uAssets/commit/50866f082b3bd88c82d99534b48ef85c3a446887

`*$script,domain=faucetbtc.net,redirect-rule=noopjs`

This filter will counter the anti-ad