### PR TITLE
Add clearbit trackers to IOS Slimlist

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -59,6 +59,9 @@ mobile.donanimhaber.com##.arareklam
 ||flux-cdn.com/plugin/common/analytics/
 ||cookpad-ads.com^
 /assets/ad/*
+! Cleabit tracking
+||clearbit.com^$3p
+||clearbitjs.com^
 ! tn.com.ar 
 @@||scdn.cxense.com^$domain=tn.com.ar
 @@||cdn.cxense.com^$domain=tn.com.ar


### PR DESCRIPTION
Include clearbit trackers into IOS slimlist.

Included in Easyprivacy:
https://github.com/easylist/easylist/commit/9a5fe8e002ab0bf45711d1c654f3634aff20b296