### PR TITLE
Fixes randomised scripts on domains

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -74,6 +74,8 @@ crunchyroll.com##+js(set-local-storage-item, /_evidon_consent_ls_\d+/, $remove$)
 ||trackersimulator.org^
 ||eviltracker.net^
 ||do-not-tracker.org^
+! omegascans.org/nsfwyoutube.com/torlock.com
+/^https:\/\/[0-9a-f]{10}\.[0-9a-f]{10}\.com\/[0-9a-f]{32}\.js$/$script,3p,domain=fastpic.org|torlock.com|nsfwyoutube.com|omegascans.org|animeland.tv|streamhub.to|unblockit.africa
 ! Disable PDFJS which we include by default's telemetry
 ||pdfjs.robwu.nl
 ! GPC issues 


### PR DESCRIPTION
Fixes ads on `https://omegascans.org/` (NSFW) Reported in https://github.com/brave-experiments/web-compat-reports/issues/212  

ALso used in other sites.