### PR TITLE
More specific rule before

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -381,17 +381,6 @@
   },
   {
     "include": [
-      "https://dev-pages.brave.software/navigation-tracking/*",
-      "https://dev-pages.bravesoftware.com/navigation-tracking/*"
-    ],
-    "exclude": [
-    ],
-    "prepend_scheme": "https",
-    "action": "regex-path",
-    "param": "^/navigation-tracking/(.*);.html$"
-  },
-  {
-    "include": [
       "https://dev-pages.brave.software/navigation-tracking/regex-multiple-capture-groups/*",
       "https://dev-pages.bravesoftware.com/navigation-tracking/regex-multiple-capture-groups/*"
     ],
@@ -400,5 +389,16 @@
     "prepend_scheme": "https",
     "action": "regex-path",
     "param": "^/navigation-tracking/regex-multiple-capture-groups/(.*)/test/(.*);.html$"
+  },
+  {
+    "include": [
+      "https://dev-pages.brave.software/navigation-tracking/*",
+      "https://dev-pages.bravesoftware.com/navigation-tracking/*"
+    ],
+    "exclude": [
+    ],
+    "prepend_scheme": "https",
+    "action": "regex-path",
+    "param": "^/navigation-tracking/(.*);.html$"
   }
 ]


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/25259

Re-order the test rules for regex-path debounce action. We need this for the [debouncing test page](https://dev-pages.brave.software/navigation-tracking/debouncing.html). The current ordering of rules triggers a URL match on the test regex rule with only one capture group, which results in the test page erroring out. We need the test rule with two capture groups to be earlier in the list. 

I'd caught this during testing and had [updated the wiki](https://github.com/brave/brave-browser/wiki/Debouncing/_compare/f1560334491791d8dff30a5e40ce5da01660cc48...5044fe2d7fb4da57db468ab91e69e4f3abec23f8) as well, but somehow forgot to update the actual PR.