### PR TITLE
Debounce clixgalore.com correctly

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -65,12 +65,23 @@
   },
   {
     "include": [
-      "*://*.clixgalore.com/Lead.aspx*"
+      "*://www.clixgalore.com/Lead.aspx*"
     ],
     "exclude": [
     ],
+    "prepend_scheme": "http",
     "action": "redirect",
     "param": "AffDirectURL"
+  },
+  {
+    "include": [
+      "*://www.clixgalore.com/Lead.aspx*"
+    ],
+    "exclude": [
+    ],
+    "prepend_scheme": "http",
+    "action": "redirect",
+    "param": "LP"
   },
   {
     "include": [


### PR DESCRIPTION
Clixgalore uses two different query string parameters, and it also omits the scheme from the destination URLs.

Sample URL: http://www.clixgalore.com/Lead.aspx?BID=188989&AfID=82776&AdID=16214&LP=www.elitemate.com%2FmyJsp%2Fjoin.jsp%3Fid%3Dclixg%26path%3DPG%26pageid%3D339

Note that this uses the new "prepend_scheme" option which recently landed. This was not available when the rule was originally added in https://github.com/brave/adblock-lists/pull/770.