### PR TITLE
Fix connatix.com blocking

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -954,6 +954,10 @@ cube365.net##+js(aopr, bootbox.alert)
 /outbrain/base?
 /outbrain?
 /outbrainAd.
+! https://github.com/uBlockOrigin/uAssets/commit/835b74295e8550d75cc9e36e81084908724f129a
+||connatix.com^$3p,domain=~accuweather.com|~elnuevoherald.com|~loot.tv|~miamiherald.com,important
+@@||cd.connatix.com/connatix.player.js^$script,badfilter
+@@||cds.connatix.com/p/*/connatix.player.dc.js^$script,badfilter
 ||outbrainimg.com^$third-party
 ! Easyprivacy Notifcations (For ios)
 ||accengage.net^$third-party


### PR DESCRIPTION
https://github.com/uBlockOrigin/uAssets/commit/835b74295e8550d75cc9e36e81084908724f129a

Due to this commit, we're allowing all `cd.connatix.com/connatix.player.js` to run.  Bad for privacy: https://publicwww.com/websites/%22connatix.com%22/

Was hoping this commit would be tuned or removed (and handled by Easylist) but no aggreement between list authors.

