### PR TITLE
Test brave-disable-pageview-api on nicovideo.jp

### DIFF
--- a/brave-lists/experimental.txt
+++ b/brave-lists/experimental.txt
@@ -5,7 +5,7 @@
 
 ! counter page visibility checks on youtube.com/twitch
 youtube.com##+js(brave-video-bg-play)
-tiktok.com,youtube.com,twitch.tv##+js(brave-disable-pageview-api)
+nicovideo.jp,tiktok.com,youtube.com,twitch.tv##+js(brave-disable-pageview-api)
 !
 ! Google precision popup
 www.google.com,www.google.ca,www.google.com.au,www.google.co.nz,www.google.co.uk,www.google.ie,www.google.fr,www.google.nl,www.google.pt,www.google.de##.gTMtLb.fp-nh[style="visibility: visible;"]


### PR DESCRIPTION
From user report: https://community.brave.com/t/niconico-live-streaming-cannot-be-played-in-the-background/538364

Lets test disabling pageview api on nicovideo. 