### PR TITLE
Add https://pcsupport.lenovo.com/nz/en/

### DIFF
--- a/brave-lists/localhost-permission-allow-list.txt
+++ b/brave-lists/localhost-permission-allow-list.txt
@@ -4,6 +4,9 @@ trezor.io
 # https://github.com/brave/brave-browser/issues/27346#issuecomment-1435404209
 razroo.com
 
+# https://pcsupport.lenovo.com/ (Service Bridge)
+lenovo.com
+
 # https://community.brave.com/t/intel-driver-support-assistant-doesnt-work-with-shields-on/212468
 intel.com
 intel.de


### PR DESCRIPTION
Needed for service bridge used by lenovo.com

```
http://localhost:50128/?Current-Version=5.0.2.14&data=undefined&domain=pcsupport.lenovo.com
http://localhost:50131/?Current-Version=5.0.2.14&data=undefined&domain=pcsupport.lenovo.com
```