### PR TITLE
Fixes anti-adblock on atozmath.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -239,6 +239,8 @@ gap.com,ibanking-services.com,connectonebank.com,tescobank.com,sbisec.co.jp,tsb.
 wetter.com,spiegel.de##[referrerpolicy]
 ! Warning message
 ||spiegel.de/public/shared/generated/3rdparty/js/msg_without_detection.
+! atozmath.com Anti-adblock
+atozmath.com###lblAdContent
 !! -- ported from uBO Annoyances filters (START)
 ! Anti-adblock message codehelppro.com
 @@||codehelppro.com^$ghide


### PR DESCRIPTION
Fixes `atozmath.com` Anti-adblock as reported, https://community.brave.com/t/ad-blocker-dectected-in-website/503685


