### PR TITLE
Remove more unnecessary Amazon URL parameters

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -28,6 +28,10 @@
 
         ],
         "params": [
+            "dib",
+            "dib_tag",
+            "keywords",
+            "th",
             "content-id",
             "linkCode",
             "tag",


### PR DESCRIPTION
Sample URL: https://www.amazon.com/Plant-Based-Mushroom-Gluten-Free-Artificial-Sweetener/dp/B0B51XMF7B/ref=sr_1_5?crid=3OB6DTGMPHIL8&dib=eyJ2IjoiMSJ9.hVN0oL-RBGwpL6fJshDsKEsDHK3x7qH091kayQ7xzJzjs8NLZ_AUxENpF1QFX7WfvBi06zcoE4ywD2ZDDylH1vZthxI3ZAiMbGd1HU61oJ-IhXGBFFAbNrgiR9vDTIgVHc-yIsfusP2oqLkYPD_-db57PePKiUaYkzpa-jsJ-cA1gGT6KRiZww427hOVKA3NcCbM5Q1FEtrI9VdqziAiotffsILEQS6Hhse8CsDLONA8G2CwzvNZ7gHWAPVkwvxD2Kf7-TwsQMINqpSdLuQfMiFWMulpQ0Sg15l1l3mhVhs.V7xR4W12fuaJaaYL-rWIRTlLsAn4DbT1teBEOiVkroU&dib_tag=se&keywords=mushroom%2Bjerky%2Bvegan&qid=1709319587&s=grocery&sprefix=mushroom%2Bjer%2Cgrocery%2C98&sr=1-5&th=1

We already remove `crid`, `qid` and `sprefix`. `s` and `sr` are [exempted in AdGuard](https://github.com/AdguardTeam/AdguardFilters/blob/22eb0dd26664a71ce614c902106f7237fe4d79a0/TrackParamFilter/sections/specific.txt#L1462-L1463) for breakage. That leaves us with `th` ([removed](https://github.com/AdguardTeam/AdguardFilters/blob/22eb0dd26664a71ce614c902106f7237fe4d79a0/TrackParamFilter/sections/specific.txt#L1508) by AdGuard), `dib` (the biggest one above) and `dib_tag`. The last two don't feature on any other list I could find but they do appear to be unnecessary for the URL to work.

Finally `keywords` has a visible effect when removed (the search bar is cleared), but search result pages actually use the `k` parameter, not `keywords` (e.g. https://www.amazon.com/s?k=mushroom+jerky+vegan) and so I don't think it will break links to search pages.