### PR TITLE
Clean ebay links

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -75,6 +75,23 @@
     },
     {
         "include": [
+            "*://www.ebay.*/itm/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "media",
+	    "mkcid",
+            "mkevt",
+            "ssspo",
+            "ssrc",
+            "var",
+            "widget_ver"
+        ]
+    },
+    {
+        "include": [
             "*://www.instagram.com/*"
         ],
         "exclude": [

--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -100,7 +100,6 @@
             "ssspo",
             "ssrc",
 	    "ssuid",
-            "var",
             "widget_ver"
         ]
     },

--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -75,7 +75,20 @@
     },
     {
         "include": [
-            "*://www.ebay.*/itm/*"
+            "*://*.ebay.com/itm/*",
+            "*://www.ebay.at/itm/*",
+            "*://www.ebay.ca/itm/*",
+            "*://www.ebay.co.uk/itm/*",
+            "*://www.ebay.com.au/itm/*",
+            "*://www.ebay.com.sg/itm/*",
+            "*://www.ebay.de/itm/*",
+            "*://www.ebay.es/itm/*",
+            "*://www.ebay.ie/itm/*",
+            "*://www.ebay.fr/itm/*",
+            "*://www.ebay.it/itm/*",
+            "*://www.ebay.ch/itm/*",
+            "*://www.ebay.nl/itm/*",
+            "*://www.ebay.pl/itm/*"
         ],
         "exclude": [
 

--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -86,6 +86,7 @@
             "mkevt",
             "ssspo",
             "ssrc",
+	    "ssuid",
             "var",
             "widget_ver"
         ]


### PR DESCRIPTION
Link I found from https://arstechnica.com/cars/2023/12/concorde-engine-sells-on-ebay-may-end-up-as-bits-of-furniture/

`
https://www.ebay.co.uk/itm/116001533010?mkcid=16&mkrid=711-127632-2357-0&ssspo=3X5IDjxbSpS&sssrc=4429486&ssuid=guVqnn7EQqq&var=&widget_ver=artemis&media=COPY
`

Works:
`https://www.ebay.co.uk/itm/116001533010`