### PR TITLE
Filter a few Amazon URL decorations

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -1,6 +1,40 @@
 [
     {
         "include": [
+            "*://*.amazon.ae/*",
+            "*://*.amazon.ca/*",
+            "*://*.amazon.cn/*",
+            "*://*.amazon.co.jp/*",
+            "*://*.amazon.co.uk/*",
+            "*://*.amazon.com/*",
+            "*://*.amazon.com.au/*",
+            "*://*.amazon.com.be/*",
+            "*://*.amazon.com.br/*",
+            "*://*.amazon.com.mx/*",
+            "*://*.amazon.com.tr/*",
+            "*://*.amazon.de/*",
+            "*://*.amazon.eg/*",
+            "*://*.amazon.es/*",
+            "*://*.amazon.fr/*",
+            "*://*.amazon.in/*",
+            "*://*.amazon.it/*",
+            "*://*.amazon.nl/*",
+            "*://*.amazon.pl/*",
+            "*://*.amazon.sa/*",
+            "*://*.amazon.se/*",
+            "*://*.amazon.sg/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "crid",
+            "qid",
+            "sprefix"
+        ]
+    },
+    {
+        "include": [
             "*://*.bandcamp.com/*"
         ],
         "exclude": [


### PR DESCRIPTION
Adguard has a [lot of rules related to Amazon](https://github.com/AdguardTeam/FiltersRegistry/blob/a5e70b74a5255ff8a36f1cc64f8ee43724e6a692/filters/filter_17_TrackParam/filter.txt#L1018-L1058), but they [disabled many of them](https://github.com/AdguardTeam/FiltersRegistry/blob/a5e70b74a5255ff8a36f1cc64f8ee43724e6a692/filters/filter_17_TrackParam/filter.txt#L1005-L1016) because of breakage.

Using this sample URL:
https://www.amazon.ca/Practical-Doomsday-Users-Guide-World/dp/1718502125/ref=sr_1_1?crid=19DBA6NX9H70U&keywords=Practical+Doomsday%3A+A+User%27s+Guide+to+the+End+of+the+World&qid=1675109036&sprefix=practical+doomsday+a+user%27s+guide+to+the+end+of+the+world%2Caps%2C392&sr=8-1

the only parameter they would strip out is `qid`. However, they don't list `crid` and `sprefix` anywhere in their rules and so perhaps we can clean that one too in our filter (until we hear about problems or see Adguard include them one way or another).

The rest of the parameters from my sample URL are all in Adguard's disabled rules, so we should omit them too.

In terms of host matching, Adguard using a `amazon.*` pattern which unfortunately matching irrelevant things like `amazon.example.com`. I've instead narrowed it down to just the [valid domains according to Wikipedia](https://en.wikipedia.org/wiki/Amazon_(company)#Amazon.com).
