### PR TITLE
Remove duplicate rule

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -22,7 +22,6 @@
       "*://mcpedl.com/leaving/?*",
       "*://track.effiliation.com/servlet/effi.redir*",
       "*://go.skimresources.com/*",
-      "*://go.redirectingat.com/*",
       "*://shop-links.co/link/*",
       "*://www.jdoqocy.com/click-*",
       "*://www.kqzyfj.com/click-*",


### PR DESCRIPTION
This was accidentally introduced in https://github.com/brave/adblock-lists/pull/902.