### PR TITLE
Remove unnecessary parameters from New York Times links

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -379,6 +379,18 @@
     },
     {
         "include": [
+            "*://*.nytimes.com/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "smid",
+            "ugrp"
+        ]
+    },
+    {
+        "include": [
             "*://*/*"
         ],
         "exclude": [


### PR DESCRIPTION
Sample URL: https://www.nytimes.com/2024/03/21/technology/apple-doj-lawsuit-antitrust.html?ugrp=c&unlocked_article_code=1.eU0.rOGs.FT-h0cSMdBpB&smid=url-share

`smid` is in the [Firefox list](https://hg.mozilla.org/mozilla-central/file/9f6186fead44331f08345609420b870c93eea2db/toolkit/components/antitracking/StripOnShareLists/LGPL/StripOnShareLGPL.json#l537).