### PR TITLE
Remove "from" param from bandcamp.com

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -1,6 +1,17 @@
 [
     {
         "include": [
+            "*://*.bandcamp.com/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "from"
+        ]
+    },
+    {
+        "include": [
             "*://*.twitter.com/*"
         ],
         "exclude": [


### PR DESCRIPTION
Example URL: https://billorcutt.bandcamp.com/album/music-for-four-guitars?from=embed