### PR TITLE
Debounce TurboPages URLs

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -347,6 +347,17 @@
   },
   {
     "include": [
+      "*://*.turbopages.org/*/s/*"
+    ],
+    "pref": "brave.de_amp.enabled",
+    "exclude": [
+    ],
+    "prepend_scheme": "https",
+    "action": "regex-path",
+    "param": "^/([^/]+)/s(/.*)$"
+  },
+  {
+    "include": [
       "https://dev-pages.brave.software/navigation-tracking/error.html?*",
       "https://dev-pages.bravesoftware.com/navigation-tracking/error.html?*"
     ],


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/22414

Using the new `regex-path` action, debounce TurboPages URLs to the link embedded in the cache URL. We need to use two regex capture groups for this, which was added by https://github.com/brave/brave-core/pull/14687.

These TurboPages URLs look like https://topnews--ru-ru.turbopages.org/topnews-ru.ru/s/2022/08/15/djoan-royling-prigrozili-smertu-za-podderjky-ryshdi-ty-sledyushaia/. Unfortunately there isn't much documentation on these, so it's possible there are other URLs out there that don't conform to the regex in the rule added by this PR. 

Add an `https` scheme to the beginning, because the embedded link doesn't have a scheme.
Only apply debouncing rule if the `de_amp` user pref is turned on.

For a given URL, we iterate over all debouncing rules and check if any of them apply. For release channels that don't have https://github.com/brave/brave-core/pull/14687 yet i.e. Beta and Release, the debouncer will just ignore this rule because of the check [here](https://github.com/brave/brave-core/commit/ee6eee131b95cb430d548a5ed6cee3534b7077ff#diff-19bb36033aacc98f6f730c5cbda666206d951a19f782c58fca555b7e44765ab3L190).

**Important**: we should change the text in the De-AMP pref. We need to address the fact that it's not just AMP caches that get debounced now. **EDIT**: this was done in https://github.com/brave/brave-core/pull/14752/. The Learn More link points to https://support.brave.com/hc/en-us/articles/8611298579981

OLD SCREENSHOT:

<img width="908" alt="image" src="https://user-images.githubusercontent.com/5284154/185535450-c2ed07d2-347c-4251-8cff-d738aadd6205.png">

NEW SCREENSHOT:

<img width="897" alt="image" src="https://user-images.githubusercontent.com/5284154/186278072-29017d11-821b-4c38-abb1-204e67eaf105.png">



# Testing
The following URLs should get debounced to the publisher URL, once the component update goes out:

1. https://topnews--ru-ru.turbopages.org/topnews-ru.ru/s/2022/08/15/djoan-royling-prigrozili-smertu-za-podderjky-ryshdi-ty-sledyushaia/
2. https://08-mchs-gov-ru.turbopages.org/08.mchs.gov.ru/s/deyatelnost/press-centr/novosti/4726459