### PR TITLE
Remove unsupported webgains bouncer

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -156,15 +156,6 @@
   },
   {
     "include": [
-      "*://track.webgains.com/click.html*"
-    ],
-    "exclude": [
-    ],
-    "action": "redirect",
-    "param": "wgtarget"
-  },
-  {
-    "include": [
       "*://click.icptrack.com/icp/relay.php*"
     ],
     "exclude": [


### PR DESCRIPTION
Sample URL: https://track.webgains.com/click.html?wgcampaignid=1653790&wgprogramid=270175&product=1&wglinkid=2580575&productname=Nike+Air+Max+95+Sneaker&wgtarget=https://www.sneakertwins.de/index.php?cl=details&anid=301940&utm_source=Affiliate&utm_medium=Webgains&utm_campaign=Webgains&a_key=Webgains

This leads to https://www.sneakertwins.de/index.php?cl=details&anid=301940&utm_source=Affiliate&utm_medium=Webgains&utm_campaign=Webgains&a_key=Webgains.

Therefore, it requires support for this debouncing method: https://github.com/brave/brave-browser/issues/22429