### PR TITLE
Add more unnecessary Amazon params

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -31,6 +31,15 @@
             "linkCode",
             "tag",
             "crid",
+            "pd_rd_r",
+            "pd_rd_w",
+            "pd_rd_wg",
+            "pf_rd_i",
+            "pf_rd_m",
+            "pf_rd_p",
+            "pf_rd_r",
+            "pf_rd_s",
+            "pf_rd_t",
             "qid",
             "sprefix"
         ]


### PR DESCRIPTION
Sample URLs:
- https://www.amazon.com/s?bbn=16225016011&rh=n%3A%2116225016011%2Cn%3A471304&dc&language=de&fst=as%3Aoff&pf_rd_i=16225016011&pf_rd_m=ATVPDKIKX0DER&pf_rd_p=03b28c2c-71e9-4947-aa06-f8b5dc8bf880&pf_rd_r=VKD0GZY2X2NDD3B0F7FQ&pf_rd_s=merchandised-search-3&pf_rd_t=101&qid=1489016289&rnid=16225016011&ref=s9_acss_bw_cts_AEVNVIDE_T4_w
- https://www.amazon.ca/dp/B09YQ9W268?pd_rd_w=N5XJn&content-id=amzn1.sym.af74bb2c-0471-4d18-a5da-d9b17b5bd7dd&pf_rd_p=af74bb2c-0471-4d18-a5da-d9b17b5bd7dd&pf_rd_r=QYNA0DCACJQWSDCHAQAQ&pd_rd_wg=NnSgq&pd_rd_r=3dbfd694-e0bd-4ace-8c00-766baccac074&pd_rd_i=B09YQ9W268&psc=1&ref_=pd_bap_d_grid_rp_0_1_ec_i

Adguard has all of these too: https://github.com/AdguardTeam/AdguardFilters/blob/18fc9321218780bde6d11e7089596009770bfd7c/TrackParamFilter/sections/specific.txt#L986-L996