### PR TITLE
Remove brave speicific YT filters

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -68,9 +68,6 @@ grubhub.com,dashboard.razorpay.com,joinhoney.com#@##credential_picker_container
 webplatform.news##+js(aopw, navigator.clipboard)
 ! navigator.connection checks
 userlytics.com##+js(set, navigator.connection, {})
-! Youtube Anti-adblock warning
-youtube.com##+js(json-prune, auxiliaryUi.messageRenderers.enforcementMessageViewModel)
-youtube.com##+js(set, ytInitialPlayerResponse.auxiliaryUi.messageRenderers.enforcementMessageViewModel, undefined)
 ! :has
 youtube.com##ytd-rich-item-renderer:has(ytd-display-ad-renderer)
 9gag.com##article:has(.promoted)


### PR DESCRIPTION
No longer needed; Now implemented in uBO and redundant

https://github.com/uBlockOrigin/uAssets/commit/b04299eb34e90cae4b0af3428cd6952df0b78178