### PR TITLE
Fixes am3t9s.net debounce

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -232,7 +232,8 @@
       "*://*.vzew.net/c/*",
       "*://*.qflm.net/c/*",
       "*://*.rfvk.net/c/*",
-      "*://redirect.viglink.com/*"
+      "*://redirect.viglink.com/*",
+      "*://*.am3t9s.net/*"
     ],
     "exclude": [
     ],


### PR DESCRIPTION
Added debounce for: `https://dsw.am3t9s.net/c/256585/315836/4837?subId1=FN--&u=https%3A%2F%2Fwww.dsw.com%2Fen%2Fus%2Fproduct%2Fdrew-bon-voyage-sandal%2F518930`