### PR TITLE
Remove tracking param from Seek shares

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -199,6 +199,18 @@
     },
     {
         "include": [
+            "*://*.seek.com.au/*",
+            "*://*.seek.co.nz/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "tracking"
+        ]
+    },
+    {
+        "include": [
             "*://*/*"
         ],
         "exclude": [


### PR DESCRIPTION
Sample URLs from the "share this job" functionality:
- https://www.seek.com.au/job/67413945?tracking=TMC-SAU-eDM-SharedJob-13246
- https://www.seek.co.nz/job/67437574?tracking=TMC-SNZ-eDM-SharedJob-13248