### PR TITLE
Allow various cosmetics for YT

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -234,6 +234,46 @@ canyoublockit.com##+js(acis, atob, decodeURIComponent)
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$xmlhttprequest,domain=livemint.com
 ! Broken video playback on tn.com.ar (https://community.brave.com/t/the-blocker-does-not-allow-you-to-watch-the-video/76691)
 @@||googletagmanager.com/gtm.js$script,domain=tn.com.ar
+! allow cosmetics, to prevent being baited
+youtube.com#@##YtKevlarVisibilityIdentifier
+youtube.com#@##YtSparklesVisibilityIdentifier
+youtube.com#@##feed-pyv-container
+youtube.com#@##ytd-player button.ytp-suggested-action-badge
+youtube.com#@#.ad-showing > .html5-video-container
+youtube.com#@#.companion-ad-container
+youtube.com#@#.promoted-sparkles-text-search-root-container
+youtube.com#@#.promoted-videos
+youtube.com#@#.statement-banner-foreground-content
+youtube.com#@#.ytd-action-companion-ad-renderer
+youtube.com#@#.ytd-carousel-ad-renderer
+youtube.com#@#.ytd-compact-promoted-video-renderer
+youtube.com#@#.ytd-merch-shelf-renderer
+youtube.com#@#.ytd-player-legacy-desktop-watch-ads-renderer
+youtube.com#@#.ytd-promoted-sparkles-text-search-renderer
+youtube.com#@#.ytd-promoted-video-renderer
+youtube.com#@#.ytd-search-pyv-renderer
+youtube.com#@#.ytd-video-masthead-ad-primary-video-overlay-renderer
+youtube.com#@#.ytd-video-masthead-ad-v3-renderer
+youtube.com#@#.ytp-ad-action-interstitial-background-container
+youtube.com#@#.ytp-ad-action-interstitial-slot
+youtube.com#@#.ytp-ad-button
+youtube.com#@#.ytp-ad-overlay-container
+youtube.com#@#.ytp-ad-player-overlay-flyout-cta
+youtube.com#@#.ytp-ad-progress
+youtube.com#@#ytd-ad-slot-renderer
+youtube.com#@#ytd-promoted-sparkles-web-renderer
+youtube.com#@#div.ytd-ad-slot-renderer
+youtube.com#@#div.ytd-in-feed-ad-layout-renderer
+youtube.com#@#ytm-companion-slot
+! Updated rules new rules
+youtube.com###related > div#player-ads
+youtube.com###items > ytd-ad-slot-renderer
+! https://www.youtube.com/watch?v=vp5sSqyZ5Go (below video, merch links)
+youtube.com##a.yt-simple-endpoint.style-scope.ytd-merch-shelf-item-renderer
+! https://www.youtube.com/watch?v=fSM6Y9wkLgI (top right of video links)
+youtube.com##.ytp-chrome-top-buttons > .ytp-cards-teaser
+! Sell minecraft ad https://www.youtube.com/watch?v=IPtpwh7r0Eo
+youtube.com##ytd-ad-slot-renderer.style-scope.ytd-item-section-renderer
 ! uptostream
 uptostream.com,tirexo.lol##+js(acis, window.a)
 @@||tirexo.lol^$generichide


### PR DESCRIPTION
Video ads (post/pre-roll) will still be blocked via uBO. 

This will just stop youtube cosmetics from being targeted in Brave, test rules for upstream into EL if this works out.

Hoping this doesn't show any image/text ads. We can adjust if needed