### PR TITLE
First party piwik exceptions no longer needed

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -67,13 +67,6 @@ youtubekids.com,youtube-nocookie.com,youtube.com##+js(json-prune, playerResponse
 ! adops.com unusable without this
 @@||adops.com^$~third-party
 @@||www.scrumpoker.online^$~third-party
-! piwick/matomo
-@@/piwik.js$first-party
-@@/piwik.php$first-party
-@@/matomo-tracking.$first-party
-@@/matomo.php$first-party
-@@/matomo.js$first-party
-@@/matomo/*$first-party
 ! fixes for several requests bypassing default blocklists
 ||aolcdn.com/*/adsWrapper.js$script
 ||zergnet.com^$script,third-party


### PR DESCRIPTION
The exceptions are no longer needed, these were general filter rules for 1st-party sites using piwik/matomo.

These rules only applied to piwik/matomo 1st party, and they predate the changes we made regarding 1st party in standard shields mode, https://brave.com/privacy-updates/9-web-compat-blocking/  


Setting your shields=Aggressive will block these scripts.