### PR TITLE
Fix search.brave.com ad flash

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -16,6 +16,7 @@
 ! search.brave.com specfic filters
 ! https://github.com/uBlockOrigin/uAssets/blob/master/filters/privacy.txt#L207
 search.brave.com#@#+js(no-fetch-if, body:browser)
+search.brave.com###search-ad
 ! stats.brave.com
 @@||stats.brave.com^$ghide
 @@||stats.brave.com^$first-party


### PR DESCRIPTION
There is a flash of the advert on search.brave.com, this should help. And should only apply in standard shields mode.

https://bravesoftware.slack.com/archives/C3GNZANPR/p1711040364417089