### PR TITLE
Add URL junk to clean

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -24,6 +24,17 @@
     },
     {
         "include": [
+            "*://techcrunch.com/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "tpcc"
+        ]
+    },
+    {
+        "include": [
             "*://*/*"
         ],
         "exclude": [

--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -41,6 +41,10 @@
 
         ],
         "params": [
+            "ss_campaign_id",
+            "ss_campaign_name",
+            "ss_campaign_sent_date",
+            "ss_source",
             "utm_ad",
             "utm_affiliate",
             "utm_brand",


### PR DESCRIPTION
Fixes #986 and #988.

https://kristenyarker.com/kristen-yarker-dietitian-blog/what-to-do-about-all-the-halloween-candy?ss_source=sscampaigns&ss_campaign_id=634fd949cd42ac187c833956&ss_campaign_name=Pumpkin+spice+recipes%2C+what+to+do+about+Halloween+candy%2C+new+vegan+cookbook&ss_campaign_sent_date=2022-10-21T18%3A25%3A52Z
https://techcrunch.com/2022/10/18/kanye-joins-the-ranks-of-arrogant-billionaires-buying-their-own-echo-chambers/?tpcc=TechCrunchPlusTwitter