### PR TITLE
Fix unblocked npr.org ad box

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -807,6 +807,8 @@ cnet.com##+js(rc, c-adSkyBox, , stay)
 cnet.com##+js(rc, c-adSkyBox_expanded, , stay)
 reuters.com##+js(rc, ad-slot__container__FEnoz, , stay)
 darkreading.com##*:style(opacity: 1 !important;)
+npr.org##[aria-label="advertisement"]
+npr.org##+js(rc, ad-standard, , stay)
 ! Regex fix (counter complex ubo regex)
 $xhr,3p,domain=nxbrew.com
 $script,3p,domain=animixplay.to|animepahe.ru|nxbrew.com


### PR DESCRIPTION
Fix empty space in standard shields on https://www.npr.org/2023/05/12/1175881950/chess-coach-national-championships-maine-custodian-school-students