### PR TITLE
Quick fix on sponsored items

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -137,6 +137,7 @@ youtube.com#@#body > ytd-app > #content.ytd-app.style-scope > tp-yt-app-drawer#g
 youtube.com###fulfilled-layout.ytd-ad-slot-renderer
 youtube.com##.ytd-statement-banner-renderer
 youtube.com##.statement-banner-content-wrapper
+youtube.com###item-list.ytd-merch-shelf-renderer
 youtube.com###player-ads
 ! youtube (previous)
 ! youtube.com###items > ytd-ad-slot-renderer


### PR DESCRIPTION
Update from: https://github.com/brave/adblock-lists/pull/1489 

From https://www.youtube.com/watch?app=desktop&v=MD35zQk7xYs  (Fixes sponsored items)

