### PR TITLE
Add Yahoo referrer tags

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -65,7 +65,10 @@
             "wbraid",
             "gclsrc",
             "gclid",
-            "usqp"
+            "usqp",
+            "guccounter",
+            "guce_referrer",
+            "guce_referrer_sig"
         ]
     },
     {


### PR DESCRIPTION
As used by 

`https://www.yahoo.com/news/onlinecheckwriter-launches-cloud-based-check-031500636.html?guccounter=1&guce_referrer=aHR0cHM6Ly93d3cuemlsbW9uZXkuY29tLw&guce_referrer_sig=AQAAALtlTSPpvxhF3tU3Xj9MHxAREbMjIDHCnJrOfdbk5IOa7spOcvIboX5nUui4__vVfPBRax4kVk2t-8PYSBqci5bE_pq3-3kirOriIgR2-mgkMb3bX6MRt3GdKLteyh4QnaJG5ORbcd3Uod1YQ7L_ixl0EeFB90yxlw_66o5g51Jd`

`https://www.engadget.com/?guccounter=1`
`https://de.yahoo.com/?p=us&guccounter=1`

We can clean the urls of these, while still displaying the pages.
