### PR TITLE
Remove unnecessary Instagram parameters related to sharing and embedding

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -74,6 +74,18 @@
     },
     {
         "include": [
+            "*://www.instagram.com/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "igshid",
+            "ig_rid"
+        ]
+    },
+    {
+        "include": [
             "*://*.twitter.com/*"
         ],
         "exclude": [


### PR DESCRIPTION
Sample URLs:
- https://www.instagram.com/reel/CyuCMRXPJk6/?utm_source=ig_embed&ig_rid=3d515e33-9a4b-432a-be16-ca0e52a212f5
- https://www.instagram.com/bodyworkbylisa/?ig_rid=a82eb172-092d-4266-89e9-e177b491f610