### PR TITLE
Fixes https://www.pravda.com.ua/news/2024/02/21/7442950/

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -136,7 +136,6 @@
 ##.ad-header-pencil
 ##.ad-incontent
 ##.ad-inline
-##.ad-label
 ##.ad-lead
 ##.ad-leaderboard
 ##.ad-left-top
@@ -484,6 +483,7 @@
 ##.ac-lre-wrapper
 ##.ad-container--hot-video
 ##.ae-player__itv
+##.nts-ad
 ##.nts-video-wrapper
 ##.aniview-inline-player
 ##.aplvideo
@@ -1152,7 +1152,7 @@ jpost.com##.line-one-row-before-and-after-container
 jpost.com##.right-side-banner
 ! msn.com
 msn.com###displayAdCard
-msn.com###div[id^="mrr-topad-"]
+msn.com##div[id^="mrr-topad-"]
 msn.com###partners
 msn.com###promotions
 msn.com##.articlePage_bannerAd_wrapper-DS-EntryPoint1-1


### PR DESCRIPTION
Add missing `##.nts-ad` element from https://github.com/brave/adblock-lists/pull/1541

Just a couple of cleanups:
Removed dube: `##.ad-label`
Fix `msn.com##div[id^="mrr-topad-"]`  (extra #)
