### PR TITLE
Remove more Facebook-related query parameters

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -294,6 +294,9 @@
 
         ],
         "params": [
+            "action_object_map",
+            "action_ref_map",
+            "action_type_map",
             "fb_action_ids",
             "fb_action_types",
             "fb_comment_id",


### PR DESCRIPTION
Sample URLs:
- https://www.coursera.org/learn/villes-africaines-1?action_object_map=%7B%22709809949048840%22%3A292462637561180%7D&action_ref_map=&action_type_map=%7B%22709809949048840%22%3A%22og.likes%22%7D
- https://www.atlassian.com/time-wasting-at-work-infographic?action_type_map=[&_ga=2.186577067.309484242.1560264247-192049351.1549900025&yt_video=2MbB46EPx4A&industry=professional-services&region=benelux-region&action_object_map=[679061992165222]&action_ref_map=[] https://www.ctvnews.ca/mobile/video?clipId=629131&action_object_map=%5B896637717064621%5D&action_type_map=%5B%22og.shares%22%5D&action_ref_map=%5B%5D
- https://www.icloud.com/mail?year=2015&fb_action_types=og.likes&fb_action_ids=10151371408449924&fb_source=other_multiline&industry=ecommerce&action_object_map=%2525252525252525257B%2525252525252525252210151371408449924%25252525252525252522%2525252525252525253A10151106514708599%2525252525252525257D&__hstc=259582869.99a265337744294b740e0787aea508c4.1578096000149.1578096000150.1578096000151.1&__hssc=259582869.1.1578096000152&action_type_map=%2525252525252525257B%2525252525252525252210151371408449924%25252525252525252522%2525252525252525253A%25252525252525252522og.likes%25252525252525252522%2525252525252525257D&_ga=2.18984888.1241921136.1560771598-192049351.1549900025&region=iberia&action_ref_map=%2525252525252525255B%2525252525252525255D&__hsfp=3969827736&hubs_post-cta=blognavcard-marketing

These are also in AdGuard: https://github.com/AdguardTeam/AdguardFilters/blob/c285952860c4428750f3fa8bfa4f97fb503e1563/TrackParamFilter/sections/general_url.txt#L264-L266