### PR TITLE
Fixes empty space on forbes.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -737,6 +737,7 @@ computerbase.de#@#.js-consent.consent
 ! Empty spaces due to shields/standard
 arstechnica.com##+js(rc, ad, , stay)
 cnn.com##+js(rc, ad-slot-header, , stay)
+forbes.com##+js(rc, top-ad-container, body, stay)
 ! Korean adblock (cosmetic) 
 newtoki64.com##.basic-banner
 newtoki64.com##.board-tail-banner


### PR DESCRIPTION
Fixes empty space on top header on `https://www.forbes.com/sites/brianbushard/2022/10/29/global-food-crisis-back-on-russia-bails-from-grain-deal-blaming-ukraine-drone-attack/`