### PR TITLE
Remove Instagram's new `igsh` parameter ("Share to...")

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -81,6 +81,7 @@
 
         ],
         "params": [
+            "igsh",
             "igshid",
             "ig_rid"
         ]


### PR DESCRIPTION
Sample URLs:
- https://www.instagram.com/reel/C04bQYMRoQj/?utm_source=ig_web_button_share_sheet&igsh=ZDNl...IxNw==
- https://www.instagram.com/p/C1nNxSbsAzk/?utm_source=ig_web_button_share_sheet&igsh=ZDNl...IxNw==