### PR TITLE
Fix blank screen on darkreading.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -792,6 +792,7 @@ forbes.com##+js(rc, top-ad-container, , stay)
 cnet.com##+js(rc, c-adSkyBox, , stay)
 cnet.com##+js(rc, c-adSkyBox_expanded, , stay)
 reuters.com##+js(rc, ad-slot__container__FEnoz, , stay)
+darkreading.com##*:style(opacity: 1 !important;)
 ! Regex fix (counter complex ubo regex)
 $xhr,3p,domain=nxbrew.com
 $script,3p,domain=animixplay.to|animepahe.ru|nxbrew.com


### PR DESCRIPTION
In standard blocking mode, there is a 6-7sec delay in showing the blank white ad item. Fixed in Aggressive mode. Fix is to counter the opacity used on the site.

![darkreading](https://user-images.githubusercontent.com/1659004/233735864-b3843bcf-ee91-4c73-950a-5b061b3a8bf5.png)
