### PR TITLE
Fix subscribing to https://epaper.thehindu.com/

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -240,7 +240,7 @@ uptostream.com,tirexo.lol##+js(acis, window.a)
 gap.com,ibanking-services.com,connectonebank.com,tescobank.com,sbisec.co.jp,tsb.co.uk,tiaabank.com,tiaa.org,directpay.irs.gov,t-mobile.com,simplii.com,citibank.com.au,fisglobal.com,adp.com,skyid.sky.com,onehealthcareid.com,betfair.es,betfair.com.au,paddypower.com,healthsafe-id.com,canadiantire.ca,sportchek.ca,ingbank.pl,optumbank.com,mbna.ca,tdcommercialbanking.com,coastcapitalsavings.com,my100bank.com,royalbank.com,td.com,spectrum.net,quicken.com,citibankonline.com,bmo.com,eftps.gov,optumbank.com,samsclub.com,intuit.com,betfair.com,sofi.com,53.com,ameriprise.com,cibc.com,citi.com,discover.com,fidelity.com,homedepot.com,sciencedirect.com,ebay.com,ebay-kleinanzeigen.de,tdbank.com,walmart.com##+js(acis, tmx_post_session_params_fixed)
 ! slate.com Anti-adblock workaround https://github.com/brave/brave-browser/issues/15702
 ! thehindu.com https://www.reddit.com/r/brave_browser/comments/10hh4j6/this_site_is_detecting_braveandroid_adblock/
-||tinypass.com^$domain=slate.com|thehindu.com
+||tinypass.com^$domain=slate.com|www.thehindu.com
 wetter.com,spiegel.de##[referrerpolicy]
 ! Warning message
 ||spiegel.de/public/shared/generated/3rdparty/js/msg_without_detection.


### PR DESCRIPTION
Limit the Anti-adblock to www.hehindu.com. Tinypass is used on the subscription.

Allows login on https://epaper.thehindu.com/