### PR TITLE
Adds scriptlet rule for the YouTube navigation fix.

### DIFF
--- a/brave-lists/brave-specific.txt
+++ b/brave-lists/brave-specific.txt
@@ -20,6 +20,9 @@ google.*##+js(de-amp)
 ! YouTube theater mode fix scriptlet rule
 youtube.*##+js(brave-youtube-theater-fix)
 
+! YouTube navigation fix scriptlet rule
+youtube.*##+js(brave-youtube-navigation-fix)
+
 ! Used for Brave QA tests
 ?335962573013224749$image,xhr,domain=dev-pages.brave.software|dev-pages.bravesoftware.com
 ! Rules for testing cosmetic filters in frames


### PR DESCRIPTION
See details [here](https://github.com/brave/brave-browser/issues/29432#issuecomment-1708692111) and [here](https://github.com/brave/brave-browser/issues/29432#issuecomment-1711897695).

Corresponding `adblock-resources` PR: https://github.com/brave/adblock-resources/pull/131