### PR TITLE
Fixes popups on bookoffonline.co.jp

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -66,6 +66,11 @@ mobile.donanimhaber.com##.arareklam
 ! Cleabit tracking
 ||clearbit.com^$3p
 ||clearbitjs.com^
+! bookoffonline.co.jp (japanese) https://community.brave.com/t/topic/483981
+||d.adlpo.com^
+||h-cast.jp^$3p
+||a-cast.jp^$3p
+||reproio.com^
 ! tn.com.ar 
 @@||scdn.cxense.com^$domain=tn.com.ar
 @@||cdn.cxense.com^$domain=tn.com.ar


### PR DESCRIPTION
Reported on https://community.brave.com/t/topic/483981 

Blocking the following trackers helps remove the popups.