### PR TITLE
Fix cookie check on pepper.pl

### DIFF
--- a/brave-lists/brave-cookie-specific.txt
+++ b/brave-lists/brave-cookie-specific.txt
@@ -1,2 +1,6 @@
 ! Cookie-snippet list
 ! Used with cookie snippets, set-local-storage-item, set-cookie, set-cookie-reload, set-ession-storage-item
+! Test filter 
+pepper.pl##+js(brave-set-cookie, cookie_policy_agreement, 3)
+pepper.pl##.popover--layout-fixed-bottomSheet
+pepper.pl##.zIndex--modal.popover-cover


### PR DESCRIPTION
Test filter on `pepper.pl`  

Remove cosmetic and set cookie. Allows user to "Thumbs up" and "Tick". https://www.pepper.pl/promocje/maskotka-fisher-price-kroliczek-usypianka-zasnij-ze-mna-614075

There are more mirrors of this site, will be rolled out more. Just a test filter