### PR TITLE
Debounce sherlock.scribblelive.com (fixes #972)

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -178,6 +178,7 @@
   },
   {
     "include": [
+      "*://sherlock.scribblelive.com/r?*",
       "*://*.engage.squarespace-mail.com/r?*",
       "*://engage.squarespace-mail.com/r?*",
       "*://goto.target.com/c/*",


### PR DESCRIPTION
See #972 for example URLs