### PR TITLE
Remove search.brave.com filter

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -15,7 +15,6 @@
 @@||basicattentiontoken.org^$first-party
 ! search.brave.com specfic filters
 ! https://github.com/uBlockOrigin/uAssets/blob/master/filters/privacy.txt#L260
-@@||search.brave.com^$ghide
 @@||search.brave.com/api/$first-party
 search.brave.com#@#+js(no-fetch-if, body:browser)
 ! stats.brave.com


### PR DESCRIPTION
Also needed to allowing filtering of Brave ads in aggressive mode.