### PR TITLE
Remove broken viglink.com rule (fixes #864)

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -275,8 +275,7 @@
   },
   {
     "include": [
-      "*://*.linksynergy.com/*",
-      "*://redirect.viglink.com/*"
+      "*://*.linksynergy.com/*"
     ],
     "exclude": [
     ],


### PR DESCRIPTION
The second rule refers to a linksynergy.com URL parameter and so it doesn't work.

See #801 for the example URL where it came from.