### PR TITLE
fix rbs.ta36.com anti-adb

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -972,6 +972,7 @@ livejournal.com##+js(aopr, webpackJsonpSSPjs)
 ||proparm.jp^$third-party
 ||i2ad.jp^$third-party
 ! Japanese specific rules below (temporarily)
+ta36.com##+js(aopr, adsBlocked)
 /ad/alliance_
 /loadPopIn.
 /itsads/*

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -972,7 +972,7 @@ livejournal.com##+js(aopr, webpackJsonpSSPjs)
 ||proparm.jp^$third-party
 ||i2ad.jp^$third-party
 ! Japanese specific rules below (temporarily)
-ta36.com##+js(aopr, adsBlocked)
+9ketsuki.info,ta36.com##+js(aopr, adsBlocked)
 /ad/alliance_
 /loadPopIn.
 /itsads/*


### PR DESCRIPTION
This can not be addressed in AG Japanese as already addressed by AG Base in accordance with AG policy.

![ta36](https://user-images.githubusercontent.com/58900598/208250175-9e32c3b1-1700-4283-a234-75bb5f2a1514.png)

I have almost no idea where to put the rule, tell me if it's wrong place. You'll need the same fix for all or most of CHP sites as uBf relies on $redirect-rule not supported by Brave to counter them.