### PR TITLE
Update Facebook and tiktok trackers

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -1200,7 +1200,8 @@ mail.google.com##.nH.PS
 stoodnt.com##.boxzilla-center-container
 stoodnt.com##.boxzilla-overlay
 ! Facebook/Instagram
-/bz?*__comet_req=
+/ajax/bnzai?_
+/ajax/bz?_
 facebook.com##.post-ads
 facebook.com##.RectangleAd
 ||facebook.com/a/bz?
@@ -1225,6 +1226,7 @@ bloomberg.com##.leaderboard-wrapper
 /api/cmp_tracker
 bloomberg.com##[class^="FullWidthAd_"]
 ! tiktok.com
+||tiktok.com/ttwid/check/
 ||tiktok.com/captcha/report
 ||tiktok.com/v1/list
 ||tiktok.com/web/report?


### PR DESCRIPTION
Sync with Easyprivacy; Facebook changed the tracking urls, and Tiktok added a new event tracker.

Facebook trackers: https://github.com/easylist/easylist/commit/bc9e3b970e07e33440539a23d07136e7f19c0730

Ticktok: https://github.com/easylist/easylist/commit/0a93935724fedd984fe61032815e4a5cd97bef5d