### PR TITLE
Create localhost-permission-allow-list.txt

### DIFF
--- a/brave-lists/localhost-permission-allow-list.txt
+++ b/brave-lists/localhost-permission-allow-list.txt
@@ -1,0 +1,6 @@
+! https://community.brave.com/t/bug-brave-shields-break-trezor-bridge-connect-when-accessing-wallet/219544
+trezor.io
+! https://github.com/brave/brave-browser/issues/27346#issuecomment-1435404209
+razroo.com
+! https://community.brave.com/t/intel-driver-support-assistant-doesnt-work-with-shields-on/212468
+intel.com

--- a/brave-lists/localhost-permission-allow-list.txt
+++ b/brave-lists/localhost-permission-allow-list.txt
@@ -1,10 +1,10 @@
-! https://community.brave.com/t/bug-brave-shields-break-trezor-bridge-connect-when-accessing-wallet/219544
+# https://community.brave.com/t/bug-brave-shields-break-trezor-bridge-connect-when-accessing-wallet/219544
 trezor.io
 
-! https://github.com/brave/brave-browser/issues/27346#issuecomment-1435404209
+# https://github.com/brave/brave-browser/issues/27346#issuecomment-1435404209
 razroo.com
 
-! https://community.brave.com/t/intel-driver-support-assistant-doesnt-work-with-shields-on/212468
+# https://community.brave.com/t/intel-driver-support-assistant-doesnt-work-with-shields-on/212468
 intel.com
 intel.de
 intel.ie

--- a/brave-lists/localhost-permission-allow-list.txt
+++ b/brave-lists/localhost-permission-allow-list.txt
@@ -1,6 +1,27 @@
 ! https://community.brave.com/t/bug-brave-shields-break-trezor-bridge-connect-when-accessing-wallet/219544
 trezor.io
+
 ! https://github.com/brave/brave-browser/issues/27346#issuecomment-1435404209
 razroo.com
+
 ! https://community.brave.com/t/intel-driver-support-assistant-doesnt-work-with-shields-on/212468
 intel.com
+intel.de
+intel.ie
+intel.it
+intel.pl
+intel.es
+intel.com.tr
+intel.co.uk
+intel.la
+intel.com.br
+intel.com.au
+intel.sg
+intel.in
+intel.co.id
+intel.co.kr
+intel.co.jp
+intel.vn
+intel.com.tw
+intel.cn
+intel.co.il


### PR DESCRIPTION
These domains are from https://docs.google.com/spreadsheets/d/1-lK-bY8NeOGsnwS__joZ7-GJLy-C8nk80tINOWalzhc/edit#gid=0

I've left these as eTLD+1 mainly because it seems like for trezor.io, we need to support subdomains as well. We could of course go full JSON (like request-otr or debounce) and use match patterns, but that's a perf/complexity hit that we should try to avoid if we can. Curious to hear thoughts!