### PR TITLE
Fix empty spaces on cultofmac.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -749,6 +749,7 @@ davidstea.com,ibotta.com,polovniautomobili.com##+js(rc, async-hide, , stay)
 ! api.ebay.com (https://community.brave.com/t/referral-not-getting-download-and-comfirmed/75898)
 @@||api.ebay.com^$xmlhttprequest,subdocument
 ! Empty spaces due to shields/standard
+cultofmac.com##+js(rc, ezoic-ad, , stay)
 theregister.com##+js(rc, adun, , stay)
 9gag.com##+js(rc, block-ad, , stay)
 businessinsider.com,insider.com##+js(rc, l-ad, , stay)


### PR DESCRIPTION
Fix empty spaces showing on `https://www.cultofmac.com/794441/slow-horses-season-2-review-apple-tv-recap/` (may require a few refreshes)