### PR TITLE
Clean Kickstarter and Reddit URLs

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -159,6 +159,17 @@
     },
     {
         "include": [
+            "*://*.kickstarter.com/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "ref"
+        ]
+    },
+    {
+        "include": [
             "*://*/*"
         ],
         "exclude": [

--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -170,6 +170,17 @@
     },
     {
         "include": [
+            "*://*.reddit.com/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "context"
+        ]
+    },
+    {
+        "include": [
             "*://*/*"
         ],
         "exclude": [


### PR DESCRIPTION
Sample URLs:

- https://www.reddit.com/r/movies/comments/113zdzt/bruce_willis_diagnosed_with_dementia/j8vliut/?context=1
- https://www.reddit.com/r/Vanced/comments/tdazfr/discontinuation_of_the_vanced_project/?utm_source=share&utm_medium=web2x&context=3
- https://www.reddit.com/r/newzealand/comments/11785hp/here_it_is_57_years_of_nz_housing_unaffordability/?context=3
- https://www.kickstarter.com/year/2016?ref=sidebar#Welcome
- https://www.kickstarter.com/projects/horribleguild/the-queens-dilemma?ref=2s4gcm
- https://www.kickstarter.com/projects/wordforgegames/sas-rogue-regiment/posts/3723085?ref=project_update_registered_users_tout_1