### PR TITLE
Adjust to cover more than body

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -737,7 +737,7 @@ computerbase.de#@#.js-consent.consent
 ! Empty spaces due to shields/standard
 arstechnica.com##+js(rc, ad, , stay)
 cnn.com##+js(rc, ad-slot-header, , stay)
-forbes.com##+js(rc, top-ad-container, body, stay)
+forbes.com##+js(rc, top-ad-container, , stay)
 ! Korean adblock (cosmetic) 
 newtoki64.com##.basic-banner
 newtoki64.com##.board-tail-banner


### PR DESCRIPTION
Just an adjustment from https://github.com/brave/adblock-lists/pull/1000 to cover more, `<body>`  isn't enough to to remove the empty space on forbes.