### PR TITLE
Medium email campaign source qs remove

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -213,5 +213,16 @@
             "brave_testing1",
             "brave_testing2"
         ]
-    }
+    },
+    {
+        "include": [
+            "*://medium.com/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "source"
+        ]
+    },
 ]

--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -148,6 +148,17 @@
     },
     {
         "include": [
+            "*://medium.com/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "source"
+        ]
+    },
+    {
+        "include": [
             "*://*/*"
         ],
         "exclude": [
@@ -213,16 +224,5 @@
             "brave_testing1",
             "brave_testing2"
         ]
-    },
-    {
-        "include": [
-            "*://medium.com/*"
-        ],
-        "exclude": [
-
-        ],
-        "params": [
-            "source"
-        ]
-    },
+    }
 ]


### PR DESCRIPTION
FIX #1079 

Removes email account identifying link in urls accessed from Medium Email Digest article links