### PR TITLE
Fixes https://github.com/brave/brave-browser/issues/35431

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -96,6 +96,11 @@ crunchyroll.com##+js(set-local-storage-item, /_evidon_consent_ls_\d+/, $remove$)
 @@||api.huobi.pro^$domain=www.huobi.pro
 ! Disable PDFJS which we include by default's telemetry
 ||pdfjs.robwu.nl
+! GPC issues; https://github.com/brave/brave-browser/issues/35431
+! Is a small delay on load, but menus will load
+weather.com##+js(trusted-set-local-storage-item, userConsents, '{"sale-of-data":false}')
+weather.com##+js(trusted-set-local-storage-item, gpcSetting, true)
+weather.com##+js(trusted-set-local-storage-item, mdLogger, false)
 ! Scroll bar-consent
 collegeconfidential.com##body:style(overflow: auto !important; max-height: 1px !important;)
 ! Fix preloader (facebook check)

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -99,8 +99,6 @@ crunchyroll.com##+js(set-local-storage-item, /_evidon_consent_ls_\d+/, $remove$)
 ! GPC issues; https://github.com/brave/brave-browser/issues/35431
 ! Is a small delay on load, but menus will load
 weather.com##+js(trusted-set-local-storage-item, userConsents, '{"sale-of-data":false}')
-weather.com##+js(trusted-set-local-storage-item, gpcSetting, true)
-weather.com##+js(trusted-set-local-storage-item, mdLogger, false)
 ! Scroll bar-consent
 collegeconfidential.com##body:style(overflow: auto !important; max-height: 1px !important;)
 ! Fix preloader (facebook check)


### PR DESCRIPTION
Fixes GPC issue with weather.com

Assigned the local storage; `weather.com##+js(trusted-set-local-storage-item, userConsents, '{"sale-of-data":false}')` on load. Fixes menus.