### PR TITLE
Fixes broken sites in https://github.com/brave/brave-browser/issues/35084

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -876,6 +876,10 @@ canyoublockit.com##+js(nowoif)
 ||betsonsport.ru^$domain=rutracker.net
 ! Fix endless loading on epaper.timesgroup.com
 @@||googletagservices.com/tag/js/gpt.js$script,domain=epaper.timesgroup.com
+! ad-shield fixes broken sites (will show ads, but not a broken site)
+! https://github.com/brave/brave-browser/issues/35084
+! https://github.com/brave/brave-browser/issues/36328
+@@||css-load.com^
 ! Fix nfl.com video playback
 @@||googletagservices.com/tag/js/gpt.js$script,domain=nfl.com
 ! Fix twitter images 


### PR DESCRIPTION
Also https://github.com/brave/brave-browser/issues/36328

Site is broken due to ad-shield anti-adblock scripts.