### PR TITLE
Add colourbox.com consent message

### DIFF
--- a/brave-lists/brave-cookie-specific.txt
+++ b/brave-lists/brave-cookie-specific.txt
@@ -7,6 +7,7 @@ chollometro.com,dealabs.com,hotukdeals.com,pepper.it,pepper.pl,preisjaeger.at,my
 chollometro.com,dealabs.com,hotukdeals.com,pepper.it,pepper.pl,preisjaeger.at,mydealz.de##.zIndex--modal.popover-cover
 chollometro.com,dealabs.com,hotukdeals.com,pepper.it,pepper.pl,preisjaeger.at,mydealz.de##body:style(overflow: auto !important;)
 ! brave-set-cookie
+colourbox.com##+js(brave-set-cookie, cookie_consent_all, 1)
 ebilet.pl##+js(brave-set-cookie, eb_cookie_agree, 1)
 snap.com##+js(brave-set-cookie, sc-cookies-accepted, true)
 ratemyprofessors.com##+js(brave-set-cookie, ccpa-notice-viewed-02, true)


### PR DESCRIPTION
Fixes cookie consent on colourbox.com, gets around the randomised cosmetic on the site.

![colorbox-cooki](https://github.com/brave/adblock-lists/assets/1659004/ad8fc55a-611d-4c52-b47f-1521f43deaf0)
