### PR TITLE
Fixes blank page on https://www.denver.org/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -174,6 +174,8 @@ igniteunmc.com##.preloader
 /fbevents.min.js
 ||facebook.com/tr/
 ||facebook.com/tr?
+! Facebook fixes
+@@||connect.facebook.net^$script,domain=denver.org
 ! Twitter embeds
 @@||api.twitter.com^$tag=twitter-embeds
 @@||platform.twitter.com^$tag=twitter-embeds


### PR DESCRIPTION
Opening https://www.denver.org/denver-restaurant-week/listing/sunday-vinyl/36028/ causes blank page issues due to facebook blocking.  Rather than having a user disable the facebook blocking globally to resolve this, we'll do this on per-site basis.