### PR TITLE
Remove referral param on HackerNoon

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -182,6 +182,7 @@
     },
     {
         "include": [
+            "*://hackernoon.com/*",
             "*://www.backerkit.com/*",
             "*://*.kickstarter.com/*"
         ],


### PR DESCRIPTION
Sample URL: https://hackernoon.com/prompt-engineering-101-i-unveiling-principles-and-techniques-of-effective-prompt-crafting?ref=hackernoon.com