### PR TITLE
Fixes login on https://www.uccu.com/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -729,6 +729,7 @@ mycima.me##+js(acis, Math, zfgloaded)
 ! Peter Lowe fixes
 ||blockthrough.com^$badfilter
 ||criteo.com^$badfilter
+||app.pendo.io^$badfilter
 ||pubmatic.com^$badfilter
 ||appsflyer.com^$badfilter
 ||tapfiliate.com^$badfilter


### PR DESCRIPTION
Fixes login issues on https://www.uccu.com/ reported in webcompat reports.  Filter not removed in uBO Assets, we'll remove.

Tracker `||pendo.io/data/ptm.gif` is blocked in Easyprivacy. but blocking the rest of `app.pendo.io` will cause false positives.