### PR TITLE
Fix message/overlay on spiegel.de

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -241,6 +241,8 @@ gap.com,ibanking-services.com,connectonebank.com,tescobank.com,sbisec.co.jp,tsb.
 ||buy.tinypass.com^$domain=slate.com|thehindu.com
 @@||id.tinypass.com^$domain=slate.com
 wetter.com,spiegel.de##[referrerpolicy]
+! Warning message
+||spiegel.de/public/shared/generated/3rdparty/js/msg_without_detection.
 !! -- ported from uBO Annoyances filters (START)
 ! Anti-adblock message codehelppro.com
 @@||codehelppro.com^$ghide


### PR DESCRIPTION
Anti-adblock message on spiegel.de

![spiegel-schot](https://user-images.githubusercontent.com/1659004/225447584-96588027-f2c9-4dad-af0a-18931e23de65.png)
