### PR TITLE
Added new params to clear at imdb.com

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -12,6 +12,17 @@
     },
     {
         "include": [
+            "*://*.imdb.com/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "ref_"
+        ]
+    },
+    {
+        "include": [
             "*://*.twitter.com/*"
         ],
         "exclude": [

--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -18,6 +18,12 @@
 
         ],
         "params": [
+            "pf_rd_m",
+            "pf_rd_p",
+            "pf_rd_r",
+            "pf_rd_s",
+            "pf_rd_t",
+            "pf_rd_i",
             "ref_"
         ]
     },


### PR DESCRIPTION
Go to imdb.com, search for anything, the url gets `ref_=nv_sr_sm` appended and every result has `ref_=fn_al_tt_X` in the url, where X is the index of the result. There are many other values passed in other contexts.

I don't know if the idea is to only remove tracking-related parameters, but as far as I'm concerned, a clean url is one with anything extraneous removed.

E.g.
1. Go to imdb.com
2. Search for "brave"
3. The url is https://www.imdb.com/find?q=brave&ref_=nv_sr_sm
4. Click on the first result
5. The url is https://www.imdb.com/title/tt1217209/?ref_=fn_al_tt_1

Or go to imdb.com and click on any link. Currently the first one that comes up is https://www.imdb.com/video/vi2508703001/?listId=ls053181649&ref_=hm_hp_i_6.