### PR TITLE
Fixes sonichits.com anti-adblock

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -18,6 +18,8 @@
 ! Admiral anti adblock
 phoronix.com##div[dir="auto"][style]
 baeldung.com##.aelzmn
+sonichits.com##+js(set-session-storage-item, fs.adb831.dis, 1)
+baeldung.com##+js(set-session-storage-item, fs.adb.dis, 1)
 ! Taboola
 /taboola-header.js
 /taboola.js


### PR DESCRIPTION
Fixes anti-adblock on sonichits.com and update baeldung.com

Resolves: https://community.brave.com/t/adblock-detected-on-sonichits/541121