### PR TITLE
Fix anti-ad on fresheroffcampus.com,cizzyscripts.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -572,6 +572,8 @@ faucetbtc.net##+js(aopr, TestAd)
 ! ||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,redirect-rule=googlesyndication_adsbygoogle.js:5,domain=~zipextractor.app
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=itscybertech.com|anysubtitle.com|filedb.io|ibomma.bar|sunucutanitim.com|movierulzhd.art|anhdep24.com
 @@||sunucutanitim.com^$ghide
+! chp anti-adblock
+fresheroffcampus.com,cizzyscripts.com##+js(aopw, startCheckingAdblock)
 ! uBO-domain wildcard workaround rnbxclusive1.* https://github.com/uBlockOrigin/uAssets/pull/12579
 @@||rnbxclusive1.me^$ghide
 rnbxclusive1.me##+js(aopw, _pop)


### PR DESCRIPTION
Tested in Brave Nightly.

Fixes reported issue on https://community.brave.com/t/some-sites-are-specifically-designed-to-detect-ad-blocking-system-by-brave/418087

resolved on uBO with `||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$xmlhttprequest,redirect-rule=googlesyndication_adsbygoogle.js:5,domain=~zipextractor.app`