### PR TITLE
Fixes ncaa.com videos

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -50,6 +50,7 @@ grubhub.com,dashboard.razorpay.com,joinhoney.com#@##credential_picker_container
 ###ad-leaderboard
 ###ad-placeholder
 ###ad_bnr_atf_01
+###ad_bnr_atf_02
 ###ad_leaderboard
 ###ad_lead1
 ###ad_rect_btf_01
@@ -87,6 +88,7 @@ grubhub.com,dashboard.razorpay.com,joinhoney.com#@##credential_picker_container
 ###dsk-box-ad-d
 ###dsk-banner-ad-a
 ###dsk-banner-ad-b
+###header-ad-block
 ###interstory_first_ddb_0
 ###interstory_second_ddb_0
 ###intro_ad_1
@@ -1781,6 +1783,8 @@ thestar.com##.adLabelWrapper
 hilltimes.com##.elementor-element-5818a09
 ! toronto.citynews.ca
 citynews.ca##.ad-load
+! ncaa.com
+ncaa.com##.top-banner
 ! .arc_ad
 ajc.com,bostonglobe.com##.arc_ad
 ! myabandonware.com (anti-adblock)

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -22,6 +22,9 @@ search.brave.com###search-ad
 @@||stats.brave.com^$first-party
 ! community.brave.com
 @@||community.brave.com^$ghide
+! ncaa.com videos breaking
+||medium.ngtv.io/v2/media/*&ssaiprofile=$xhr,removeparam=ssaiProfile
+@@||medium.ngtv.io/v2/media/*&ssaiprofile=$xhr,removeparam=ssaiProfile,domain=cnn.com
 ! CNAME: account.adobe.com
 @@||account.adobe.com^
 ! CNAME: pol.dk


### PR DESCRIPTION
Counter the uBO filter 

`||medium.ngtv.io/v2/media/*&ssaiprofile=$xhr,removeparam=ssaiProfile,from=~cnn.com`

Replaced with 

```
||medium.ngtv.io/v2/media/*&ssaiprofile=$xhr,removeparam=ssaiProfile
@@||medium.ngtv.io/v2/media/*&ssaiprofile=$xhr,removeparam=ssaiProfile,domain=cnn.com
```

Also add some generic cosmetics used on the site.

User will still need Widevine for the videos to work correctly, other issues will occur without it
