### PR TITLE
Fixes removeparam standard blocking (video ads)

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -466,6 +466,21 @@
 /parsonsmaize/mulvane.js
 /parsonsmaize/olathe.js
 /tardisrocinante/vitals.js
+! remove-params (ads)
+||warnermediacdn.com/csm/*&caid=$xhr,removeparam=caid,from=cnn.com
+||warnermediacdn.com/csm/*afid=$xhr,removeparam=afid,from=cnn.com
+||warnermediacdn.com/csm/*app_csid=$xhr,removeparam=app_csid,from=cnn.com
+||warnermediacdn.com/csm/*conf_csid=$xhr,removeparam=conf_csid,from=cnn.com
+||brightcove.com^$xhr,removeparam=ad_config_id,domain=roosterteeth.com
+||medium.ngtv.io/v2/media/*&ssaiProfile=$xhr,removeparam=ssaiProfile,domain=~cnn.com
+||cxm-api.fifa.com/fifaplusweb/api/video/*$xhr,removeparam=adConfig
+||hbo.yspsvc-na.net/csm/*&caid=$xhr,removeparam=caid,domain=play.hbomax.com
+*&caid=$xhr,removeparam=caid,domain=max.com
+||brightcove.com/playback/*/*?ad_config_id$removeparam=ad_config_id,xhr,domain=tvnz.co.nz
+||brightcovecdn.com/playback/*/*?ad_config_id$removeparam=ad_config_id,xhr,domain=tvnz.co.nz
+||brightcove.com^$removeparam=ad_config_id,domain=player.stv.tv
+*$xhr,removeparam=ad_config_id,domain=telequebec.tv
+||edge.api.brightcove.com^$xhr,removeparam=ad_config_id,domain=9now.com.au|mech-plus.com|threenow.co.nz
 ! Mgid
 ##div[id*="MarketGid"]
 ##div[id*="ScriptRoot"]


### PR DESCRIPTION
Fixes video ads on `cnn.com` and other sites using `removeparam`

Sample: `https://edition.cnn.com/videos/business/2023/09/23/train-high-speed-rail-florida-brightline-muntean-dnt-cnntm-contd-vpx.cnn`

Other sites imported from uAssests. Strictly video ads 