### PR TITLE
Add animepahe.ru regex

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -761,7 +761,7 @@ cnet.com##+js(rc, c-adSkyBox, , stay)
 cnet.com##+js(rc, c-adSkyBox_expanded, , stay)
 reuters.com##+js(rc, ad-slot__container__FEnoz, , stay)
 ! Regex fix (counter complex ubo regex)
-$script,3p,domain=animixplay.to
+$script,3p,domain=animixplay.to|animepahe.ru
 @@||disqus.com/count-data.js$script,domain=animixplay.to
 @@||disqus.com/embed.js$script,domain=animixplay.to
 ! Korean adblock (cosmetic) 


### PR DESCRIPTION
Based on previous reports; https://community.brave.com/t/animepahe-com-ad-appears/432668

animepahe.ru has randomised servers, should be added here also.