### PR TITLE
Add MailerLite parameters

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -83,6 +83,8 @@
 
         ],
         "params": [
+            "ml_subscriber",
+            "ml_subscriber_hash",
             "mc_cid",
             "ss_campaign_id",
             "ss_campaign_name",


### PR DESCRIPTION
Was done in the global filter in https://github.com/brave/brave-browser/issues/17507, but let's add it here to catch same-origin requests too (until we tweak copy-clean-urls to always apply the main filter).

e.g. https://www.tandfonline.com/doi/abs/10.1080/15368378.2021.1881866?ml_subscriber=1695975887331137303&ml_subscriber_hash=d1c0