### PR TITLE
Remove Facebook third-party URL params

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -294,6 +294,11 @@
 
         ],
         "params": [
+            "fb_action_ids",
+            "fb_action_types",
+            "fb_comment_id",
+            "fb_ref",
+            "fb_source",
             "irclickid",
             "irgwc",
             "ir_adid",


### PR DESCRIPTION
Sample URLs:
- https://ciusssmcq.ca/blogue/4/outil-gastro-recette-de-liquide-de-rehydratation/?fb_comment_id=2018780648164493_2026993357343222
- https://www.nasa.gov/audience/foreducators/topnav/materials/listbytype/Orion_Model.html?fb_action_ids=10201679565844214&fb_action_types=og.likes&fb_ref=.UrJbyJguoz4.like&fb_source=other_multiline&action_object_map=%5B457911120947104%5D&action_type_map=%5B%22og.likes%22%5D&action_ref_map=%5B%22.UrJbyJguoz4.like%22%5D