### PR TITLE
Add more Amazon params from affiliate links

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -28,6 +28,8 @@
 
         ],
         "params": [
+            "linkCode",
+            "tag",
             "crid",
             "qid",
             "sprefix"


### PR DESCRIPTION
Sample URL: https://www.amazon.com/dp/B002CVTT4S?tag=affiliate-name&linkCode=osi&th=1&psc=1&language=en_US

I'm not sure what `th` or `psc` do, but they're not on the Adguard list and they're pretty short, so maybe we just leave them out for now.