### PR TITLE
Fixes Cover Your tracks EFF test

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -74,6 +74,10 @@ youtube.com##ytd-rich-item-renderer:has(ytd-display-ad-renderer)
 ! fixes for several requests bypassing default blocklists
 ||aolcdn.com/*/adsWrapper.js$script
 ||zergnet.com^$script,third-party
+! https://coveryourtracks.eff.org/ Cover your tracks test
+||trackersimulator.org^
+||eviltracker.net^
+||do-not-tracker.org^
 ! block scripts that profile user behavior using password managers
 @@||api.huobi.pro^$domain=www.huobi.pro
 ! Twitter ad cosmetic element 


### PR DESCRIPTION
Block the domains used on https://coveryourtracks.eff.org/   

Addressing https://old.reddit.com/r/brave_browser/comments/133st6u/cover_your_tracks/