### PR TITLE
Optimise YT filters

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -108,13 +108,13 @@ collegeconfidential.com##body:style(overflow: auto !important; max-height: 1px !
 ! Fix preloader (facebook check)
 igniteunmc.com##.preloader
 ! https://github.com/brave/adblock-lists/pull/1471
-youtube.com##+js(spoof-css, #player-ads, display, block)
-youtube.com##+js(spoof-css, .ytd-merch-shelf-renderer, display, block)
-youtube.com##+js(spoof-css, .ytd-page-top-ad-layout-renderer, display, block)
-youtube.com##+js(spoof-css, .ytp-suggested-action-badge, display, block)
-youtube.com##+js(spoof-css, ytd-ad-slot-renderer, display, block)
-youtube.com##+js(spoof-css, ytd-banner-promo-renderer, display, block)
-youtube.com##+js(spoof-css, ytd-search-pyv-renderer, display, block)
+! youtube.com##+js(spoof-css, #player-ads, display, block)
+! youtube.com##+js(spoof-css, .ytd-merch-shelf-renderer, display, block)
+! youtube.com##+js(spoof-css, .ytd-page-top-ad-layout-renderer, display, block)
+! youtube.com##+js(spoof-css, .ytp-suggested-action-badge, display, block)
+! youtube.com##+js(spoof-css, ytd-ad-slot-renderer, display, block)
+! youtube.com##+js(spoof-css, ytd-banner-promo-renderer, display, block)
+! youtube.com##+js(spoof-css, ytd-search-pyv-renderer, display, block)
 !
 ! youtube
 youtube.com#@#body > ytd-app > #content.ytd-app.style-scope > tp-yt-app-drawer#guide.ytd-app.style-scope[align="start"][role="navigation"][style^="transition-duration:"][position] + ytd-mini-guide-renderer.ytd-app.style-scope + ytd-page-manager#page-manager.ytd-app.style-scope > ytd-browse.ytd-page-manager.style-scope[page-subtype="home"][role="main"] > ytd-settings-sidebar-renderer.ytd-browse.style-scope + dom-if.ytd-browse.style-scope + ytd-two-column-browse-results-renderer.grid-disabled.grid.ytd-browse.style-scope[page-subtype="home"][style] > #primary.ytd-two-column-browse-results-renderer.style-scope > ytd-rich-grid-renderer.ytd-two-column-browse-results-renderer.style-scope[style^="--ytd-rich-grid-item-max-width:"] > #header.ytd-rich-grid-renderer.style-scope ~ #masthead-ad.ytd-rich-grid-renderer.style-scope > ytd-ad-slot-renderer.ytd-rich-grid-renderer.style-scope:not(:empty)
@@ -133,14 +133,20 @@ youtube.com#@#body > ytd-app > #content.ytd-app.style-scope > tp-yt-app-drawer#g
 youtube.com#@#body > ytd-app > #content.ytd-app.style-scope > tp-yt-app-drawer#guide.ytd-app.style-scope[align="start"][role="navigation"][style^="transition-duration:"][position] + ytd-mini-guide-renderer.ytd-app.style-scope + ytd-page-manager#page-manager.ytd-app.style-scope > ytd-watch-flexy.ytd-page-manager.style-scope[video-id][js-panel-height_][flexy][rounded-info-panel][role="main"][style^="--ytd-watch-flexy-"] > #single-column-container.ytd-watch-flexy.style-scope + #columns.ytd-watch-flexy.style-scope > #primary.ytd-watch-flexy.style-scope > #primary-inner.ytd-watch-flexy.style-scope > #player.ytd-watch-flexy.style-scope > #player-container-outer.ytd-watch-flexy.style-scope > #player-container-inner.ytd-watch-flexy.style-scope > #player-container.ytd-watch-flexy.style-scope[role="complementary"][style] > ytd-player#ytd-player.ytd-watch-flexy.style-scope[style] > #container.ytd-player.style-scope > #movie_player.playing-mode.html5-video-player[data-version^="/s/player/"][aria-label] > .ytp-suggested-action[data-layer] > button.ytp-suggested-action-badge-with-controls.ytp-suggested-action-badge.ytp-button:not(:empty)
 youtube.com#@#body > ytd-app > #content.ytd-app.style-scope > tp-yt-app-drawer#guide.ytd-app.style-scope[align="start"][role="navigation"][style^="transition-duration:"][position] + ytd-mini-guide-renderer.ytd-app.style-scope + ytd-page-manager#page-manager.ytd-app.style-scope > ytd-watch-flexy.ytd-page-manager.style-scope[video-id][js-panel-height_][flexy][rounded-info-panel][role="main"][style^="--ytd-watch-flexy-"] > #single-column-container.ytd-watch-flexy.style-scope + #columns.ytd-watch-flexy.style-scope > #secondary.ytd-watch-flexy.style-scope > #secondary-inner.ytd-watch-flexy.style-scope > #related.ytd-watch-flexy.style-scope > #player-ads.ytd-watch-flexy.style-scope:not(:empty)
 !
-! youtube
-youtube.com###content > ytd-ad-slot-renderer
+! youtube (optimised)
+youtube.com###fulfilled-layout.ytd-ad-slot-renderer
+youtube.com##.ytd-statement-banner-renderer
+youtube.com##.statement-banner-content-wrapper
+youtube.com###player-ads
+! youtube (previous)
+! youtube.com###items > ytd-ad-slot-renderer
+! youtube.com###panels > [target-id="engagement-panel-ads"]
+! youtube.com###related > div#player-ads
+! youtube.com###content > ytd-ad-slot-renderer
+!
 youtube.com###contents.style-scope.ytd-search-pyv-renderer
-youtube.com###items > ytd-ad-slot-renderer
 youtube.com###main > #banner.ytd-merch-shelf-renderer
 youtube.com###masthead-ad > .ytd-rich-grid-renderer
-youtube.com###panels > [target-id="engagement-panel-ads"]
-youtube.com###related > div#player-ads
 youtube.com###scroll-container > #items.ytd-merch-shelf-renderer
 youtube.com###ytd-player button.ytp-suggested-action-badge
 youtube.com##.ytp-chrome-top-buttons > .ytp-cards-teaser


### PR DESCRIPTION
Lets  try to improve performance on Ios (and possible on desktop)

1. `spoof-css` Maybe causing perf issues highlighted on ios, not needed currently. So let disable these for the time being.
2.  Create more optimised cosmetic filters  

No warnings so far, and ads still blocked.
 