### PR TITLE
Remove campaign-tracking params on Humble Bundle

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -288,6 +288,19 @@
     },
     {
         "include": [
+            "*://*.humblebundle.com/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "hmb_campaign",
+            "hmb_medium",
+            "hmb_source"
+        ]
+    },
+    {
+        "include": [
             "*://*/*"
         ],
         "exclude": [


### PR DESCRIPTION
Sample URLs:
- https://www.humblebundle.com/games/vr-bundle?hmb_source=navbar&hmb_medium=product_tile&hmb_campaign=tile_index_1
- https://www.humblebundle.com/books/write-like-a-writer-books?hmb_source=navbar&hmb_medium=product_tile&hmb_campaign=tile_index_5
- https://www.humblebundle.com/games/ultimate-racing-sim-bundle?hmb_source=&hmb_medium=product_tile&hmb_campaign=mosaic_section_1_layout_index_1_layout_type_threes_tile_index_1_c_ultimateracingsimbundle_bundle

These are also in AdGuard: https://github.com/AdguardTeam/AdguardFilters/commit/23b26c8c06ae31ff550ddaf069ae1cc0f6e0b222