### PR TITLE
Fix cnn.com anti-ad nag

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -369,7 +369,7 @@ topspeed.com##.txt-ad
 topspeed.com##.daily-vid-ad
 topspeed.com##.top-horizontal-ad-content
 ! 1st-party fix for cnn.com
-cnn.com##+js(aopw, window._sp_.writeCookie)
+cnn.com##+js(set, _sp_.msg.displayMessage, noopFunc)
 ! Anti-adblock message suncalc.org 
 ###adsGross1
 ###adsKlein


### PR DESCRIPTION
Fixes `cnn.com` Anti-adblock Nag (due to first-party not being blocked)

Checked video playback on `https://edition.cnn.com/2022/08/17/asia/north-korea-fires-cruise-missiles-intl-hnk/index.html` works with the patch.

![cnn-warning](https://user-images.githubusercontent.com/1659004/185066187-3905de89-0010-4b38-8d23-ff46aa9f8f9a.png)

