### PR TITLE
Fix regex filters on animixplay.to

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -760,6 +760,10 @@ forbes.com##+js(rc, top-ad-container, , stay)
 cnet.com##+js(rc, c-adSkyBox, , stay)
 cnet.com##+js(rc, c-adSkyBox_expanded, , stay)
 reuters.com##+js(rc, ad-slot__container__FEnoz, , stay)
+! Regex fix (counter complex ubo regex)
+$script,3p,domain=animixplay.to
+@@||disqus.com/count-data.js$script,domain=animixplay.to
+@@||disqus.com/embed.js$script,domain=animixplay.to
 ! Korean adblock (cosmetic) 
 newtoki64.com##.basic-banner
 newtoki64.com##.board-tail-banner


### PR DESCRIPTION
From a discussion on https://community.brave.com/t/forced-website-redirect-are-still-pushing-through/450369/

Because of lack of complex regex in uBO, some sites will not block randomised adservers. Best fix would be to just block these specific 3p scripts on a site-by site basis. 

`https://animixplay.to/v1/blue-lock/ep9` 