### PR TITLE
Fix threatmatrix on healthsafeid.optumbank.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -206,7 +206,7 @@ canyoublockit.com##+js(acis, atob, decodeURIComponent)
 uptostream.com,tirexo.lol##+js(acis, window.a)
 @@||tirexo.lol^$generichide
 ! portscanning script
-mbna.ca,tdcommercialbanking.com,coastcapitalsavings.com,my100bank.com,royalbank.com,td.com,spectrum.net,quicken.com,citibankonline.com,bmo.com,eftps.gov,optumbank.com,samsclub.com,intuit.com,betfair.com,sofi.com,53.com,ameriprise.com,cibc.com,citi.com,discover.com,fidelity.com,homedepot.com,sciencedirect.com,ebay.com,ebay-kleinanzeigen.de,tdbank.com,walmart.com##+js(acis, tmx_post_session_params_fixed)
+optumbank.com,mbna.ca,tdcommercialbanking.com,coastcapitalsavings.com,my100bank.com,royalbank.com,td.com,spectrum.net,quicken.com,citibankonline.com,bmo.com,eftps.gov,optumbank.com,samsclub.com,intuit.com,betfair.com,sofi.com,53.com,ameriprise.com,cibc.com,citi.com,discover.com,fidelity.com,homedepot.com,sciencedirect.com,ebay.com,ebay-kleinanzeigen.de,tdbank.com,walmart.com##+js(acis, tmx_post_session_params_fixed)
 ! slate.com Anti-adblock workaround https://github.com/brave/brave-browser/issues/15702
 ||buy.tinypass.com^$domain=slate.com
 @@||id.tinypass.com^$domain=slate.com


### PR DESCRIPTION
Fixes perf issues on `https://healthsafeid.optumbank.com/rt/login/hsid/en?TARGET=https%3A%2F%2Fhealthsafeid.optumbank.com%2Frt%2Fsecure%2Fauth%2Fhsid%2Fen&resume=%2Fas%2FE9pAO%2Fresume%2Fas%2Fauthorization.ping&reason=0`  due to threatmatrix