### PR TITLE
Fixes open-in-app fix for imgur.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -944,6 +944,8 @@ scrolller.com##.popup--fixed
 ! https://github.com/uBlockOrigin/uAssets/issues/18148#issuecomment-1555962148
 ||akamaized.net/audio/$media,redirect-rule=noop-1s.mp4,domain=open.spotify.com,important
 ||scdn.co/audio/$media,redirect=noop-1s.mp4,domain=open.spotify.com,important
+! Mobile-app (trusted) Open-in-app 
+imgur.com##+js(trusted-set-local-storage-item, see_imgur_oia, '{"closed":true}')
 ! fixes from remove()
 apnews.com##+js(ra, data-leaderboard-is-fixed, html, stay)
 ! Counter blocked by extension warnings


### PR DESCRIPTION
Resolves open in app check on https://imgur.com/4ZeIC (mobile uA)

![imgur-open-in-app](https://github.com/brave/adblock-lists/assets/1659004/7687e244-2346-4455-8435-4372ac01e2dc)
