### PR TITLE
Fix empty spaces on various news sites

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -8,7 +8,6 @@
 /greenoaks.gif?
 /porpoiseant/*
 !
-##AD-SLOT
 ###ad--article-top-wrapper
 ###ad--sidebar
 ###ad-mpu
@@ -42,6 +41,7 @@
 ###interstory_first_ddb_0
 ###interstory_second_ddb_0
 ###intro_ad_1
+###js-Taboola-Container-0
 ###js-image-ad-mpu
 ###leftrail_dynamic_ad_wrapper
 ###mpu1_parent
@@ -53,6 +53,8 @@
 ###rightrail_pos3_ddb_0
 ###skin-ad-left-rail-container
 ###splashy-ad-container-top
+###story_bottom_ddb_0
+###story_top_ddb_0
 ###taboola-below-article-1
 ###taboola-below-article-thumbnails
 ###taboola-below-article-thumbnails-v2
@@ -122,6 +124,7 @@
 ##.ad-section
 ##.ad-sidebar
 ##.ad-slot
+##.ad-slot--container
 ##.ad-slot-1
 ##.ad-slot-2
 ##.ad-slot-container
@@ -146,6 +149,9 @@
 ##.ad-unit--leaderboard
 ##.ad-wrap
 ##.ad-wrapper
+##.ad-wrapper--ad-unit-wrap
+##.ad-wrapper--articletop
+##.ad-wrapper__ad-slug
 ##.ad-zone
 ##.ad-zone-container
 ##.ad.card
@@ -164,6 +170,7 @@
 ##.adWrapper
 ##.ad_300
 ##.ad_300by250
+##.ad__align
 ##.ad__container
 ##.ad__section-border
 ##.ad__w728
@@ -225,6 +232,7 @@
 ##.c-asurionBottomBanner
 ##.c-gallery-vertical__advert
 ##.channel-sidebar-big-box-ad
+##.cnx-player-wrapper
 ##.collapsed-ad
 ##.column-ad
 ##.content-ad
@@ -265,6 +273,7 @@
 ##.horizontal.ad
 ##.image-viewer-ad
 ##.image-viewer-mpu
+##.index-module_adBeforeContent__UYZT
 ##.ins_adwrap
 ##.insticator-ads
 ##.instoryAdBlock
@@ -349,6 +358,7 @@
 ##.taboola-widget
 ##.taboola-wrapper
 ##.tadm_ad_unit
+##.takeover-ad
 ##.td-a-ad
 ##.td-ad
 ##.td-ad-m
@@ -612,6 +622,29 @@ euronews.com###js-smart-banner
 euronews.com##.base-leaderboard
 euronews.com##.enw-MPU
 euronews.com##.qa-dfpLeaderBoard
+! merriam-webster.com
+merriam-webster.com##.home-redesign-ad
+! themessenger.com
+themessenger.com##.htlad-leaderboard_top
+! dailyvoice.com
+dailyvoice.com##.b-banner
+dailyvoice.com##.e-nativo-container
+! mbl.is
+mbl.is##.augl
+! thepinknews.com
+thepinknews.com##.pn-ad-container
+thepinknews.com##.pn-remove-ads-container
+! inews.co.uk
+inews.co.uk##.inews__advert
+inews.co.uk##.inews__mpu
+! boingboing.net
+boingboing.net##.boing-amp-triple13-amp-1
+boingboing.net##.boing-homepage-after-first-article-in-list
+! propublica.org
+propublica.org##.bb-ad
+! sciencealert.com
+sciencealert.com###Purch_D_R_0_1
+sciencealert.com##.ad-desktop\:block
 ! business-standard.com
 business-standard.com##.advertisement-bg
 business-standard.com##div[id^="between_article_content_"]
@@ -731,7 +764,7 @@ cnbc.com##.TopBanner-container
 ! .zone
 bellinghamherald.com,bnd.com,bradenton.com,centredaily.com,charlotteobserver.com,elnuevoherald.com,fresnobee.com,heraldonline.com,heraldsun.com,idahostatesman.com,islandpacket.com,kansas.com,kansascity.com,kentucky.com,ledger-enquirer.com,macon.com,mcclatchydc.com,mercedsunstar.com,miamiherald.com,modbee.com,myrtlebeachonline.com,newsobserver.com,sacbee.com,sanluisobispo.com,star-telegram.com,sunherald.com,thenewstribune.com,theolympian.com,thestate.com,tri-cityherald.com##.zone
 ! .ads
-1sale.com,1v1.lol,7billionworld.com,9jaflaver.com,achieveronline.co.za,canstar.com.au,canstarblue.co.nz,cheapies.nz,climatechangenews.com,coingax.com,cryptonomist.ch,currencyrate.today,economictimes.com,energyforecastonline.co.za,esports.com,eventcinemas.co.nz,filmapik21.tv,flashx.tv,gamesadshopper.com,geo.tv,govtrack.us,gramfeed.com,hentaikun.com,hockeyfeed.com,i24news.tv,idiva.com,indiatimes.com,inspirock.com,investing.com,m.economictimes.com,mangasect.com,marinetraffic.com,mb.com.ph,mega4upload.com,mehrnews.com,meta-calculator.com,mini-ielts.com,miningprospectus.co.za,motogp.com,mugshots.com,nbc.na,news.nom.co,nsfwyoutube.com,onlinerekenmachine.com,ozbargain.com.au,piliapp.com,russia-insider.com,russian-faith.com,savevideo.me,sgcarmart.com sherdog.com,stars-portraits.com,straitstimes.com,teamblind.com,tehrantimes.com,tellerreport.com,thenews.com.pk,thestar.com.my,viamichelin.com,viamichelin.ie,vijesti.me,y8.com,yummy.ph##.ads
+1sale.com,1v1.lol,7billionworld.com,9jaflaver.com,achieveronline.co.za,canstar.com.au,canstarblue.co.nz,cheapies.nz,climatechangenews.com,coingax.com,cryptonomist.ch,currencyrate.today,economictimes.com,energyforecastonline.co.za,esports.com,eventcinemas.co.nz,filmapik21.tv,flashx.tv,gamesadshopper.com,geo.tv,govtrack.us,gramfeed.com,hentaikun.com,hockeyfeed.com,i24news.tv,idiva.com,indiatimes.com,inspirock.com,investing.com,m.economictimes.com,mangasect.com,marinetraffic.com,mb.com.ph,mega4upload.com,mehrnews.com,meta-calculator.com,mini-ielts.com,miningprospectus.co.za,motogp.com,mugshots.com,nbc.na,news.nom.co,nsfwyoutube.com,onlinerekenmachine.com,ozbargain.com.au,piliapp.com,readcomicsonline.ru,russia-insider.com,russian-faith.com,savevideo.me,sgcarmart.com,sherdog.com,stars-portraits.com,straitstimes.com,teamblind.com,tehrantimes.com,tellerreport.com,thenews.com.pk,thestar.com.my,viamichelin.com,viamichelin.ie,vijesti.me,y8.com,yummy.ph##.ads
 ! .advertisement
 aan.com,aarp.org,additudemag.com,animax-asia.com,apkforpc.com,audioxpress.com,axn-asia.com,bravotv.com,citiblog.co.uk,cnbctv18.com,cnn59.com,controleng.com,downzen.com,dw.com,dwturkce.com,escapeatx.com,foodsforbetterhealth.com,gemtvasia.com,hcn.org,huffingtonpost.co.uk,inqld.com.au,inspiredminds.de,investmentnews.com,jewishworldreview.com,legion.org,lifezette.com,livestly.com,magtheweekly.com,moneyland.ch,offshore-energy.biz,onetvasia.com,oxygen.com,pch.com,prospectmagazine.co.uk,readamericanfootball.com,readarsenal.com,readastonvilla.com,readbasketball.com,readbetting.com,readbournemouth.com,readboxing.com,readbrighton.com,readbundesliga.com,readburnley.com,readcars.co,readceltic.com,readchampionship.com,readchelsea.com,readcricket.com,readcrystalpalace.com,readeverton.com,readeverything.co,readfashion.co,readfilm.co,readfood.co,readfootball.co,readgaming.co,readgolf.com,readhorseracing.com,readhuddersfield.com,readhull.com,readinternationalfootball.com,readlaliga.com,readleicester.com,readliverpoolfc.com,readmancity.com,readmanutd.com,readmiddlesbrough.com,readmma.com,readmotorsport.com,readmusic.co,readnewcastle.com,readnorwich.com,readnottinghamforest.com,readolympics.com,readpl.com,readrangers.com,readrugbyunion.com,readseriea.com,readshowbiz.co,readsouthampton.com,readsport.co,readstoke.com,readsunderland.com,readswansea.com,readtech.co,readtennis.co,readtottenham.com,readtv.co,readussoccer.com,readwatford.com,readwestbrom.com,readwestham.com,readwsl.com,reason.com,redvoicemedia.com,revolver.news,rogerebert.com,smithsonianmag.com,streamingmedia.com,the-scientist.com,thecatholicthing.org,therighthairstyles.com,weatherwatch.co.nz,wheels.ca,whichcar.com.au,woot.com,worldofbitco.in##.advertisement
 ! clutchpoints.com
@@ -781,7 +814,7 @@ ndtv.com##div[class^="add_"]
 ! .adBanner
 chron.com,crypto-news-flash.com,greenwichtime.com,houstonchronicle.com,mysanantonio.com,seattlepi.com,sfchronicle.com,sfgate.com,thetelegraph.com,timesunion.com##.adBanner
 ! .code-block
-180gadgets.com,247media.com.ng,academicful.com,alltechnerd.com,americansongwriter.com,androidsage.com,animatedtimes.com,anoopcnair.com,askpython.com,asurascans.com,australiangeographic.com.au,autodaily.com.au,bigleaguepolitics.com,borncity.com,boxingnews24.com,browserhow.com,charlieintel.com,chillinghistory.com,chromeunboxed.com,conservativebrief.com,cookingwithdog.com,corrosionhour.com,crimereads.com,cryptobriefing.com,cryptopotato.com,cryptoreporter.info,cryptoslate.com,dailynewshungary.com,dcenquirer.com,dexdotexe.com,eurweb.com,exeo.app,fandomwire.com,firstsportz.com,flickeringmyth.com,flyingmag.com,freemagazines.top,gameinfinitus.com,gatewaynews.co.za,geekdashboard.com,getdroidtips.com,goodyfeed.com,greekreporter.com,hard-drive.net,hollywoodinsider.com,hollywoodunlocked.com,indianhealthyrecipes.com,inspiredtaste.net,iotwreport.com,journeybytes.com,journeyjunket.com,libertyunlocked.com,linuxfordevices.com,lithub.com,medievalists.net,mpost.io,nationalfile.com,nintendoeverything.com,notalwaysright.com,organicfacts.net,patriotfetch.com,protrumpnews.com,pureinfotech.com,quickanswer.blog,redrightvideos.com,reneweconomy.com.au,reptilesmagazine.com,rezence.com,roadaheadonline.co.za,rok.guide,sciencenotes.org,sdnews.com,simscommunity.info,small-screen.co.uk,storypick.com,streamingbetter.com,superwatchman.com,talkers.com,techpp.com,techrounder.com,techviral.net,thecinemaholic.com,thecricketlounge.com,thedriven.io,thegamehaus.com,thegatewaypundit.com,thegeekpage.com,thenipslip.com,thewincentral.com,trendingpolitics.com,trendingpoliticsnews.com,twistedvoxel.com,videogamer.com,walletinvestor.com,waves4you.com,wbiw.com,welovetrump.com,wepc.com,win.gg,wisden.com,zerohanger.com##.code-block
+180gadgets.com,247media.com.ng,academicful.com,alltechnerd.com,americansongwriter.com,androidsage.com,animatedtimes.com,anoopcnair.com,askpython.com,asurascans.com,australiangeographic.com.au,autodaily.com.au,bigleaguepolitics.com,borncity.com,boxingnews24.com,browserhow.com,charlieintel.com,chillinghistory.com,chromeunboxed.com,conservativebrief.com,cookingwithdog.com,corrosionhour.com,crimereads.com,cryptobriefing.com,cryptopotato.com,cryptoreporter.info,cryptoslate.com,dailynewshungary.com,dcenquirer.com,dexdotexe.com,eurweb.com,exeo.app,fandomwire.com,firstsportz.com,flickeringmyth.com,flyingmag.com,freemagazines.top,gameinfinitus.com,gatewaynews.co.za,geekdashboard.com,getdroidtips.com,goodyfeed.com,greekreporter.com,hard-drive.net,hollywoodinsider.com,hollywoodunlocked.com,indianhealthyrecipes.com,inspiredtaste.net,iotwreport.com,journeybytes.com,journeyjunket.com,libertyunlocked.com,linuxfordevices.com,lithub.com,medicotopics.com,medievalists.net,mpost.io,nationalfile.com,nintendoeverything.com,notalwaysright.com,organicfacts.net,patriotfetch.com,protrumpnews.com,pureinfotech.com,quickanswer.blog,redrightvideos.com,reneweconomy.com.au,reptilesmagazine.com,rezence.com,roadaheadonline.co.za,rok.guide,sciencenotes.org,sdnews.com,simscommunity.info,small-screen.co.uk,storypick.com,streamingbetter.com,superwatchman.com,talkers.com,tech-latest.com,techpp.com,techrounder.com,techviral.net,thecinemaholic.com,thecricketlounge.com,thedriven.io,thegamehaus.com,thegatewaypundit.com,thegeekpage.com,thenipslip.com,thewincentral.com,trendingpolitics.com,trendingpoliticsnews.com,twistedvoxel.com,videogamer.com,walletinvestor.com,waves4you.com,wbiw.com,welovetrump.com,wepc.com,win.gg,wisden.com,zerohanger.com##.code-block
 ! .code-block > center p
 storytohear.com,thefamilybreeze.com,thetravelbreeze.com,theworldreads.com,womensmethod.com##.code-block > center p
 ! kokomotribune.com,goshennews.com
@@ -1635,9 +1668,9 @@ latimes.com##.revcontent
 ! newsweek.com
 ||gc.newsweek.com/front/js/counter.js
 ! thehackernews.com
-thehackernews.com##[href^="https://thn.news/"]
 thehackernews.com##.babsi
 thehackernews.com##.gg-2
+thehackernews.com##[href^="https://thn.news/"]
 ! weather.com
 /eventproxy/track
 ||mparticle.weather.com/identity/
@@ -1645,9 +1678,9 @@ thehackernews.com##.gg-2
 /newrelic.js
 ! stuff.co.nz
 /adnostic/*
+||ads-api.stuff.co.nz^
 ||stuff.co.nz/static/adnostic/
 ||stuff.co.nz/static/stuff-adfliction/
-||ads-api.stuff.co.nz^
 ! patch.com
 ||pixel.patch.com^
 ! screenrant.com

--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -645,6 +645,8 @@ propublica.org##.bb-ad
 ! sciencealert.com
 sciencealert.com###Purch_D_R_0_1
 sciencealert.com##.ad-desktop\:block
+! softonic.com
+softonic.com##.sam-slot
 ! business-standard.com
 business-standard.com##.advertisement-bg
 business-standard.com##div[id^="between_article_content_"]

--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -1677,7 +1677,6 @@ thehackernews.com##[href^="https://thn.news/"]
 ! nzherald.co.nz
 /newrelic.js
 ! stuff.co.nz
-/adnostic/*
 ||ads-api.stuff.co.nz^
 ||stuff.co.nz/static/adnostic/
 ||stuff.co.nz/static/stuff-adfliction/


### PR DESCRIPTION
Only targeting and fixing empty blank space issues; only cosmetic, no network blocks.

```
softonic.com##.sam-slot
```

```
! fastcompany.com
##.ad-wrapper--ad-unit-wrap
##.ad-wrapper--articletop
##.ad-wrapper__ad-slug
! merriam-webster.com
merriam-webster.com##.home-redesign-ad
```

```
! https://wgme.com/
###story_top_ddb_0
###story_bottom_ddb_0
###rightrail_pos2_ddb_0
###rightrail_pos1_ddb_0
###js-Taboola-Container-0
##.index-module_adBeforeContent__UYZT
```

```
! themessenger.com
themessenger.com##.htlad-leaderboard_top
##.bg-grey-ad
```

```
! wtop.com
##.ad__align
##div[id^="rc-widget-"]
```

```
! mbl.is
mbl.is##.augl
##.takeover-ad
```

```
! propublica.org
propublica.org##.bb-ad
```

```
! sciencealert.com
sciencealert.com##.ad-desktop\:block
sciencealert.com###Purch_D_R_0_1
##.ad-slot--container
```

```
! thepinknews.com
thepinknews.com##.pn-ad-container
thepinknews.com##.pn-remove-ads-container
thepinknews.com##.pn-remove-ads-container
```

```
! inews.co.uk
inews.co.uk##.inews__advert
inews.co.uk##.inews__mpu
```

```
! https://boingboing.net
boingboing.net##.boing-amp-triple13-amp-1
boingboing.net##.boing-homepage-after-first-article-in-list
```

```
! dailyvoice.com
dailyvoice.com##.b-banner
dailyvoice.com##.e-nativo-container
##.cnx-player-wrapper
```