### PR TITLE
Update first-party filters

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -1185,7 +1185,7 @@ beincrypto.com,bitcoinist.com,coincodex.com,coinpaprika.com,coinspeaker.com,cryp
 streetinsider.com###bottom_ad_fixed
 streetinsider.com##.im-ad
 ! investing.com
-investing.com## + js(nostif, offsetHeight)
+investing.com##+js(nostif, offsetHeight)
 investing.com###__next > .fixed
 investing.com###ad1
 investing.com###ad2
@@ -1472,8 +1472,6 @@ bloomberg.com##[class^="FullWidthAd_"]
 ||youtubekids.com/api/stats/ads?
 ||youtubekids.com/api/stats/qoe?
 ||youtubekids.com/ptracking?
-! Apply 1stparty
-www.youtube.com## + js(json-prune-xhr-response, [].playerResponse.adPlacements [].playerResponse.playerAds [].playerResponse.adSlots playerResponse.adPlacements playerResponse.playerAds playerResponse.adSlots adPlacements playerAds adSlots, , propsToMatch, url:/player\?key=|watch\?v=|youtubei\/v1\/player/)
 ! Reddit
 /shreddit/perfmetrics
 ||alb.reddit.com^


### PR DESCRIPTION
Sorted filters also.

Included new generics from EL:

```
##.td-ad
##.td-ad-m
##.td-ad-p
##.td-ad-tp
###td-ad-placeholder
##.td-a-rec-id-custom_ad_1
##.td-a-rec-id-custom_ad_2
##.td-a-rec-id-custom_ad_3
##.td-a-rec-id-custom_ad_4
##.td-a-rec-id-custom_ad_5
```

Updated the following (domain specific) rules: (imported from EL)

```
##.zone
##.ads
##.advertisement
##.ad-container
##.code-block
##.code-block > center p
```

Updated following sites: (imported from EL)

- msn.com
- chron.com/houstonchronicle.com/sfgate.com/seattlepi.com
- yahoo.com
- reuters.com
- zycrypto.com