### PR TITLE
Test for multiple capture groups

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -389,5 +389,16 @@
     "prepend_scheme": "https",
     "action": "regex-path",
     "param": "^/navigation-tracking/(.*);.html$"
+  },
+  {
+    "include": [
+      "https://dev-pages.brave.software/navigation-tracking/regex-multiple-capture-groups/*",
+      "https://dev-pages.bravesoftware.com/navigation-tracking/regex-multiple-capture-groups/*"
+    ],
+    "exclude": [
+    ],
+    "prepend_scheme": "https",
+    "action": "regex-path",
+    "param": "^/navigation-tracking/regex-multiple-capture-groups/(.*)/test/(.*);.html$"
   }
 ]


### PR DESCRIPTION
 Example test URL that will be debounced: https://dev-pages.bravesoftware.com/navigation-tracking/regex-multiple-capture-groups/blog./test/brave.com;.html would go to https://blog.brave.com