### PR TITLE
Remove original_referer from LinkedIn links

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -88,6 +88,17 @@
     },
     {
         "include": [
+            "*://www.linkedin.com/in/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "original_referer"
+        ]
+    },
+    {
+        "include": [
             "*://*/*"
         ],
         "exclude": [


### PR DESCRIPTION
Sample URL: https://www.linkedin.com/in/fmarier/?original_referer=