### PR TITLE
Clean url ex_cid

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -297,7 +297,8 @@
             "usqp",
             "guccounter",
             "guce_referrer",
-            "guce_referrer_sig"
+            "guce_referrer_sig",
+            "ex_cid"
         ]
     },
     {


### PR DESCRIPTION
Clean urls;

`https://abc7.com/10470802/?ex_cid=TA_KABC_FB&utm_campaign=trueAnthem%253A+New+Content+%2528Feed%2529&utm_medium=trueAnthem&utm_source=facebook&fbclid=IwAR1REhFRt9RInDe61y1EUhtG_83aDrtV66G6c1jrVis_kHt3vDtyxhHkNxg`

`https://abc7chicago.com/chicago-migrants-daley-college-ford-city-news/13340062/?ex_cid=TA_WLS_TW&taid=641cb19acf91b310017ce32d`