### PR TITLE
Fixes france24 empty space issue

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -1666,7 +1666,6 @@ afr.com###stickyLeaderboard
 ! france24.com
 france24.com##.m-block-ad
 france24.com##.m-interstitial
-france24.com##.o-ad-container
 ! timesofisrael.com
 timesofisrael.com##.banner-placeholder
 ! timesofindia.com


### PR DESCRIPTION
Removed filter for france24.com, possibly causing issues. Fix was up'd in https://github.com/easylist/easylist/commit/4dc083b87609997411284ae499353c352f38fb98