### PR TITLE
Expand awin1 rule

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -119,6 +119,7 @@
   },
   {
     "include": [
+      "*://www.awin1.com/cread.php?*",
       "*://www.awin1.com/awclick.php?*"
     ],
     "exclude": [


### PR DESCRIPTION
Fixes #938

Sample URL: https://www.awin1.com/cread.php?awinmid=11388&awinaffid=97249&p=https%3A%2F%2Fwww.eventim.de%2Fnoapp%2Fevent%2F14873318%2F%3Faffiliate%3DBNO&clickref=257~103168679~~onaqfvagbja_jro