### PR TITLE
Remove YouTube's new `si` share param

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -156,6 +156,7 @@
     },
     {
         "include": [
+            "*://youtu.be/?*",
             "*://*.youtube.com/watch?*"
         ],
         "exclude": [
@@ -166,6 +167,7 @@
             "embeds_loader_url_for_pings",
             "embeds_origin",
             "feature",
+            "si",
             "source_ve_path"
         ]
     },


### PR DESCRIPTION
Also add the short domain youtu.be.

Sample URLs:
- https://youtu.be/dQw4w9WgXcQ?si=YjziZuccJeIE-b6z
- https://youtu.be/dQw4w9WgXcQ?feature=shared

Originally reported on brave/brave-browser#33037.