### PR TITLE
Remove unnecessary params in links from Linkedin emails

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -169,6 +169,19 @@
     },
     {
         "include": [
+            "*://www.linkedin.com/help/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "mcid",
+            "src",
+            "trk"
+        ]
+    },
+    {
+        "include": [
             "*://youtu.be/?*",
             "*://*.youtube.com/watch?*"
         ],

--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -164,6 +164,7 @@
 
         ],
         "params": [
+            "trackingCode",
             "original_referer"
         ]
     },


### PR DESCRIPTION
Sample URLs:
- https://www.linkedin.com/in/fmarier/opportunities/job-opportunities/onboarding/?trackingCode=eml-email_profile_analyzer_01-EmailProfileAnalyzer-0-cta_job_pref
- https://www.linkedin.com/help/linkedin/answer/a1356464?trk=eml-mktg-con-f-awr-202310-global-pages-messaging-transactional-en&src=e-eml&mcid=7122661895492263936