### PR TITLE
Fixes https://github.com/AdguardTeam/AdguardFilters/issues/85641

### DIFF
--- a/brave-lists/brave-specific.txt
+++ b/brave-lists/brave-specific.txt
@@ -11,10 +11,6 @@
 ! https://community.brave.com/t/bug-brave-shields-break-trezor-bridge-connect-when-accessing-wallet/219544/
 @@||127.0.0.1^$domain=trezor.io
 
-! https://github.com/AdguardTeam/AdguardFilters/issues/85641
-modalina.jp###ggleadv:style(height: 60px!important;)
-modalina.jp###header:style(margin-top: 60px!important;)
-
 ! De-AMP rule that uses the De-AMP scriptlet
 google.*##+js(de-amp)
 

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -964,8 +964,6 @@ livejournal.com##+js(aopr, webpackJsonpSSPjs)
 ||ad-stir.com^$third-party
 ||proparm.jp^$third-party
 ||i2ad.jp^$third-party
-! Japanese specific rules below (temporarily)
-9ketsuki.info,ta36.com##+js(aopr, adsBlocked)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/85641
 modalina.jp##+js(aopr, AdBlockLimitation)
 /ad/alliance_

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -966,6 +966,8 @@ livejournal.com##+js(aopr, webpackJsonpSSPjs)
 ||i2ad.jp^$third-party
 ! Japanese specific rules below (temporarily)
 9ketsuki.info,ta36.com##+js(aopr, adsBlocked)
+! https://github.com/AdguardTeam/AdguardFilters/issues/85641
+modalina.jp##+js(aopr, AdBlockLimitation)
 /ad/alliance_
 /loadPopIn.
 /itsads/*


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/commit/e64ee70b63f73ac5f36e14a72ec23fd96ec1d115

Since its in an Adguard syntax, had to re-formated to make it usable for us. Moved into unbreak.

Also removed  `9ketsuki.info,ta36.com##+js(aopr, adsBlocked)` no longer needed