### PR TITLE
Fix links in Hive emails

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -219,6 +219,18 @@
     },
     {
         "include": [
+            "*://*/*"
+        ],
+        "exclude": [
+            "*://app.hive.co/*"
+        ],
+        "params": [
+            "h_sid",
+            "h_slt"
+        ]
+    },
+    {
+        "include": [
             "*://*.seek.com.au/*",
             "*://*.seek.co.nz/*"
         ],
@@ -237,8 +249,6 @@
 
         ],
         "params": [
-            "h_sid",
-            "h_slt",
             "brave-campaign-id",
             "brave-creative-id",
             "brave-creative-set-id",


### PR DESCRIPTION
Two broken URLs:
- https://app.hive.co/email/28077/view/public?h_sid=1271475706-5aba9932b99a399aeb76f234&hash=a5a07febf520004
- https://app.hive.co/email//elt/?h_sid=48e61db721-599f6907b822446c56ff58e4&hash=7c241dd75c08b18&next=https%3A%2F%2Fwww.complex.com%2Fpop-culture%2F2018%2F06%2Fjohnny-knoxville-gets-smoked-by-spicy-wings-hot-ones

See brave/brave-browser#30731.