### PR TITLE
Remove param from Backerkit emails

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -182,6 +182,7 @@
     },
     {
         "include": [
+            "*://www.backerkit.com/*",
             "*://*.kickstarter.com/*"
         ],
         "exclude": [


### PR DESCRIPTION
Sample URL: https://www.backerkit.com/c/cephalofair/gloomhaven?ref=just_launched_mailer