### PR TITLE
Remove Impact.com's URL parameters

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -294,6 +294,11 @@
 
         ],
         "params": [
+            "irclickid",
+            "irgwc",
+            "ir_adid",
+            "ir_campaignid",
+            "ir_partnerid",
             "yadclid",
             "yadordid",
             "yclid",


### PR DESCRIPTION
Sample URL:
https://www.trifectanutrition.com/?irgwc=1&utm_campaign=Sin%20City%20Training&utm_medium=&utm_source=partners&irclickid=W8gToW3kdxyLUMYwUx0Mo36NUkERd6xdy2DHVo0&mpid=2612210&ir_campaignid=4609&ir_adid=492677&ir_partnerid=2612210

Also in Adguard: https://github.com/AdguardTeam/AdguardFilters/blob/be4f6af10b3bb8a8424611a0b03ad785d495692a/TrackParamFilter/sections/general_url.txt#L35-L39