### PR TITLE
Fixes no pictures on novinky.cz

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -804,6 +804,8 @@ davidstea.com,ibotta.com,polovniautomobili.com##+js(rc, async-hide, , stay)
 @@||ebay.com/ws/$xmlhttprequest
 ! api.ebay.com (https://community.brave.com/t/referral-not-getting-download-and-comfirmed/75898)
 @@||api.ebay.com^$xmlhttprequest,subdocument
+! env fixes
+novinky.cz#@#+js(aost, Math, inlineScript)
 ! Empty spaces due to shields/standard
 cultofmac.com,futuregaming.io,cydiageeks.com,askdavetaylor.com,pedigreedatabase.com,greatamericandaily.com,basquetplus.com,liverampup.com,q4interview.com,happybirthdaymsg.com,gerweck.net,smartwatchspecifications.com,toutandroid.fr,wikinetworth.com,tutorials-raspberrypi.com##+js(rc, ezoic-ad, , stay)
 webmd.com##+js(rc, instreamAd, , stay)


### PR DESCRIPTION
Fixes: https://community.brave.com/t/brave-shield-blocking-images-and-videos-on-the-site-novinky-cz/499018

!#if !env_firefox
novinky.cz##+js(aost, Math, inlineScript)
!#endif

Since we ignore `#if !env_firefox`, `novinky.cz##+js(aost, Math, inlineScript)` is applied.