### PR TITLE
Remove twitter filter

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -853,7 +853,6 @@ fivethirtyeight.com##.master-ad
 twitter.com##.promoted-account
 twitter.com##.promotion
 twitter.com##.stream-item-group-start[label="promoted"]
-twitter.com##[style] > div > div > [data-testid=placementTracking]
 twitter.com##a[href*="src=promoted_trend_click"]
 twitter.com##a[href*="src=promoted_trend_click"] + div
 twitter.com##div[data-testid="cellInnerDiv"] > div.css-1dbjc4n > div[class="css-1dbjc4n"] > div[class="css-1dbjc4n"][data-testid="placementTracking"]

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -94,8 +94,6 @@ crunchyroll.com##+js(set-local-storage-item, /_evidon_consent_ls_\d+/, $remove$)
 ||do-not-tracker.org^
 ! block scripts that profile user behavior using password managers
 @@||api.huobi.pro^$domain=www.huobi.pro
-! Twitter ad cosmetic element 
-twitter.com##[style]>div>div>[data-testid=placementTracking]
 ! Disable PDFJS which we include by default's telemetry
 ||pdfjs.robwu.nl
 ! Scroll bar-consent


### PR DESCRIPTION
Previously good filter, had to be removed due to missing images

https://twitter.com/elonmusk/status/1734106499868131340

Reported https://community.brave.com/t/issue-brave-shield-and-x-twitter-images-videos-not-loading/520821