### PR TITLE
Fixes https://signin.quicken.com/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -206,7 +206,7 @@ canyoublockit.com##+js(acis, atob, decodeURIComponent)
 uptostream.com,tirexo.lol##+js(acis, window.a)
 @@||tirexo.lol^$generichide
 ! portscanning script
-quicken.com,citibankonline.com,bmo.com,eftps.gov,optumbank.com,samsclub.com,intuit.com,betfair.com,sofi.com,53.com,ameriprise.com,cibc.com,citi.com,discover.com,fidelity.com,homedepot.com,sciencedirect.com,ebay.com,ebay-kleinanzeigen.de,tdbank.com,walmart.com##+js(acis, tmx_post_session_params_fixed)
+spectrum.net,quicken.com,citibankonline.com,bmo.com,eftps.gov,optumbank.com,samsclub.com,intuit.com,betfair.com,sofi.com,53.com,ameriprise.com,cibc.com,citi.com,discover.com,fidelity.com,homedepot.com,sciencedirect.com,ebay.com,ebay-kleinanzeigen.de,tdbank.com,walmart.com##+js(acis, tmx_post_session_params_fixed)
 ! slate.com Anti-adblock workaround https://github.com/brave/brave-browser/issues/15702
 ||buy.tinypass.com^$domain=slate.com
 @@||id.tinypass.com^$domain=slate.com

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -206,7 +206,7 @@ canyoublockit.com##+js(acis, atob, decodeURIComponent)
 uptostream.com,tirexo.lol##+js(acis, window.a)
 @@||tirexo.lol^$generichide
 ! portscanning script
-citibankonline.com,bmo.com,eftps.gov,optumbank.com,53.com,samsclub.com,intuit.com,betfair.com,sofi.com,53.com,ameriprise.com,cibc.com,citi.com,discover.com,fidelity.com,homedepot.com,sciencedirect.com,ebay.com,ebay-kleinanzeigen.de,tdbank.com,walmart.com##+js(acis, tmx_post_session_params_fixed)
+quicken.com,citibankonline.com,bmo.com,eftps.gov,optumbank.com,samsclub.com,intuit.com,betfair.com,sofi.com,53.com,ameriprise.com,cibc.com,citi.com,discover.com,fidelity.com,homedepot.com,sciencedirect.com,ebay.com,ebay-kleinanzeigen.de,tdbank.com,walmart.com##+js(acis, tmx_post_session_params_fixed)
 ! slate.com Anti-adblock workaround https://github.com/brave/brave-browser/issues/15702
 ||buy.tinypass.com^$domain=slate.com
 @@||id.tinypass.com^$domain=slate.com


### PR DESCRIPTION
Removed `53.com` dube domain. 

Added quicken.com (Reported https://community.brave.com/t/quicken-com-sign-in-page-always-hangs/409691/2)

