### PR TITLE
Fix reviews on jcrec.om

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -182,6 +182,8 @@ igniteunmc.com##.preloader
 ! LinkedIn in embeds
 @@||licdn.com^$tag=linked-in-embeds
 @@||platform.linkedin.com^$tag=linked-in-embeds
+! jcrew.com reviews not showing
+jcrew.com##+js(cookie-remover.js, dns_cookie)
 ! Fix sign in icon on https://app.mysms.com/#login
 @@||developers.google.com/identity/$image,domain=mysms.com
 ! vresp.com (https://community.brave.com/t/cant-see-captcha-on-form/67187)


### PR DESCRIPTION
Fix reviews not showing. removing this cookie will let reivews will show.

1. Clearing cookies on https://www.jcrew.com/p/mens/categories/clothing/shirts/secret-wash/secret-wash-cotton-poplin-shirt/BJ706 will let the reviews show near the bottom.
2. Then refreshing the same page, the reviews are gone. And no longer show after a few refreshes.

Doesn't affect Safari or Firefox/Strict.  Disabling shields has no affect. Or using brave-fix()

The cookie causing the issue is `dns_cookie` 