### PR TITLE
Include more akam first-party trackers

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -1187,6 +1187,9 @@ autoevolution.com##.bgcutgrad
 !
 .snowplowanalytics.
 /__ssobj/core.js
+/akam/*/pixel_
+/akam/10/*
+/akam/11/*
 /akam/13/*
 /analytics-dotcom/*
 /analytics_wbc.


### PR DESCRIPTION
Fixes some first-party trackers addressed in https://grantwinney.com/websites-requesting-access-to-motion-sensors/

All filters are used in Easyprivacy