### PR TITLE
Added new params to clear at twitter.com

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -20,6 +20,7 @@
         "params": [
             "cxt",
             "ref_src",
+            "ref_url",
             "s",
             "t"
         ]

--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -18,6 +18,8 @@
 
         ],
         "params": [
+            "cxt",
+            "ref_src",
             "s",
             "t"
         ]


### PR DESCRIPTION
`cxt` is added when any specific post is clicked from the user's page.
`ref_src` was added for me yesterday, with the value `twsrc%5Etfw`, can't reproduce this now.