### PR TITLE
Exempt the Twitter redirector from URL modification

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -32,7 +32,7 @@
             "*://*.twitter.com/*"
         ],
         "exclude": [
-
+            "*://*.twitter.com/i/redirect?*"
         ],
         "params": [
             "cxt",


### PR DESCRIPTION
Sample URL that breaks when `t` is removed:

https://twitter.com/i/redirect?url=https%3A%2F%2Ftwitter.com%2Fmask_3dcg%2Fstatus%2F1617094871818596354%3Fcn%3DZmxleGlibGVfcmVjcw%253D%253D%26refsrc%3Demail&t=1+1674400145805&cn=ZmxleGlibGVfcmVjcw%3D%3D&sig=5d71ce9ef69b11a9f5e9ad0489166c17e89947ce&iid=93b0f359fc6f4fe795753cb5475c6801&uid=1360753837754048512&nid=244+276893697

See https://github.com/brave/brave-browser/issues/28184.