### PR TITLE
General first-party tracking fixes

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -10,6 +10,7 @@
 /discourse-adplugin-
 /porpoiseant/*
 /plugins/advanced-ads/*$domain=~wordpress.org
+/prebid/*$script
 /webads.
 !
 ! Taboola
@@ -1612,6 +1613,7 @@ autoevolution.com##.bgcutgrad
 /analytics-dotcom/*
 /analytics_wbc.
 /analytics_www.
+/analytics.config.js
 /appmeasurement.min.js
 /appmeasurement_module_
 ://cmpworker.
@@ -1679,6 +1681,7 @@ autoevolution.com##.bgcutgrad
 /px/client/main.min.js
 /remote-weblab-triggers/*
 /reporting/metrics
+/r.rnc?
 /rum_cmp?
 /ruxitagentjs_
 /s.gif?
@@ -1687,8 +1690,10 @@ autoevolution.com##.bgcutgrad
 /smetrics.*/id?
 /track?eventkey=
 /transparent.gif?ray=
+/trackjs.$domain=~trackjs.com
 /uedata?
 /unagi.amazon.
+/visitoridentification.js
 /.well-known/shopify/monorail
 /wa.gif?
 /web-pixel-shopify-app-pixel@
@@ -1981,6 +1986,8 @@ redtube.com,redtube.com.br,youporn.com##+js(set-constant, page_params.holiday_pr
 ! figma.com
 /?sentry_key=
 /web_logger/*
+! play.google.com
+||play.google.com/log
 ! kijiji.ca
 kijiji.ca##.adChoices-804693302
 kijiji.ca##.gqNGFh
@@ -1996,6 +2003,8 @@ latimes.com##.revcontent
 ! newatlas.com
 /brightspot/analytics/*
 /bsp-analytics.
+! theguardian.com
+||ophan.theguardian.com^
 ! nypost.com
 /blaize/datalayer
 ||t.nypost.com^

--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -1678,6 +1678,7 @@ autoevolution.com##.bgcutgrad
 /pixel_V2.js
 /pixeljs/*
 /pixelNew.js
+/plugins/duracelltomi-google-tag-manager/*
 /px/client/main.min.js
 /remote-weblab-triggers/*
 /reporting/metrics


### PR DESCRIPTION
1. https://housefresh.com/david-vs-digital-goliaths/  `/plugins/duracelltomi-google-tag-manager/*`
2. https://www.theguardian.com/politics/2024/feb/19/it-must-be-exhausting-to-be-kemi-badenoch-anger-her-ever-faithful-companion `ophan.theguardian.com/`
3. https://safc.com/news/team-news/2024/february/mike-dodds-appointed-interim-head-coach `/visitoridentification.js`
4. https://www.mirror.co.uk/3am/celebrity-news/breaking-bbc-strictlys-amy-dowden-32156961 `/analytics.config.js` `/prebid/*$script`
5. https://www.snopes.com/fact-check/last-photo-alexei-navalny/ `play.google.com/log` (via google news link)
6.  https://www.virginatlantic.com/ `/r.rnc?` `/trackjs.$domain=~trackjs.com`
