### PR TITLE
Add jiocinema.com anti-adblock

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -586,6 +586,7 @@ akwam.cc##+js(acis, eval, ignielAdBlock)
 @@||wyze.com^$script,first-party
 ! uBO-redirect work around, Fixes BlockAdblock blocked via ||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,redirect-rule=googlesyndication_adsbygoogle.js:5
 @@||havoc-os.com^$ghide
+@@||jiocinema.com^$ghide
 @@||compuhoy.com^$ghide
 @@||spigotunlocked.org^$ghide
 @@||filmybro.top^$ghide


### PR DESCRIPTION
Fixes anti-adblock being reported on `jiocinema.com`. Cosmetic checks.