### PR TITLE
Add ztk5.net/rg35.net debounce

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -174,6 +174,7 @@
   },
   {
     "include": [
+      "*://*.ztk5.net/*",
       "*://sherlock.scribblelive.com/r?*",
       "*://*.engage.squarespace-mail.com/r?*",
       "*://engage.squarespace-mail.com/r?*",

--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -175,6 +175,7 @@
   {
     "include": [
       "*://*.ztk5.net/*",
+      "*://*.rg35.net/*",
       "*://sherlock.scribblelive.com/r?*",
       "*://*.engage.squarespace-mail.com/r?*",
       "*://engage.squarespace-mail.com/r?*",


### PR DESCRIPTION
Fix debounce `https://ulta.ztk5.net/15nWLa?subId1=1304145mothersdayhero&u=https%3A%2F%2Fwww.ulta.com%2Fp%2F4-in-1-radiant-renewal-skincare-wand-pimprod2037834`

Also `https://stitchfix.rg35.net/3PELXK?subId1=1304145mothersdayhero&u=https%3A%2F%2Fwww.stitchfix.com%2Fgifts`

From sample page: https://www.nbcnews.com/select/shopping/best-mothers-day-gifts-ncna1304145