### PR TITLE
Add eventbrite.com params

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -285,11 +285,12 @@
 
         ],
         "params": [
-            "link_id",
+            "aff",
             "can_id",
-            "source",
             "email_referrer",
-            "email_subject"
+            "email_subject",
+            "link_id",
+            "source"
         ]
     },
     {

--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -279,6 +279,21 @@
     },
     {
         "include": [
+            "*://*.eventbrite.com/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "link_id",
+            "can_id",
+            "source",
+            "email_referrer",
+            "email_subject"
+        ]
+    },
+    {
+        "include": [
             "*://*.seek.com.au/*",
             "*://*.seek.co.nz/*"
         ],


### PR DESCRIPTION
Remove unneeded params:

`https://www.eventbrite.com/e/end-of-year-potluck-dinner-for-urban-environmentalists-members-tickets-762087894407?aff=oddtdtcreator&link_id=13&can_id=736e45dc4450fb0402129dfaa54624e1&source=email-people-protected-bike-lane-carmageddon-lincoln-park-art-deco-2&email_referrer=email_2115569&email_subject=zoning-chair-letter-north-center-homes-_-holiday-potluck-ward-leads`


