### PR TITLE
Test rules for google precision popup

### DIFF
--- a/brave-lists/experimental.txt
+++ b/brave-lists/experimental.txt
@@ -9,3 +9,9 @@ www.youtube.com##+js(trusted-replace-fetch-response, /"auxiliaryUi":\{"messageRe
 www.youtube.com##+js(trusted-replace-fetch-response, /("trackingParam":"kx_fmPxhoPZR)[-_0-9A-Za-z]{150}[-_0-9A-Za-z]+?([-_0-9A-Za-z]{43}BwOcCE59TDtslLKPQ-SS"\})/, $1$2, player?)
 www.youtube.com##+js(trusted-replace-xhr-response, /"auxiliaryUi":\{"messageRenderers":\{"bkaEnforcementMessageViewModel.*?e\}\}\}\,/, , player?)
 www.youtube.com##+js(trusted-replace-xhr-response, /("trackingParam":"kx_fmPxhoPZR)[-_0-9A-Za-z]{150}[-_0-9A-Za-z]+?([-_0-9A-Za-z]{43}BwOcCE59TDtslLKPQ-SS"\})/, $1$2, player?)
+!
+! Google precision popup
+www.google.com,www.google.ca,www.google.com.au,www.google.co.nz,www.google.co.uk,www.google.ie,www.google.fr,www.google.nl,www.google.pt,www.google.de##.gTMtLb.fp-nh[style="visibility: visible;"]
+! Google precision popup (Fix disabled scroll)
+www.google.com,www.google.ca,www.google.com.au,www.google.co.nz,www.google.co.uk,www.google.ie,www.google.fr,www.google.nl,www.google.pt,www.google.de##html.TaoyYc:style(position: static !important; overflow: auto !important; width: auto !important;)
+


### PR DESCRIPTION
Test rules

Rather than target all of *.google.com, just target www.* on some specific domains.

Tweaked rule to be more specific to `##html.TaoyYc` rather than add a sytle to every html header

Fixing:

![image (11)](https://github.com/brave/adblock-lists/assets/1659004/b2010012-13df-474b-a691-794f195497a8)
