### PR TITLE
Remove another Amazon parameter from URLs

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -28,6 +28,7 @@
 
         ],
         "params": [
+            "content-id",
             "linkCode",
             "tag",
             "crid",


### PR DESCRIPTION
Sample URLs:
- https://www.amazon.com/gp/video/storefront/ref=dvm_us_tv_cs_desktopAndMob_all_PCPO_PD23/ref=dvm_us_tv_cs_desktopAndMob_all_PCPO_PD23?ie=UTF8&contentType=merch&contentId=store&merchId=deals&pd_rd_w=7vTQd&content-id=amzn1.sym.25061dab-1fce-471f-895e-0a8283981cce&pf_rd_p=25061dab-1fce-471f-895e-0a8283981cce&pf_rd_r=KJ9C60MWD2NW8WRYB103&pd_rd_wg=eRx2j&pd_rd_r=f97cdd07-59c9-4468-a91c-5f83f8d380e4
- https://www.amazon.com/amazonprime/ref=sxts_snpl_0_0_5c3d7591-6487-40c7-ae04-742cca4ad638?pd_rd_w=32e8Q&content-id=amzn1.sym.5c3d7591-6487-40c7-ae04-742cca4ad638:amzn1.sym.5c3d7591-6487-40c7-ae04-742cca4ad638&pf_rd_p=5c3d7591-6487-40c7-ae04-742cca4ad638&pf_rd_r=YA5M6SZD05BZRGPHDSJ0&pd_rd_wg=T8LWC&pd_rd_r=262ef078-e077-4216-a657-6c9b007f8d1f&qid=1698771532

Also appears in [AdGuard list](https://github.com/AdguardTeam/AdguardFilters/blob/2063cab8e644bc0943b026a4002b0ab76ac7098b/TrackParamFilter/sections/specific.txt#L1299).