### PR TITLE
Update stuff.co.nz sites, fixes empty ad space

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -1715,6 +1715,7 @@ thehackernews.com##[href^="https://thn.news/"]
 ||ads-api.stuff.co.nz^
 ||stuff.co.nz/static/adnostic/
 ||stuff.co.nz/static/stuff-adfliction/
+thepress.co.nz,waikatotimes.co.nz,stuff.co.nz##.header-ads-block
 ! patch.com
 ||pixel.patch.com^
 ! screenrant.com


### PR DESCRIPTION
https://github.com/easylist/easylist/commit/ad42e41da4882712a261c186d099604c83e5a73b
https://github.com/easylist/easylist/commit/839f0da4680e976f409612e404a78de8bba34329

Fixes empty header ad space, site was re-designed.