### PR TITLE
Fixes anti-adblock on https://anysubtitle.com/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -548,7 +548,7 @@ faucetbtc.net##+js(aopr, TestAd)
 @@||v1sts.me^$image
 ! uBO-redirect work around :5
 ! ||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,redirect-rule=googlesyndication_adsbygoogle.js:5,domain=~zipextractor.app
-@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=itscybertech.com
+@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=itscybertech.com|anysubtitle.com
 ! uBO-domain wildcard workaround rnbxclusive1.* https://github.com/uBlockOrigin/uAssets/pull/12579
 rnbxclusive1.biz##+js(aopw, _pop)
 ! uBO-domain wildcard workaround crichd


### PR DESCRIPTION
Fixes anti-adblock on `https://anysubtitle.com/`  Reported in Webcompat reports

Tested in Brave Nightly (1.43.3)