### PR TITLE
Remove YouTube mobile URL decorations

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -99,6 +99,21 @@
     },
     {
         "include": [
+            "*://*.youtube.com/watch?*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "embeds_euri",
+            "embeds_loader_url_for_pings",
+            "embeds_origin",
+            "feature",
+            "source_ve_path"
+        ]
+    },
+    {
+        "include": [
             "*://*/*"
         ],
         "exclude": [


### PR DESCRIPTION
Sample URLs:

https://m.youtube.com/watch?v=OJzH-nPeaCw&embeds_euri=https%3A%2F%2Fnaitreetgrandir.com%2F&source_ve_path=MjM4NTE&feature=emb_title https://m.youtube.com/watch?time_continue=2842&v=p6lGS7FZOPQ&source_ve_path=MTM5MTE3LDM2ODQyLDEzOTExNywyMzg1MQ&feature=emb_title https://m.youtube.com/watch?time_continue=1&v=J2q72-ow4u8&embeds_loader_url_for_pings=aHR0cHM6Ly9rb3JpbnRob3N0di5nci8lY2YlODAlY2YlODQlY2YlOGUlY2YlODMlY2UlYjctJWNlJWIyJWNmJTgxJWNlJWFjJWNmJTg3JWNmJTg5JWNlJWJkLSVjZiU4MyVjZiU4NCVjZSViNyVjZSViZC0lY2UlYjElY2UlYjg&source_ve_path=Mjg2NjM&feature=emb_logo&ab_channel=Korinthostv.gr https://m.youtube.com/watch?time_continue=36&v=_hIstgX595Q&embeds_loader_url_for_pings=aHR0cHM6Ly9zdHJvbmdkYWxsYXMuY29tLw&embeds_origin=aHR0cHM6Ly93d3cueW91dHViZS5jb20&source_ve_path=MjM4NTE&feature=emb_title