### PR TITLE
Fixes revolving adservers in ios

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -25,6 +25,13 @@
 ||fleraprt.com^
 ||tzegilo.com^
 
+! generic blocks
+/script/utils.js$script,third-party
+/script/suv5.js
+/script/suurl5.php
+/script/ut.js?cb=
+/d3.php?m=
+
 ! https://github.com/easylist/easylist/commit/d3a2c54ac
 @@||app.posthog.com/decide/
 


### PR DESCRIPTION
Imported from uBO, fixes revolving adservers on `https://www.extreme-down.moe/` (and other sites)