### PR TITLE
Update google signin popups

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -24,6 +24,10 @@ search.brave.com#@#+js(no-fetch-if, body:browser)
 @@||community.brave.com^$ghide
 ! Remove google login popup nag
 ###credential_picker_container
+###credential_picker_iframe
+! Google signin popup (fixes)
+thebetterindia.com##.vspl__gtap-notification-content
+thebetterindia.com##.vspl__gtap-notification-overlay
 ! vendors serving video ads and tracking via proxied requests
 ||vidazoo.com/aggregate^$third-party
 ||vidazoo.com/proxy^$third-party


### PR DESCRIPTION
Sync: `###credential_picker_iframe` from: https://github.com/easylist/easylist/commit/5655c99ca89e7b64851e662463a410ce7d439bd9

Also Override the google login nag requirement for thebetterindia.com



