### PR TITLE
Add cc.techbargains.com debounce

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -25,7 +25,8 @@
       "*://go.redirectingat.com/*",
       "*://x.chip.de/linktrack/button/*",
       "*://*.mailchimp.com/mctx/clicks?*",
-      "*://*.tradedoubler.com/click?*"
+      "*://*.tradedoubler.com/click?*",
+      "*://cc.techbargains.com/*"
     ],
     "exclude": [
     ],

--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -26,7 +26,7 @@
       "*://x.chip.de/linktrack/button/*",
       "*://*.mailchimp.com/mctx/clicks?*",
       "*://*.tradedoubler.com/click?*",
-      "*://cc.techbargains.com/*"
+      "*://cc.techbargains.com/v1/otc/*"
     ],
     "exclude": [
     ],


### PR DESCRIPTION
From site: `https://www.techbargains.com/deals/lg-oled-c1-4k-tv`

Debouncing `https://cc.techbargains.com/v1/otc/06LJoHfGQoCuYdVtZVoTdgY?merchant=03yqSJWwdU65jruBzT9LVdv&url=https%3A%2F%2Fwww.buydig.com%2Fshop%2Fproduct%2FLGOLED77C1PUB&i=deal_description&e=deal_tile&p=1&m=deals_list&t=deal_page`