### PR TITLE
Removed megaup anti-adblock filter

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -584,7 +584,6 @@ theblock.co##.modal-container
 theblock.co##body:style(overflow: auto !important;)
 !! -- ported from Fanboy Annoyances filters (END)
 !! -- ported from uBO Quick Fixes --
-megaup.net##.metaRedirectWrapperBottomAds > div > a > img:style(margin-top: 10000px !important; pointer-events: none !important;)
 canale.live##+js(set-constant, moneyAbovePrivacyByvCDN, true)
 canale.live##+js(no-setInterval-if, href)
 ! luscious. net anti adb


### PR DESCRIPTION
Seems to be used as a bait now on the website, so removing. 

Partially address https://old.reddit.com/r/brave_browser/comments/11cja57/brave_adblock_gets_detected/