### PR TITLE
Add zillow's rtoken

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -46,6 +46,17 @@
     },
     {
         "include": [
+            "*://www.zillow.com/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "rtoken"
+        ]
+    },
+    {
+        "include": [
             "*://*/*"
         ],
         "exclude": [


### PR DESCRIPTION
https://www.zillow.com/homedetails/747-S-Dearborn-St-Chicago-IL-60605/2060831791_zpid/?utm_source=email&utm_medium=email&utm_campaign=emo-SendToFriendHDP-image&rtoken=0137679e-abe0-435f-8ff9-e4e7bd9d7308~X1-ZU1685qgvl91czt_aovt3