### PR TITLE
Improve adblock-tester.com score

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -465,6 +465,10 @@ spectrum.ieee.org##.top-leader-container
 spectrum.ieee.org##div[class^="rblad-"]
 ! theglobeandmail.com
 theglobeandmail.com###BaseAd__StyledAdPlaceholder-sc-1khlkqq-0
+! adblock-tester.com
+||adblock-tester.com/banners/
+adblock-tester.com##embed[width="240"]
+adblock-tester.com##object[width="240"]
 ! atlasobscura.com
 atlasobscura.com##.advertisement-disclaimer
 atlasobscura.com##.advertisement-shadow


### PR DESCRIPTION
While just a benchmark, people will measure Brave against other browsers/blockers.  We should improve our scores with filters included in EL in start blocking mode.

Ref: https://old.reddit.com/r/brave_browser/comments/163e86c/adblock_test_results_firefox_ublock_origin_vs/