### PR TITLE
Update threatmetrix fingerprinting

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -206,7 +206,7 @@ canyoublockit.com##+js(acis, atob, decodeURIComponent)
 uptostream.com,tirexo.lol##+js(acis, window.a)
 @@||tirexo.lol^$generichide
 ! portscanning script
-optumbank.com,53.com,samsclub.com,intuit.com,betfair.com,sofi.com,53.com,ameriprise.com,cibc.com,citi.com,discover.com,fidelity.com,homedepot.com,sciencedirect.com,ebay.com,ebay-kleinanzeigen.de,tdbank.com,walmart.com##+js(acis, tmx_post_session_params_fixed)
+citibankonline.com,bmo.com,eftps.gov,optumbank.com,53.com,samsclub.com,intuit.com,betfair.com,sofi.com,53.com,ameriprise.com,cibc.com,citi.com,discover.com,fidelity.com,homedepot.com,sciencedirect.com,ebay.com,ebay-kleinanzeigen.de,tdbank.com,walmart.com##+js(acis, tmx_post_session_params_fixed)
 ! slate.com Anti-adblock workaround https://github.com/brave/brave-browser/issues/15702
 ||buy.tinypass.com^$domain=slate.com
 @@||id.tinypass.com^$domain=slate.com


### PR DESCRIPTION
All 3 domains using threatmetrix fingerprinting causing perf issues this should help.

**eftps.gov:** https://community.brave.com/t/brave-hangs-on-eftps-gov/408507/

Were discovered while troubleshooting, citibankonline.com, bmo.com were reported via email support. 