### PR TITLE
Add new MailerLite parameters

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -486,6 +486,8 @@
             "brave-campaign-id",
             "brave-creative-id",
             "brave-creative-set-id",
+            "ml_sub",
+            "ml_sub_hash",
             "ml_subscriber",
             "ml_subscriber_hash",
             "mc_cid",


### PR DESCRIPTION
We added longer parameters for this mailing list service in https://github.com/brave/adblock-lists/pull/1032, but it looks like they're now using a shorter version of them.

Sample URL: https://www.drinkcontainer.beer/csa?ml_sub=24459090&ml_sub_hash=a0o5