### PR TITLE
Fix walmart redirect in https://github.com/brave/brave-browser/issues/32229

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -946,6 +946,10 @@ mycima.biz##+js(acis, parseInt, break;case $.)
 ||tapfiliate.com^$badfilter
 ! Fix blank page on flipp.com
 @@||wishabi.net^$image,domain=flipp.com
+! https://community.brave.com/t/walmart-com-redirects-to-account-sign-in-screen-brave-linux-and-mac-not-ff-or-safari/500040/
+! window.navigator.globalPrivacyControl related
+walmart.com##+js(cookie-remover.js, sod)
+walmart.com##+js(set-cookie, sod, 0)
 ! Fix "Alien Warning" script check on dslreports.com https://community.brave.com/t/alien-script-detected-inline-code-at-dslreports-com-speedtest/173716/
 dslreports.com###errorlog
 ! Anti-adblock: docker.events.cube365.net 


### PR DESCRIPTION
Address  https://github.com/brave/brave-browser/issues/32229

From @ShivanKaul 

> Okay, it’s the sod cookie set by `www.walmart.com`. If I use an extension to prevent the cookie from being received via Set-Cookie response, the website works correctly. 
> With GPC on, by default, it’s set to be torbit<random numbers>, if it’s set to be 0, then it works fine
> I added a Sec GPC extension for Chrome and tested Walmart on that, and noticed that once the GPC header was sent once, the website remembered it and redirected even when the header was not sent, which pointed to some sort of state. I verified that by deleting session and local storage, but only after deleting all cookies did it work correctly. 

We need to remove the previous "sod" cookie, otherwise it will still redirect. In the near future we could probably remove the cookie deletion.