### PR TITLE
Fixes Admiral 1p scripts on dotesports/primagames

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -1385,6 +1385,7 @@ autoevolution.com##.bgcutgrad
 /analytics_www.
 /appmeasurement.min.js
 /appmeasurement_module_
+://cmpworker.
 /ard.png?
 /b/ss/*/js-
 /batch/1/oe/*


### PR DESCRIPTION
Adjust exisited rule.

https://github.com/easylist/easylist/commit/66e647071776860fa42ad37b7160afa1514a91a6

As seen on: `https://www.destructoid.com/` reported https://community.brave.com/t/destructoid-com-ad-block-detected/526516/3