### PR TITLE
Add test entries to the debounce list.

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -392,5 +392,33 @@
     ],
     "action": "base64,redirect",
     "param": "a"
+  },
+  {
+    "include": [
+      "https://fmarier.github.io/brave-testing/debouncer/redirect.html?*"
+    ],
+    "exclude": [
+    ],
+    "action": "redirect",
+    "param": "brave_testing"
+  },
+  {
+    "include": [
+      "https://fmarier.github.io/brave-testing/debouncer/redirect.html?*"
+    ],
+    "exclude": [
+    ],
+    "action": "base64,redirect",
+    "param": "brave_testing_base64"
+  },
+  {
+    "include": [
+      "https://fmarier.github.io/brave-testing/debouncer/*"
+    ],
+    "exclude": [
+    ],
+    "prepend_scheme": "https",
+    "action": "regex-path",
+    "param": "^/brave-testing/debouncer/(.*);.html$"
   }
 ]


### PR DESCRIPTION
These dummy entries can be used in tests since they will be stable.