### PR TITLE
Fix anti-adblock on ios (planetf1.com)

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -25,6 +25,8 @@ theblockcrypto.com##body:style(overflow: auto !important;)
 ! Bait (anti-adblock)
 ! https://cmp.uniconsent.mgr.consensu.org/ads.js?a=1&ad_block=1
 @@||uniconsent.mgr.consensu.org/ads.js
+! Bait (https://www.planetf1.com/)
+@@||ad.doubleclick.net/favicon.ico$domain=planetf1.com
 ! appsflyer.com adjustment https://github.com/easylist/easylist/commit/c608be1
 @@||appsflyer.com^$third-party
 @@||app.appsflyer.com^$third-party


### PR DESCRIPTION
IOs specific anti-adblock. Not applicable to Desktop/Anroid due to snippet use. 
`filters/filters.txt:planetf1.com##+js(aopr, CatapultTools)`

The site just uses a simple bait check.  `https://ad.doubleclick.net/favicon.ico?ad=300x250&ad_box_=1&adnet=1&showad=1&size=250x250`

![image_from_ios (3)](https://user-images.githubusercontent.com/1659004/181171569-61944b5d-6a58-4ed7-8d97-de3b9b1ae186.png)

