### PR TITLE
Add Facebook event trackers (while facebook logins enabled)

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -145,6 +145,12 @@ igniteunmc.com##.preloader
 @@||connect.facebook.com^$tag=fb-embeds
 @@||facebook.com/plugins/$tag=fb-embeds
 @@||graph.facebook.com^$tag=fb-embeds
+! Facebook tracking events
+/fbevents-amd.js$important
+/fbevents.js$important
+/fbevents.min.js$important
+||facebook.com/tr/$important
+||facebook.com/tr?$important
 ! Twitter embeds
 @@||api.twitter.com^$tag=twitter-embeds
 @@||platform.twitter.com^$tag=twitter-embeds


### PR DESCRIPTION
With Facebook logins allowed in shields via brave://settings/socialBlocking this also enables a number of trackers

Included from Easyprivacy we can get around this. Blocking these won't cause any false positives since included already included.

$important is to counter the, while still keeping the facebook logins working when enabled.

```
@@||connect.facebook.net^$tag=fb-embeds
@@||connect.facebook.com^$tag=fb-embeds
@@||facebook.com/plugins/$tag=fb-embeds
@@||graph.facebook.com^$tag=fb-embeds
```