### PR TITLE
Fixes login button on britishairways.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -94,6 +94,9 @@ maxroll.gg##+js(trusted-set-local-storage-item, adBlockWarning, '{"value":true}'
 collegeconfidential.com##body:style(overflow: auto !important; max-height: 1px !important;)
 ! open-in-app reddit nag
 reddit.com##+js(trusted-set-local-storage-item, xpromo-consolidation, $currentDate$)
+! fingerprinting issues, login text not showing on homepage
+ba.com,britishairways.com##+js(tset-cookie, publicRefreshToken, 1)
+ba.com,britishairways.com##+js(set-cookie, publicAccessToken, 1)
 ! Fix preloader (facebook check)
 igniteunmc.com##.preloader
 ! youtube.com improve blocking

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -95,7 +95,7 @@ collegeconfidential.com##body:style(overflow: auto !important; max-height: 1px !
 ! open-in-app reddit nag
 reddit.com##+js(trusted-set-local-storage-item, xpromo-consolidation, $currentDate$)
 ! fingerprinting issues, login text not showing on homepage
-ba.com,britishairways.com##+js(tset-cookie, publicRefreshToken, 1)
+ba.com,britishairways.com##+js(set-cookie, publicRefreshToken, 1)
 ba.com,britishairways.com##+js(set-cookie, publicAccessToken, 1)
 ! Fix preloader (facebook check)
 igniteunmc.com##.preloader


### PR DESCRIPTION
Address: https://community.brave.com/t/unable-to-login-to-british-airways/535309/

Brave fingerprinting causing login button not to show.

1. Opening `https://www.britishairways.com/`
2. Login text doesn't show with default shields, with fingerprinting enabled
