### PR TITLE
Fixes shop-links debounce

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -11,7 +11,7 @@
       "*://mcpedl.com/leaving/?*",
       "*://track.effiliation.com/servlet/effi.redir*",
       "*://go.skimresources.com/*",
-      "*://shop-links.co/link/*",
+      "*://shop-links.co/link*",
       "*://www.jdoqocy.com/click-*",
       "*://www.kqzyfj.com/click-*",
       "*://www.pjtra.com/t/*",


### PR DESCRIPTION
Adjust debounce for `shop-links.co/link?` and   `shop-links.co/link/`

covering: 

`https://shop-links.co/link?publisher_slug=future&exclusive=1&u1=grd-nz-1123541732855489800&url=https%3A%2F%2Fwww.bestbuy.com%2Fsite%2Fasus-rog-ally-7-120hz-fhd-1080p-gaming-handheld-amd-ryzen-z1-extreme-processor-512gb-white%2F6542964.p&article_name=The%20Asus%20ROG%20Ally%20has%20been%20Black%20Friday%27d%20-%20and%20you%20won%27t%20find%20a%20gaming%20laptop%20cheaper%20than%20this%20%7C%20GamesRadar%2B&article_url=https%3A%2F%2Fwww.gamesradar.com%2Fthe-asus-rog-ally-has-been-black-fridayd-and-you-wont-find-a-gaming-laptop-cheaper-than-this%2F%3Futm_content%3Dgamesradar%26utm_source%3Dtwitter.com%26utm_medium%3Dsocial%26utm_campaign%3Dsocialflow​​​​​​`