### PR TITLE
Clean feverup.com 

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -133,6 +133,17 @@
     },
     {
         "include": [
+            "*://feverup.com/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "CAMEFROM"
+        ]
+    },
+    {
+        "include": [
             "*://www.linkedin.com/in/*"
         ],
         "exclude": [
@@ -226,6 +237,8 @@
 
         ],
         "params": [
+            "h_sid",
+            "h_slt",
             "brave-campaign-id",
             "brave-creative-id",
             "brave-creative-set-id",


### PR DESCRIPTION
Cleaning the following url;

`https://feverup.com/m/131211?CAMEFROM=CFC_THE_SALT_SHED_EMAIL_NEWSLETTER_PIZZACITYEARLYBIRD&utm_source=hive&utm_medium=email&utm_campaign=hive_email_id_191222_pizza-city-fest&h_sid=11356142e6-5e32511cc45c11e8337023d0&h_slt=eyJoYXNoIjoiNzAyNjAyOGNmZjM0NzhiIiwiaG23ZV91c2VyX2lkIjozMzQxMTk4OX0%3D`

- "h_sid","h_slt",  Used for Hive  (made generic)
