### PR TITLE
Avoid GPC detection on weather.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -96,12 +96,11 @@ crunchyroll.com##+js(set-local-storage-item, /_evidon_consent_ls_\d+/, $remove$)
 @@||api.huobi.pro^$domain=www.huobi.pro
 ! Disable PDFJS which we include by default's telemetry
 ||pdfjs.robwu.nl
-! GPC issues https://github.com/brave/adblock-resources/pull/148
-sephora.com##+js(set, Navigator.prototype.globalPrivacyControl, false)
-sephora.com##+js(set, navigator.globalPrivacyControl, false)
-! GPC issues; https://github.com/brave/brave-browser/issues/35431
-! Is a small delay on load, but menus will load
-weather.com##+js(trusted-set-local-storage-item, userConsents, '{"sale-of-data":false}')
+! GPC issues 
+! sephora.com https://github.com/brave/adblock-resources/pull/148
+! weather.com https://github.com/brave/brave-browser/issues/35431
+sephora.com,weather.com##+js(set, Navigator.prototype.globalPrivacyControl, false)
+sephora.com,weather.com##+js(set, navigator.globalPrivacyControl, false)
 ! Soft anti-adblock
 maxroll.gg##+js(trusted-set-local-storage-item, adBlockWarning, '{"value":true}')
 ! Scroll bar-consent


### PR DESCRIPTION
Setting these to false avoid GPC being checked in weather.com

![weathercom](https://github.com/brave/adblock-lists/assets/1659004/8197ae2d-60ca-4dfb-96e5-4891a9300417)
