### PR TITLE
Remove mod param from WallStreet Journal

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -55,6 +55,17 @@
     },
     {
         "include": [
+            "*://www.wsj.com/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "mod"
+        ]
+    },
+    {
+        "include": [
             "*://actionnetwork.org/petitions/*"
         ],
         "exclude": [


### PR DESCRIPTION
Example URL: https://www.wsj.com/articles/google-and-metas-advertising-dominance-fades-as-tiktok-netflix-emerge-11672711107?mod=djemCMOToday