### PR TITLE
Adjust to cosmetic hiding on google login nag

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -23,10 +23,7 @@ search.brave.com#@#+js(no-fetch-if, body:browser)
 ! community.brave.com
 @@||community.brave.com^$ghide
 ! Remove google login popup nag
-||accounts.google.com/gsi/iframe/select$subdocument,third-party
-! google login popup nag
-@@||accounts.google.com/gsi/iframe/select$subdocument,domain=vrbo.com
-vrbo.com###credential_picker_container
+###credential_picker_container
 ! vendors serving video ads and tracking via proxied requests
 ||vidazoo.com/aggregate^$third-party
 ||vidazoo.com/proxy^$third-party


### PR DESCRIPTION
Network block on `accounts.google.com/gsi/iframe/select$subdocument,third-party` seems to a bit problematic, cosmetic hiding the google login nag seems to be a safier approach.  

Fixes occasional login issue on pinterest.