### PR TITLE
Limit Youtube dissamissable anti-adblock warning

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -71,6 +71,8 @@ userlytics.com##+js(set, navigator.connection, {})
 ! :has
 youtube.com##ytd-rich-item-renderer:has(ytd-display-ad-renderer)
 9gag.com##article:has(.promoted)
+! youtube.com dismissable warning
+youtube.com##+js(cookie-remover.js, CONSISTENCY)
 ! Fix browser lockup on skepticalscience.com (https://github.com/brave/brave-browser/issues/5406)
 ||skepticalscience.net/widgets/heat_widget/js/heat_content.js$script,domain=skepticalscience.com
 ! adops.com unusable without this


### PR DESCRIPTION
Cookie used to set/check when displaying the dismissiable Anti-adblock warning. Can be safely removed, doesn't affect video playback.