### PR TITLE
Add Cxense URL parameters

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -294,6 +294,9 @@
 
         ],
         "params": [
+            "cx_click",
+            "cx_recsOrder",
+            "cx_recsWidget",
             "at_campaign",
             "at_campaign_type",
             "at_channel",


### PR DESCRIPTION
Cxense [was acquired by another company](https://en.wikipedia.org/wiki/Cxense) and their product appears to be shutdown and so this is only really going to be useful for old links.

Sample URLs:
- https://www.lifehacker.jp/article/225548jeff-bezos-says-you-need-to-avoid-this-1-mistake-if-you-want-to-be-a-successful-entrepreneur/?cx_click=sp_ranking
- https://www.agorize.com/es/challenges/ricoh-2023?cx_click=pc_ranking
- https://bg-mania.jp/2011/06/01008257.html?cx_recsOrder=1&cx_recsWidget=articleBottom