### PR TITLE
Add Google Ads, analytics params

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -49,7 +49,12 @@
             "utm_term",
             "utm_umguk",
             "utm_userid",
-            "utm_viz_id"
+            "utm_viz_id",
+            "gbraid",
+            "wbraid",
+            "gclsrc",
+            "gclid",
+            "usqp"
         ]
     },
     {


### PR DESCRIPTION
Merged from https://github.com/AdguardTeam/AdguardFilters/blob/master/TrackParamFilter/sections/general_url.txt#L115

```
! Google ads/analytics
$removeparam=gbraid
$removeparam=wbraid
$removeparam=gclsrc
$removeparam=gclid
! Google AMP-analytics
$removeparam=usqp
```