### PR TITLE
Add streaklinks debounce

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -382,7 +382,7 @@
     "exclude": [
     ],
     "action": "regex-path",
-    "param": "^/([^/]+)/s(/.*)$"
+    "param": "^/[^/]+/(.*)$"
   },
   {
     "include": [

--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -381,9 +381,8 @@
     ],
     "exclude": [
     ],
-    "prepend_scheme": "https",
     "action": "regex-path",
-    "param": "^/streaklinks.com/(.*)$"
+    "param": "^\/[^\/]+\/(.*)$"
   },
   {
     "include": [

--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -377,6 +377,16 @@
   },
   {
     "include": [
+      "*://streaklinks.com/*"
+    ],
+    "exclude": [
+    ],
+    "prepend_scheme": "https",
+    "action": "regex-path",
+    "param": "^/streaklinks.com/(.*)$"
+  },
+  {
+    "include": [
       "*://*.turbopages.org/*/s/*"
     ],
     "pref": "brave.de_amp.enabled",

--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -382,7 +382,7 @@
     "exclude": [
     ],
     "action": "regex-path",
-    "param": "^\/[^\/]+\/(.*)$"
+    "param": "^/([^/]+)/s(/.*)$"
   },
   {
     "include": [


### PR DESCRIPTION
Was discussed in https://old.reddit.com/r/uBlockOrigin/comments/10kryo7/streaklinkscom/

From the example:

`https://streaklinks.com/BQ_bCtlcnH91IqmN1QFG0nUm/https%3A%2F%2Fwww.congress.gov%2Fbill%2F117th-congress%2Fhouse-bill%2F6707`