### PR TITLE
Add cbs/paramountplus/nbc video ads fixes

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -517,6 +517,10 @@ canale.live##+js(no-setInterval-if, href)
 @@||s0.2mdn.net/instream/html5/ima3.js$script,domain=paramountplus.com|cbs.com
 @@||adservice.google.com/adsid/integrator.js$script,domain=paramountplus.com|cbs.com
 ||ad.doubleclick.net^$image,redirect=1x1.gif,domain=cbs.com|paramountplus.com
+! cbs.com,paramountplus.com,nbc (Video Ads fixes)
+cbs.com,paramountplus.com##+js(cbs)
+cbs.com,paramountplus.com##+js(cbs0)
+player.theplatform.com##+js(nbc)
 ! Anti-adblock: concert.io (vox sites)
 twinkietown.com,chicago.suntimes.com,theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com,mmafighting.com,racked.com,mmamania.com,funnyordie.com,riftherald.com##+js(nostif, adsBlocked)
 twinkietown.com,chicago.suntimes.com,theverge.com,vox.com,eater.com,polygon.com,sbnation.com,curbed.com,theringer.com,mmafighting.com,racked.com,mmamania.com,funnyordie.com,riftherald.com##.adblock-allowlist-messaging__wrapper


### PR DESCRIPTION
Paramount,cbs (and seperately nbc) have been rolling out video ads. Thanks to the community  (esp to Adguard) has got behind working around these ads. https://github.com/uBlockOrigin/uAssets/issues/14813 https://github.com/uBlockOrigin/uAssets/issues/14849#issuecomment-1248962943

Paramount/cbs: https://github.com/brave/adblock-resources/pull/84
nbc: https://github.com/brave/adblock-resources/pull/85 / https://github.com/brave/adblock-resources/pull/86