### PR TITLE
GitHub Linguist support for adblock filters

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+brave-*.txt linguist-language=AdBlock linguist-detectable
+coin-*.txt linguist-language=AdBlock linguist-detectable

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -1,3 +1,4 @@
+[Adblock Plus 2.0; uBlock Origin]
 ||ntv.io^$third-party
 @@||adm.fwmrm.net^*/AdManager.js$domain=msnbc.com|sky.com|cnbc.com
 ||novately.com^$third-party

--- a/coin-miners.txt
+++ b/coin-miners.txt
@@ -1,4 +1,4 @@
-[Adblock Plus 2.0]
+[Adblock Plus 2.0; uBlock Origin]
 !-------------------------------------------------------------------------------
 ! Title: NoCoin Filter List
 ! Expires: 2 days (update frequency)


### PR DESCRIPTION
GitHub has been supporting adblock syntax highlighting since September 5th. This PR will help you turn it on.

Further informations:
- Syntax highlighter repository: https://github.com/ameshkov/VscodeAdblockSyntax
- How Linguist works: https://github.com/github/linguist/blob/master/docs/how-linguist-works.md
- Linguist overrides: https://github.com/github/linguist/blob/master/docs/overrides.md
- Linguist commit: https://github.com/github/linguist/commit/e78ef71af3600f96b9a40a06511ebbe3797e7401