### PR TITLE
Add trackers/adservers for cookpad.com (ios)

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -50,6 +50,10 @@ theblockcrypto.com##body:style(overflow: auto !important;)
 @@||static.foxnews.com/static/$domain=foxnews.com|foxbusiness.com
 ! 5ch.net (japanese)
 ||thench.net^$third-party
+! cookpad.com (japanese)
+||flux-cdn.com/plugin/common/analytics/
+||cookpad-ads.com^
+/assets/ad/*
 ! tn.com.ar 
 @@||scdn.cxense.com^$domain=tn.com.ar
 @@||cdn.cxense.com^$domain=tn.com.ar


### PR DESCRIPTION
Attempting to fix issues with cookpad.com;

Reported issues on `https://cookpad.com/recipe/7267399` & `https://cookpad.com/recipe/7261406`

![downlo213ad](https://user-images.githubusercontent.com/1659004/183042329-9e61536b-b494-4dc9-921f-4df0ee5a824c.jpg)

Recently added to EL/EP:

https://github.com/easylist/easylist/commit/8b7bb425afd04c492ab1ef88b5ac182299d6754d