### PR TITLE
Fixes blogto.com banner shadow (ios)

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -33,6 +33,8 @@ theblockcrypto.com##.modal-container
 theblockcrypto.com##body:style(overflow: auto !important;)
 ! Anti-adblock: concert.io (vox sites)
 @@||vox-cdn.com/packs/concert_ads-$script,domain=chicago.suntimes.com|theverge.com|eater.com|polygon.com|vox.com|sbnation.com|curbed.com|theringer.com|mmafighting.com|racked.com|mmamania.com|funnyordie.com|riftherald.com
+! Fix blogto.com bottom sticky banner (import from EL) 
+blogto.com##.blogto-sticky-banner
 ! uBO-redirect work around imperfectcomic.com
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=imperfectcomic.com
 ! Bait (https://www.planetf1.com/)


### PR DESCRIPTION
Imported from EL; https://github.com/easylist/easylist/blob/master/easylist/easylist_specific_hide.txt#L1527

Reported by @StephenHeaps 