### PR TITLE
Merge brave-disable-pageview-api rules from experimental

### DIFF
--- a/brave-lists/experimental.txt
+++ b/brave-lists/experimental.txt
@@ -5,7 +5,7 @@
 
 ! counter page visibility checks on youtube.com/twitch
 youtube.com##+js(brave-video-bg-play)
-nicovideo.jp,tiktok.com,youtube.com,twitch.tv##+js(brave-disable-pageview-api)
+youtube.com##+js(brave-disable-pageview-api)
 !
 ! Google precision popup
 www.google.com,www.google.ca,www.google.com.au,www.google.co.nz,www.google.co.uk,www.google.ie,www.google.fr,www.google.nl,www.google.pt,www.google.de##.gTMtLb.fp-nh[style="visibility: visible;"]

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -22,6 +22,8 @@ search.brave.com###search-ad
 @@||stats.brave.com^$first-party
 ! community.brave.com
 @@||community.brave.com^$ghide
+! pageview-api detection
+nicovideo.jp,tiktok.com,twitch.tv,nzherald.co.nz##+js(brave-disable-pageview-api)
 ! CNAME: account.adobe.com
 @@||account.adobe.com^
 ! CNAME: pol.dk


### PR DESCRIPTION
Allow videos to play in the background, and avoid pausing when tab is unselected (minise the window or switching)

Also included nzherald.co.nz `https://www.nzherald.co.nz/nz/politics/act-leader-david-seymour-on-lifting-state-funding-for-private-schools-but-reducing-free-lunches-in-state-schools/DHRCXW5J3JEOTHY5FAMBOYVGFQ/` where the video will pause when tab is unselected, rather than letting video playing in the background.

Leaving the Youtube fix in experimental.txt for the time being.



- nicovideo.jp https://github.com/brave/adblock-lists/pull/1599
- tiktok.com https://github.com/brave/adblock-lists/pull/1581
- twitch.tv https://github.com/brave/adblock-lists/pull/1559