### PR TITLE
Add navigator.clipboard checks on webplatform.news

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -52,6 +52,8 @@ stats.brave.com#@#adsContent
 ! theatlantic.com anti-blocker filters
 ||theatlantic.blueconic.net$domain=theatlantic.com
 ||theatlantic.com/please-support-us^
+! navigator.clipboard checks
+webplatform.news##+js(aopw, navigator.clipboard)
 ! navigator.connection checks
 userlytics.com##+js(set, navigator.connection, {})
 ! youtube ads


### PR DESCRIPTION
Reported in various https://news.ycombinator.com/item?id=32614037 & https://www.ghacks.net/2022/08/27/websites-may-write-to-the-clipboard-in-chrome-without-user-permission/

Won't fix the issue, but fixes this specific test case