### PR TITLE
Address https://github.com/brave/brave-browser/issues/27542

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -22,6 +22,8 @@ search.brave.com#@#+js(no-fetch-if, body:browser)
 @@||stats.brave.com^$first-party
 ! community.brave.com
 @@||community.brave.com^$ghide
+! Remove google login popup nag
+||accounts.google.com/gsi/iframe/select$subdocument,third-party
 ! vendors serving video ads and tracking via proxied requests
 ||vidazoo.com/aggregate^$third-party
 ||vidazoo.com/proxy^$third-party


### PR DESCRIPTION
Removes google signin popup. Still allows logins or signups.

 Filter merged in from https://github.com/easylist/easylist/blob/master/fanboy-addon/fanboy_annoyance_thirdparty.txt#L400

Filter was adjusted to avoid false positives on a few sites. https://github.com/easylist/easylist/commit/38891e2b12256204d90d11a2940a2a67a61a18af