### PR TITLE
Add exception for youtube/ubo-dev specific filter

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -83,6 +83,7 @@ youtube.com,youtubekids.com,youtube-nocookie.com##+js(json-prune, playerResponse
 youtube.com,youtubekids.com,youtube-nocookie.com##+js(json-prune, playerResponse.adPlacements playerResponse.playerAds playerResponse.adSlots adPlacements playerAds adSlots important, playerResponse.captions)
 youtube.com,youtubekids.com,youtube-nocookie.com##+js(json-prune, playerResponse.adPlacements playerResponse.playerAds playerResponse.adSlots adPlacements playerAds adSlots important, responseContext.serviceTrackingParams.2)
 youtube.com,youtubekids.com,youtube-nocookie.com##+js(json-prune, playerResponse.adPlacements playerResponse.playerAds playerResponse.adSlots adPlacements playerAds adSlots important, playerResponse.responseContext.serviceTrackingParams.2)
+youtube.com,youtubekids.com,youtube-nocookie.com#@#+js(json-prune, playerResponse.adPlacements playerResponse.playerAds playerResponse.adSlots adPlacements playerAds adSlots, , /^(?=.*\.js)(?!.*[A-z]hb \S+polymer).*/)
 ! Fix browser lockup on skepticalscience.com (https://github.com/brave/brave-browser/issues/5406)
 ||skepticalscience.net/widgets/heat_widget/js/heat_content.js$script,domain=skepticalscience.com
 ! adops.com unusable without this


### PR DESCRIPTION
Just an exception for uBO-dev;  https://github.com/uBlockOrigin/uAssets/blob/master/filters/filters.txt#L46 part https://github.com/brave/adblock-lists/pull/1280

Part of the `!#if ext_devbuild`  `!#endif`
