### PR TITLE
Cover weather.com firtst-party trackers

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -2026,8 +2026,9 @@ thehackernews.com##.babsi
 thehackernews.com##.gg-2
 thehackernews.com##[href^="https://thn.news/"]
 ! weather.com
+.privacydatanotice.
+||weather.com/*.medalliasurvey.
 /eventproxy/track
-||mparticle.weather.com/identity/
 ! nzherald.co.nz
 /newrelic.js
 ! stuff.co.nz


### PR DESCRIPTION
Cover first-party trackers on weather.com, limit the nag screens on the site.