### PR TITLE
Fixes signin issue with blockclubchicago.org (ios)

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -48,7 +48,7 @@ mobile.donanimhaber.com##.arareklam
 @@||starbucks.com/app-assets/
 @@||app.starbucks.com/weblx/static/$domain=starbucks.com
 ! google fixes
-@@||googletagmanager.com/gtm.js$domain=rednoseday.org|verygoodvault.com|uqr.to
+@@||googletagmanager.com/gtm.js$domain=blockclubchicago.org|rednoseday.org|verygoodvault.com|uqr.to
 @@||googletagmanager.com/gtag/$domain=rednoseday.org|verygoodvault.com
 ! Foxnews/business
 @@||js.taplytics.com/jssdk/$domain=foxnews.com|foxbusiness.com


### PR DESCRIPTION
Visiting `https://blockclubchicago.org/2022/12/19/northwest-side-teen-gets-surprise-quinceanera-thanks-to-taft-high-school-fulfilling-mothers-dream/` Doesn't allow signin to work correctly. I suspect its related to GTM, can revisit this issue if still not resolved (a few trackers on the site).

- Putting in a fake email into the email address, should get a warning. Nothing received. 

![unnamed-iphone](https://user-images.githubusercontent.com/1659004/208773681-08f66399-ee54-48c4-b52a-277623740e22.jpg)

