### PR TITLE
Cover ads & trackers on decrypt.co (ios)

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -25,6 +25,13 @@
 ||fleraprt.com^
 ||tzegilo.com^
 
+! decrypt.co
+decrypt.co##span:has-text(AD)
+decrypt.co##div[style^="min-width: 300px;"]
+decrypt.co##.opacity-75
+||pubgenius.io^$3p
+||btloader.com^
+||customer.io^$3p
 ! naver.com search is broken  https://m.search.naver.com/search.naver?where=m_image&sm=mtb_jum&query=brave
 @@||ssl.pstatic.net^$domain=naver.com
 ! apnews.com


### PR DESCRIPTION
Address some ads/trackers and cosmetics used on `decrypt.co`

(imported from EL/EP)