### PR TITLE
Add first-party rules for searchengineland.com

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -481,6 +481,10 @@ autoevolution.com##.bgcutgrad
 mail.google.com##.nH.PS
 mail.google.com##.aeF > .nH > .nH[role="main"] > .aKB
 ||mail-ads.google.com^
+! searchengineland.com
+##[id^="div-gpt-ad"]
+##div[id^="div-gpt-"]
+/gpt.js$script
 ! stoodnt.com
 stoodnt.com##.boxzilla-center-container
 stoodnt.com##.boxzilla-overlay


### PR DESCRIPTION
Import 3 common rules in EP and EL.

From Easylist: ##[id^="div-gpt-ad"] ##div[id^="div-gpt-"]
Generic used in Easylist, widely used.

From Easyprivacy: /gpt.js$script  (google script block)
`https://searchengineland.com/wp-content/cache/min/1/tag/js/gpt.js`