### PR TITLE
Fix debounce on click.redditmail.com

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -381,7 +381,15 @@
   },
   {
     "include": [
-      "*://click.redditmail.com/*",
+      "*://click.redditmail.com/*"
+    ],
+    "exclude": [
+    ],
+    "action": "regex-path",
+    "param": "^/CL0/([^/]+)/.*$"
+  },
+  {
+    "include": [
       "*://streaklinks.com/*"
     ],
     "exclude": [

--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -381,6 +381,7 @@
   },
   {
     "include": [
+      "*://click.redditmail.com/*",
       "*://streaklinks.com/*"
     ],
     "exclude": [


### PR DESCRIPTION
Fixes Debounce of `https://click.redditmail.com/CL0/https:%2F%2Fwww.reddit.com%2Fr%2FCryptoCurrency%2Fcomments%2F11uycvy%2Fcoinbase_is_looking_for_a_new_overseas%2F%3F$deep_link=true%26correlation_id=3fa0d687-770e-46d1-b901-f66d87c1f9f2%26post_fullname=t3_11uycvy%26post_index=2%26ref=email_digest%26ref_campaign=email_digest%26ref_source=email%26utm_content=post_title/1/01000186f87ebc5b-bd2b745a-9ccd-43c3-b088-013e454697ca-000000/AEzOEmcrhWz3Rlpr0tnYU2bQWItWlElct4rU3qgL8XU=292`

