### PR TITLE
Update Ad elements on economist.com

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -1890,7 +1890,7 @@ reddit.com,reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad.onion#?#arti
 reddit.com,reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad.onion##shreddit-comments-page-ad
 reddit.com,reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad.onion##xpromo-top-button
 ! economist.com
-economist.com##.adComponent_advert__V79Pp
+economist.com##.adComponent_advert__kPVUI
 ! oregonlive.com
 oregonlive.com###rightRail-Bottom-300xFlex
 oregonlive.com##.below-toprail


### PR DESCRIPTION
Update ad element on `economist.com` sync with https://github.com/easylist/easylist/commit/c0b5090063ed8e40657474df564aa29f755a18c1