### PR TITLE
Fix grep top bar on allrecipes.com

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -282,6 +282,7 @@
 ##.m1-header-ad
 ##.mapped-ad
 ##.min-height-ad
+##.mntl-gpt-adunit
 ##.mntl-leaderboard-header
 ##.mntl-leaderboard-spacer
 ##.native-ad


### PR DESCRIPTION
Fixes a minor nit on allrecipes.com, grey top bar. Also include another  `.mntl-gpt-adunit` (From EL)