### PR TITLE
Fixes https://www.anycodings.com/1questions/28857/how-to-speed-up-writing-dataframe-to-s3-from-emr-pyspark-notebook

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -572,7 +572,7 @@ faucetbtc.net##+js(aopr, TestAd)
 @@||v1sts.me^$image
 ! uBO-redirect work around :5
 ! ||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,redirect-rule=googlesyndication_adsbygoogle.js:5,domain=~zipextractor.app
-@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=sevenjournals.com|movierulzhd.wtf|lifefeeling.in|itscybertech.com|anysubtitle.com|filedb.io|ibomma.bar|sunucutanitim.com|movierulzhd.art|anhdep24.com
+@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=anycodings.com|sevenjournals.com|movierulzhd.wtf|lifefeeling.in|itscybertech.com|anysubtitle.com|filedb.io|ibomma.bar|sunucutanitim.com|movierulzhd.art|anhdep24.com
 @@||sunucutanitim.com^$ghide
 ! chp anti-adblock
 fresheroffcampus.com,cizzyscripts.com##+js(aopw, startCheckingAdblock)


### PR DESCRIPTION
Fixes anti-adblock on `https://www.anycodings.com/1questions/28857/how-to-speed-up-writing-dataframe-to-s3-from-emr-pyspark-notebook` due to `redirect-rule:5` checks on the site.