### PR TITLE
Delete broken imported rules

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -194,8 +194,7 @@
   },
   {
     "include": [
-      "*://*.maranhesduve.club/?*",
-      "*://*.sparbuttantowa.pro/*?*"
+      "*://*.maranhesduve.club/?*"
     ],
     "exclude": [
     ],
@@ -310,9 +309,7 @@
   {
     "include": [
       "*://*.blogspot.com/*/*/*?url=*",
-      "*://*.mispuani.xyz/*?url=*",
       "*://*.safelinku.icu/*?url=*",
-      "*://*.ad4msan.win/safe?url=*",
       "*://*.infotekno.net/vga?url=*",
       "*://*.sehuruf.com/linkku/?url=*",
       "*://*.novicearea.com/*/?url=*",
@@ -332,7 +329,6 @@
     "include": [
       "*://*.telolet.in/?go=*",
       "*://*.lompat.in/?go=*",
-      "*://*.grandmovie21.com/?go=*",
       "*://*.postku.org/?go=*"
     ],
     "exclude": [
@@ -347,9 +343,7 @@
       "*://*.vius.info/*?site=*",
       "*://*.cariskuy.com/*?site=*",
       "*://*.losstor.com/ini/?site=*",
-      "*://*.giga74.com/*?site=*",
-      "*://*.hfiz.site/?site=*",
-      "*://*.cemiw.net/*?site=*"
+      "*://*.giga74.com/*?site=*"
     ],
     "exclude": [
     ],
@@ -358,8 +352,6 @@
   },
   {
     "include": [
-      "*://*.remiyu.me/*?reff=*",
-      "*://*.ceksite.id/*?reff=*",
       "*://*.postku.org/*?reff=*"
     ],
     "exclude": [
@@ -369,20 +361,9 @@
   },
   {
     "include": [
-      "*://*.kharismanews.com/?rel=*",
-      "*://out.x-forex.site/?rel=*"
-    ],
-    "exclude": [
-    ],
-    "action": "base64,redirect",
-    "param": "rel"
-  },
-  {
-    "include": [
       "*://*.leechpremium.link/cheat/?link=*",
       "*://*.bdzone.xyz/cheat.php?link=*",
       "*://*.extramovies.casa/download.php?name=*&link=*",
-      "*://*.gilakerja.com/*/?link=*",
       "*://sekolahgan.my.id/?link=*"
     ],
     "exclude": [

--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -3,12 +3,8 @@
     "include": [
       "*://*.leechall.com/redirect.php?url=*",
       "*://*.news-gg.com/l/?*",
-      "*://*.mobile01.com/redirect.php?*",
-      "*://*.nurhamka.com/*?url=*",
-      "*://*.linepc.site/*?url=*",
       "*://www.sopasti.com/anime.php?*",
       "*://*.zxro.com/u/*?url=*",
-      "*://*.macdownload.org/redirect/?url=*",
       "*://flake.creditcable.info/*",
       "*://*.adfoc.us/serve/sitelinks/?*",
       "*://*.itsbx.com/redirect/?url=*",
@@ -294,11 +290,7 @@
   },
   {
     "include": [
-      "*://*.safelinku.icu/*?url=*",
-      "*://*.infotekno.net/vga?url=*",
-      "*://*.sehuruf.com/linkku/?url=*",
-      "*://*.blackmod.net/dl/?url=*",
-      "*://*.omglyrics.com/*/?url=*"
+      "*://*.blackmod.net/dl/?url=*"
     ],
     "exclude": [
     ],
@@ -307,8 +299,6 @@
   },
   {
     "include": [
-      "*://*.masreyhan.com/*?site=*",
-      "*://*.vius.info/*?site=*",
       "*://*.losstor.com/ini/?site=*"
     ],
     "exclude": [
@@ -319,23 +309,12 @@
   {
     "include": [
       "*://*.leechpremium.link/cheat/?link=*",
-      "*://*.bdzone.xyz/cheat.php?link=*",
-      "*://*.extramovies.casa/download.php?name=*&link=*",
-      "*://sekolahgan.my.id/?link=*"
+      "*://*.extramovies.casa/download.php?name=*&link=*"
     ],
     "exclude": [
     ],
     "action": "base64,redirect",
     "param": "link"
-  },
-  {
-    "include": [
-      "*://*.infosia.xyz/?kesehatan=*"
-    ],
-    "exclude": [
-    ],
-    "action": "base64,redirect",
-    "param": "kesehatan"
   },
   {
     "include": [

--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -133,7 +133,6 @@
   },
   {
     "include": [
-      "*://*.spaste.com/r/*link=*",
       "*://*.getprice.com.au/prodhits.aspx?*"
     ],
     "exclude": [
@@ -149,17 +148,6 @@
     ],
     "action": "redirect",
     "param": "aurl"
-  },
-  {
-    "include": [
-      "*://*.ouo.io/*?s=*",
-      "*://*.cpmlink.net/s/*?s=*",
-      "*://*.shon.xyz/s/*?s=*"
-    ],
-    "exclude": [
-    ],
-    "action": "redirect",
-    "param": "s"
   },
   {
     "include": [
@@ -290,26 +278,7 @@
   },
   {
     "include": [
-      "*://*.blackmod.net/dl/?url=*"
-    ],
-    "exclude": [
-    ],
-    "action": "base64,redirect",
-    "param": "url"
-  },
-  {
-    "include": [
-      "*://*.losstor.com/ini/?site=*"
-    ],
-    "exclude": [
-    ],
-    "action": "base64,redirect",
-    "param": "site"
-  },
-  {
-    "include": [
-      "*://*.leechpremium.link/cheat/?link=*",
-      "*://*.extramovies.casa/download.php?name=*&link=*"
+      "*://*.leechpremium.link/cheat/?link=*"
     ],
     "exclude": [
     ],
@@ -324,15 +293,6 @@
     ],
     "action": "base64,redirect",
     "param": "cr"
-  },
-  {
-    "include": [
-      "*://*.adsafelink.net/generate?a=*"
-    ],
-    "exclude": [
-    ],
-    "action": "base64,redirect",
-    "param": "a"
   },
   {
     "include": [

--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -1,15 +1,9 @@
 [
   {
     "include": [
-      "*://*.leechall.com/redirect.php?url=*",
-      "*://*.news-gg.com/l/?*",
       "*://www.sopasti.com/anime.php?*",
-      "*://*.zxro.com/u/*?url=*",
       "*://flake.creditcable.info/*",
-      "*://*.adfoc.us/serve/sitelinks/?*",
-      "*://*.itsbx.com/redirect/?url=*",
       "*://www.forocoches.com/link.php?*",
-      "*://gate.sc/?url=*",
       "*://mcpedl.com/leaving/?*",
       "*://track.effiliation.com/servlet/effi.redir*",
       "*://go.skimresources.com/*",
@@ -142,15 +136,6 @@
   },
   {
     "include": [
-      "*://*.folderenius.com/*/*?*"
-    ],
-    "exclude": [
-    ],
-    "action": "redirect",
-    "param": "aurl"
-  },
-  {
-    "include": [
       "*://www.shareasale.com/r.cfm?*",
       "*://shareasale.com/r.cfm?*",
       "*://www.shareasale-analytics.com/r.cfm?*",
@@ -275,15 +260,6 @@
     ],
     "action": "redirect",
     "param": "murl"
-  },
-  {
-    "include": [
-      "*://*.leechpremium.link/cheat/?link=*"
-    ],
-    "exclude": [
-    ],
-    "action": "base64,redirect",
-    "param": "link"
   },
   {
     "include": [

--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -308,7 +308,6 @@
   },
   {
     "include": [
-      "*://*.blogspot.com/*/*/*?url=*",
       "*://*.safelinku.icu/*?url=*",
       "*://*.infotekno.net/vga?url=*",
       "*://*.sehuruf.com/linkku/?url=*",

--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -9,16 +9,11 @@
       "*://www.sopasti.com/anime.php?*",
       "*://*.zxro.com/u/*?url=*",
       "*://*.macdownload.org/redirect/?url=*",
-      "*://*.forek.info/*?url=*",
       "*://flake.creditcable.info/*",
       "*://*.adfoc.us/serve/sitelinks/?*",
-      "*://*.made-by.org/redirection/?url=*",
       "*://*.itsbx.com/redirect/?url=*",
       "*://www.forocoches.com/link.php?*",
-      "*://*.pixiv.net/jump.php?url=*",
-      "*://hdblurayindir.com/git.php?url=*",
       "*://gate.sc/?url=*",
-      "*://freetutsdownload.net/redirect-to/?url=*",
       "*://mcpedl.com/leaving/?*",
       "*://track.effiliation.com/servlet/effi.redir*",
       "*://go.skimresources.com/*",
@@ -194,15 +189,6 @@
   },
   {
     "include": [
-      "*://*.maranhesduve.club/?*"
-    ],
-    "exclude": [
-    ],
-    "action": "redirect",
-    "param": "href"
-  },
-  {
-    "include": [
       "*://click.icptrack.com/icp/relay.php*"
     ],
     "exclude": [
@@ -311,13 +297,8 @@
       "*://*.safelinku.icu/*?url=*",
       "*://*.infotekno.net/vga?url=*",
       "*://*.sehuruf.com/linkku/?url=*",
-      "*://*.novicearea.com/*/?url=*",
-      "*://*.dikatekno.com/go/?url=*",
       "*://*.blackmod.net/dl/?url=*",
-      "*://*.hulblog.com/*/?url=*",
-      "*://*.omglyrics.com/*/?url=*",
-      "*://*.nyantaidulu.com/linknya/?url=*",
-      "*://*.pixelshost.com/?url=*"
+      "*://*.omglyrics.com/*/?url=*"
     ],
     "exclude": [
     ],
@@ -326,37 +307,14 @@
   },
   {
     "include": [
-      "*://*.telolet.in/?go=*",
-      "*://*.lompat.in/?go=*",
-      "*://*.postku.org/?go=*"
-    ],
-    "exclude": [
-    ],
-    "action": "base64,redirect",
-    "param": "go"
-  },
-  {
-    "include": [
       "*://*.masreyhan.com/*?site=*",
-      "*://*.pasardownload.com/*?site=*",
       "*://*.vius.info/*?site=*",
-      "*://*.cariskuy.com/*?site=*",
-      "*://*.losstor.com/ini/?site=*",
-      "*://*.giga74.com/*?site=*"
+      "*://*.losstor.com/ini/?site=*"
     ],
     "exclude": [
     ],
     "action": "base64,redirect",
     "param": "site"
-  },
-  {
-    "include": [
-      "*://*.postku.org/*?reff=*"
-    ],
-    "exclude": [
-    ],
-    "action": "base64,redirect",
-    "param": "reff"
   },
   {
     "include": [


### PR DESCRIPTION
This removes 59 of the 65 rules imported from external sources in https://github.com/brave/adblock-lists/commit/05db8d5d23b3b9476707cfd8892f2d71506248bf.

These removals include sample URLs and sources where appropriate and are split across several commits grouping them by reason for removal.