### PR TITLE
Fix Spotify ads in https://github.com/brave/brave-browser/issues/30476

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -844,6 +844,10 @@ aftonbladet.se##.css-1d3w5wq
 ! scrolller.com (anti-adblock, upward)
 scrolller.com##.popup--fixed
 ! Cosmetic fixes (https://github.com/brave/brave-browser/issues/14825)
+! Spotify (redirect priority issue)  https://github.com/brave/brave-browser/issues/30476
+! https://github.com/uBlockOrigin/uAssets/issues/18148#issuecomment-1555962148
+||akamaized.net/audio/$media,redirect-rule=noop-1s.mp4,domain=open.spotify.com,important
+||scdn.co/audio/$media,redirect=noop-1s.mp4,domain=open.spotify.com,important
 ! Counter blocked by extension warnings
 naver.com###veta_top
 naver.com###veta_branding


### PR DESCRIPTION
Fixes Spotify ads showing in Brave. Prioritys in this case don't work; cc @antonok-edm 

```
||akamaized.net/audio/$media,redirect-rule=noop-1s.mp4:10,from=open.spotify.com
||scdn.co/audio/*$media,redirect=noop-1s.mp4:10,domain=open.spotify.com
```