### PR TITLE
Add debounce rule for AMP Viewer URLs

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -388,6 +388,17 @@
   },
   {
     "include": [
+      "*://www.google.com/amp/s/*"
+    ],
+    "pref": "brave.de_amp.enabled",
+    "exclude": [
+    ],
+    "prepend_scheme": "https",
+    "action": "regex-path",
+    "param": "^/amp/s/(.*)$"
+  },
+  {
+    "include": [
       "https://dev-pages.brave.software/navigation-tracking/error.html?*",
       "https://dev-pages.bravesoftware.com/navigation-tracking/error.html?*"
     ],


### PR DESCRIPTION
These used to be auto-redirected on mainframe navigations.

Example URL: https://www.google.com/amp/s/amp.theguardian.com/football/2022/dec/29/pele-brazil-dies-football-legend