### PR TITLE
Fixes https://filmybro.top/ (Anti-adblock)

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -528,7 +528,7 @@ twinkietown.com,chicago.suntimes.com,theverge.com,vox.com,eater.com,polygon.com,
 ! uBO-redirect work around nation.africa (Anti-adblock)
 @@||evolok.net/acd/api/$xmlhttprequest,domain=nation.africa
 ! uBO-redirect work pagead2.googlesyndication.com/pagead/js/adsbygoogle.js  
-@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=mangawt.com|sprintally.com|uploadbank.com|kitguru.net|imagetotext.info|jojo-themes.net|turreta.com|akwam.cc|scat.gold|ovagames.com|livehindustan.com|rp5.ru|onlinefreecourse.net|shineads.in|games-manuals.com|photopea.com|bluedrake42.com|filecr.com|arkadium.com|rockmods.net|paraphraser.io|sportsguild.net|imperfectcomic.com|invisibleoranges.com|nj1015.com|tasteofcountry.com|wyrk.com|xxlmag.com|ultimateclassicrock.com
+@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=filmybro.top|mangawt.com|sprintally.com|uploadbank.com|kitguru.net|imagetotext.info|jojo-themes.net|turreta.com|akwam.cc|scat.gold|ovagames.com|livehindustan.com|rp5.ru|onlinefreecourse.net|shineads.in|games-manuals.com|photopea.com|bluedrake42.com|filecr.com|arkadium.com|rockmods.net|paraphraser.io|sportsguild.net|imperfectcomic.com|invisibleoranges.com|nj1015.com|tasteofcountry.com|wyrk.com|xxlmag.com|ultimateclassicrock.com
 ! uBO-redirect work imasdk.googleapis.com/js/sdkloader/ima3.js
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$domain=gbnews.uk|livexlive.com
 ! uBO-redirect work securepubads.g.doubleclick.net/tag/js/gpt.js
@@ -557,6 +557,7 @@ akwam.cc##+js(acis, eval, ignielAdBlock)
 @@||wyze.com^$script,first-party
 ! uBO-redirect work around, Fixes BlockAdblock blocked via ||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,redirect-rule=googlesyndication_adsbygoogle.js:5
 @@||havoc-os.com^$ghide
+@@||filmybro.top^$ghide
 @@||fluttercampus.com^$ghide
 ! uBO-redirect work around faucetbtc.net 
 faucetbtc.net##+js(aopr, TestAd)


### PR DESCRIPTION
Removed bait filters;  https://github.com/easylist/easylist/commit/efd3960fa

resolves: https://community.brave.com/t/filmybro-top-adblock-detected/428886 