### PR TITLE
Fix admiral anti-adblock. Converted to redirect

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -510,7 +510,7 @@ newscon.net###adblock-warning
 ! Admiral popups
 boston.com,britannica.com,download.mokeedev.com,freep.com,ijr.com,inquirer.net,legacy.com,nationalreview.com,nofilmschool.com,order-order.com,savvytime.com,techlicious.com,technicpack.net,thedraftnetwork.com,wrestlezone.com##+js(acis, document.createElement, admiral)
 ! Admiral Anti-adblock (gamerevolution.com/playstationlifestyle.net/probably others)
-@@||succeedscene.com/ads_*/ads.load.js$script
+||succeedscene.com/ads_*/ads.load.js$script,redirect=noop.js
 !! -- ported from uBO Annoyances filters (END)
 !! -- ported from Fanboy Annoyances filters (START)
 ! theblock.co (newsletter blocks, overlays)

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -509,6 +509,8 @@ katholisches.info##+js(nostif, pop)
 newscon.net###adblock-warning
 ! Admiral popups
 boston.com,britannica.com,download.mokeedev.com,freep.com,ijr.com,inquirer.net,legacy.com,nationalreview.com,nofilmschool.com,order-order.com,savvytime.com,techlicious.com,technicpack.net,thedraftnetwork.com,wrestlezone.com##+js(acis, document.createElement, admiral)
+! Admiral Anti-adblock (gamerevolution.com/playstationlifestyle.net/probably others)
+@@||succeedscene.com/ads_*/ads.load.js$script
 !! -- ported from uBO Annoyances filters (END)
 !! -- ported from Fanboy Annoyances filters (START)
 ! theblock.co (newsletter blocks, overlays)


### PR DESCRIPTION
Fixes anti-adblock on `gamerevolution.com`, `playstationlifestyle.net`

`filters/filters.txt:||succeedscene.com/ads_*/ads.load.js$script,redirect=noop.js`