### PR TITLE
Fixes top leaderboard on apnews.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -878,6 +878,8 @@ scrolller.com##.popup--fixed
 ! https://github.com/uBlockOrigin/uAssets/issues/18148#issuecomment-1555962148
 ||akamaized.net/audio/$media,redirect-rule=noop-1s.mp4,domain=open.spotify.com,important
 ||scdn.co/audio/$media,redirect=noop-1s.mp4,domain=open.spotify.com,important
+! fixes from remove()
+apnews.com##+js(ra, data-leaderboard-is-fixed, html, stay)
 ! Counter blocked by extension warnings
 naver.com###veta_top
 naver.com###veta_branding


### PR DESCRIPTION
From uBO: `apnews.com##.Page-header-leaderboardAd:remove()` Since we don't have remove. This a better work around to fix header from loading.