### PR TITLE
Address debounce in https://github.com/brave/brave-browser/issues/30731

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -48,6 +48,15 @@
   },
   {
     "include": [
+      "*://app.hive.co/email/elt/*"
+    ],
+    "exclude": [
+    ],
+    "action": "redirect",
+    "param": "next"
+  },
+  {
+    "include": [
       "*://redir.tradedoubler.com/*"
     ],
     "exclude": [


### PR DESCRIPTION
Debounce:

https://app.hive.co/email/elt/?h_sid=3d...22d0&hash=20..2&next=https%3A//www.hive.co/%3Ftid%3Dfteremail%26utm_source%3Dhive%26utm_medium%3Demail%26utm_campaign%3Dhive_email_id_196293_pizza-city-fest