### PR TITLE
Fix https://lnkd.in/interstitial

### DIFF
--- a/brave-lists/brave-social.txt
+++ b/brave-lists/brave-social.txt
@@ -9,7 +9,7 @@
 ||api.twitter.com^$third-party,domain=~tweetdeck.com|~twitter.com|~twitter.jp
 ||platform.twitter.com^$third-party,domain=~tweetdeck.com|~twitter.com|~twitter.jp
 ! Linkedin
-||licdn.com^$third-party,domain=~linkedin.com
+||licdn.com^$third-party,domain=~linkedin.com|~lnkd.in
 ||linkedin.com^$third-party
 ! Outbrain
 ||outbrain.com^$third-party,domain=~sphere.com


### PR DESCRIPTION
Reported in https://community.brave.com/t/website-broken-because-assets-getting-blocked/473280/3

https://lnkd.in/interstitial is currently broken due our current linkedin rule. Should allow the page to display correctly.

Test link: https://lnkd.in/interstitial