### PR TITLE
Fixes empty spaces on arstechnica.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -734,6 +734,8 @@ computerbase.de#@#.js-consent.consent
 @@||ebay.com/ws/$xmlhttprequest
 ! api.ebay.com (https://community.brave.com/t/referral-not-getting-download-and-comfirmed/75898)
 @@||api.ebay.com^$xmlhttprequest,subdocument
+! Empty spaces due to shields/standard
+arstechnica.com##+js(rc, ad, , stay)
 ! Korean adblock (cosmetic) 
 newtoki64.com##.basic-banner
 newtoki64.com##.board-tail-banner


### PR DESCRIPTION
Reported: https://community.brave.com/t/empty-ads-placeholders-visible-on-ars-technica/441664

Blank spacing due to standard mode, got a work around to remove the `ad` element. Fixes empty spacing in standard blocking mode.