### PR TITLE
Improve cnn.com page display

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -736,6 +736,7 @@ computerbase.de#@#.js-consent.consent
 @@||api.ebay.com^$xmlhttprequest,subdocument
 ! Empty spaces due to shields/standard
 arstechnica.com##+js(rc, ad, , stay)
+cnn.com##+js(rc, ad-slot-header, , stay)
 ! Korean adblock (cosmetic) 
 newtoki64.com##.basic-banner
 newtoki64.com##.board-tail-banner


### PR DESCRIPTION
Fixes small delay in loading cnn.com, showing the header on load. Removes the div element showing the advert.