### PR TITLE
Fixes bottom advert on  https://www.nyctourism.com/restaurant-week/

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -640,6 +640,8 @@ inews.co.uk##.inews__mpu
 ! boingboing.net
 boingboing.net##.boing-amp-triple13-amp-1
 boingboing.net##.boing-homepage-after-first-article-in-list
+! nyctourism.com
+nyctourism.com##.Layout_mobileStickyAdContainer__fCbCq
 ! propublica.org
 propublica.org##.bb-ad
 ! sciencealert.com


### PR DESCRIPTION
Imported from https://github.com/easylist/easylist/commit/68292b98523318526d1b1615d4cb8f7e87019294

