### PR TITLE
Add Title and Expires fields to Brave Default lists

### DIFF
--- a/brave-lists/brave-android-specific.txt
+++ b/brave-lists/brave-android-specific.txt
@@ -1,4 +1,5 @@
-! Brave Android specific filters
+! Title: Brave Android-Specific Rules
+! Expires: 2 days
 
 ! fmovies
 fmovies.to##+js(acis, JSON.parse)

--- a/brave-lists/brave-cookie-specific.txt
+++ b/brave-lists/brave-cookie-specific.txt
@@ -1,5 +1,5 @@
 ! Title: Brave Cookie-snippet list
-! Description: Used with cookie snippets, set-local-storage-item, set-cookie, set-cookie-reload, set-ession-storage-item
+! Description: Brave-specific additions to Easylist Cookie
 ! Expires: 2 days
 
 ! dealabs mirrors

--- a/brave-lists/brave-cookie-specific.txt
+++ b/brave-lists/brave-cookie-specific.txt
@@ -1,6 +1,7 @@
-! Cookie-snippet list
-! Used with cookie snippets, set-local-storage-item, set-cookie, set-cookie-reload, set-ession-storage-item
-!
+! Title: Brave Cookie-snippet list
+! Description: Used with cookie snippets, set-local-storage-item, set-cookie, set-cookie-reload, set-ession-storage-item
+! Expires: 2 days
+
 ! dealabs mirrors
 chollometro.com,dealabs.com,hotukdeals.com,pepper.it,pepper.pl,preisjaeger.at,mydealz.de##+js(brave-set-cookie, cookie_policy_agreement, 3)
 chollometro.com,dealabs.com,hotukdeals.com,pepper.it,pepper.pl,preisjaeger.at,mydealz.de##.popover--layout-fixed-bottomSheet

--- a/brave-lists/brave-social.txt
+++ b/brave-lists/brave-social.txt
@@ -1,5 +1,7 @@
-! List used by Brave for preventing social elements from loading
-!
+! Title: Brave Social
+! Description: List used by Brave for preventing social elements from loading
+! Expires: 2 days
+
 ! Facebook
 ||connect.facebook.net^$third-party,domain=~atlassolutions.com|~facebook.com|~facebook.de|~facebook.fr|~facebook.net|~fb.com|~fb.me|~fbcdn.net|~fbsbx.com|~friendfeed.com|~instagram.com|~internalfb.com|~messenger.com|~oculus.com|~whatsapp.com|~workplace.com
 ||connect.facebook.com^$third-party,domain=~atlassolutions.com|~facebook.com|~facebook.de|~facebook.fr|~facebook.net|~fb.com|~fb.me|~fbcdn.net|~fbsbx.com|~friendfeed.com|~instagram.com|~internalfb.com|~messenger.com|~oculus.com|~whatsapp.com|~workplace.com

--- a/brave-lists/brave-specific.txt
+++ b/brave-lists/brave-specific.txt
@@ -1,3 +1,6 @@
+! Title: Brave Specific
+! Expires: 2 days
+
 ! Specific filters (Tracking or ads) for Brave
 ||0.0.0.0^$third-party,domain=~[::]|~[::ffff:0:0]
 ||[::]^$third-party,domain=~0.0.0.0|~[::ffff:0:0]

--- a/brave-lists/brave-sugarcoat.txt
+++ b/brave-lists/brave-sugarcoat.txt
@@ -1,3 +1,6 @@
+! Title: Brave SugarCoat Rules
+! Expires: 7 days
+
 ! dell.com
 ||ensighten.com/dell/marketing/code/280f261e277ca609b7450f5304929274.js$script,important,domain=dell.com,redirect=async-sugarcoat-04394153a7ce417b88e3fe1790a4e6a269bfebe5
 ! live.house.gov

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -1,4 +1,7 @@
 [Adblock Plus 2.0; uBlock Origin]
+! Title: Brave Unbreak
+! Expires: 12 hours
+
 ! brave.com specfic filters
 @@||ads.brave.software^$first-party
 @@||ads-admin.bravesoftware.com^$first-party


### PR DESCRIPTION
closes https://github.com/brave/adblock-lists/issues/1231

Adds Title and Expires to the all the the Brave default lists listed in [default.json](https://github.com/brave/adblock-resources/blob/master/filter_lists/default.json) and the [brave-cookie-specific.txt](https://github.com/brave/adblock-lists/blob/master/brave-lists/brave-cookie-specific.txt) list in case that is ever used officially by Brave, so they are readable when added as Custom lists in `brave://settings/shields/filters`.

# Before
![image](https://github.com/brave/adblock-lists/assets/122518587/16751c89-4d4b-480b-ab31-095c461a62f6)


# After
![image](https://github.com/brave/adblock-lists/assets/122518587/b06a91f6-e81c-47d7-bd33-97f4b5db4370)


### Note
The only Default list I didn't edit was the **empty** [adblock-lists/brave-lists/brave-unbreak.txt](https://github.com/brave/adblock-lists/blob/master/brave-lists/brave-unbreak.txt)