### PR TITLE
Fix empty space on reuters.com

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -1186,6 +1186,7 @@ wccftech.com##.mb-11
 wccftech.com##[href^="https://cutt.ly/"]
 ! reuters.com
 reuters.com##[data-testid="ResponsiveAdSlot"]
+reuters.com##[class^="primary-video__container_"]
 reuters.com##div[class^="AdSlot__container"]
 reuters.com##div[class^="RightRail-sticky-container"]
 reuters.com##div[class^="ad-slot__"]


### PR DESCRIPTION
Fixes empty ad space on https://www.reuters.com/business/autos-transportation/toyota-recalls-1-million-us-vehicles-over-sensor-that-could-short-circuit-2023-12-20/ due to invideo adverts.

Sync from: https://github.com/easylist/easylist/commit/e93d235