### PR TITLE
Debounce AMP cache URLs

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -364,5 +364,16 @@
     "prepend_scheme": "https",
     "action": "regex-path",
     "param": "^/navigation-tracking/(.*);.html$"
+  },
+  {
+    "include": [
+      "*://*.cdn.ampproject.org/c/s/*"
+    ],
+    "pref": "brave.de_amp.enabled",
+    "exclude": [
+    ],
+    "prepend_scheme": "https",
+    "action": "regex-path",
+    "param": "^/c/s/(.*)$"
   }
 ]

--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -336,6 +336,17 @@
   },
   {
     "include": [
+      "*://*.cdn.ampproject.org/c/s/*"
+    ],
+    "pref": "brave.de_amp.enabled",
+    "exclude": [
+    ],
+    "prepend_scheme": "https",
+    "action": "regex-path",
+    "param": "^/c/s/(.*)$"
+  },
+  {
+    "include": [
       "https://dev-pages.brave.software/navigation-tracking/error.html?*",
       "https://dev-pages.bravesoftware.com/navigation-tracking/error.html?*"
     ],
@@ -364,16 +375,5 @@
     "prepend_scheme": "https",
     "action": "regex-path",
     "param": "^/navigation-tracking/(.*);.html$"
-  },
-  {
-    "include": [
-      "*://*.cdn.ampproject.org/c/s/*"
-    ],
-    "pref": "brave.de_amp.enabled",
-    "exclude": [
-    ],
-    "prepend_scheme": "https",
-    "action": "regex-path",
-    "param": "^/c/s/(.*)$"
   }
 ]


### PR DESCRIPTION
Using the new `regex-path` action, debounce AMP cache URLs to the link embedded in the cache URL.

These AMP cache URLs look like https://www-nytimes-com.cdn.ampproject.org/c/s/www.nytimes.com/wirecutter/blog/burner-browser-to-hide-internet-searches/amp/
The regex is in the param: it captures the embedded URL after the `/c/s` in the path.
Add an `https` scheme to the beginning, because the embedded link doesn't have a scheme.
Only apply debouncing rule if the `de_amp` user pref is turned on.