### PR TITLE
Fixes win7/8 Youtube Crashes

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -24,6 +24,26 @@ search.brave.com###search-ad
 @@||community.brave.com^$ghide
 ! pageview-api detection
 nicovideo.jp,tiktok.com,twitch.tv,nzherald.co.nz##+js(brave-disable-pageview-api)
+! 
+! win7/8 YT crashes
+! Exception rule for the current YT
+m.youtube.com,music.youtube.com,www.youtube.com#@#+js(trusted-rpnt, script, /^(\(function serverContract\(\))/s, '/*start*/(function(){const wrapper=(target,thisArg,args)=>{let content=Reflect.apply(target,thisArg,args);if(content.includes("ssapPrerollEnabled")){const modifiedContent=content.replace(/\n.\n.playerConfig\.ssapConfig\.ssapPrerollEnabled.{2}(?:tru|fals)e/,"");return modifiedContent;}return content;};const handler={apply:wrapper};window.atob=new Proxy(window.atob,handler);const scripts=document.querySelectorAll("script");for(let i=scripts.length-1;i>=0;i--){if(scripts[i].textContent.startsWith("/*start*/")){scripts[i].textContent=scripts[i].textContent.replace(/\/\*start\*\/(.*)\/\*end\*\//g,"");break}}}());/*end*/$1')
+! Add escape chars (ads will still show, but won't crash YT)
+m.youtube.com,music.youtube.com,www.youtube.com##+js(trusted-rpnt, script, /^(\(function serverContract\(\))/s, /*start*/(function(){const wrapper=(target\,thisArg\,args)=>{let content=Reflect.apply(target\,thisArg\,args);if(content.includes("ssapPrerollEnabled")){const modifiedContent=content.replace(/\n.\n.playerConfig\.ssapConfig\.ssapPrerollEnabled.{2}(?:tru|fals)e/\,"");return modifiedContent;}return content;};const handler={apply:wrapper};window.atob=new Proxy(window.atob\,handler);const scripts=document.querySelectorAll("script");for(let i=scripts.length-1;i>=0;i--){if(scripts[i].textContent.startsWith("/*start*/")){scripts[i].textContent=scripts[i].textContent.replace(/\/\*start\*\/(.*)\/\*end\*\//g\,"");break}}}());/*end*/$1)
+! excempt the buggy quotes here also
+www.youtube.com#@#+js(trusted-replace-fetch-response, `/"auxiliaryUi":\{"messageRenderers":\{"bkaEnforcementMessageViewModel.*?e\}\}\}\,/`, , player?)
+www.youtube.com#@#+js(trusted-replace-fetch-response, `/("trackingParam":"kx_fmPxhoPZR)[-_0-9A-Za-z]{50}[-_0-9A-Za-z]+?([-_0-9A-Za-z]{55}lLKPQ-SS"\})/`, $1$2, player?)
+www.youtube.com#@#+js(trusted-replace-fetch-response, '/("trackingParam":"k5DfmPxhoXpR)[-_0-9A-Za-z]{50}[-_0-9A-Za-z]+?([-_0-9A-Za-z]{151}lLKPQGiS"\})/', $1$2, player?)
+www.youtube.com#@#+js(trusted-replace-xhr-response, '/"auxiliaryUi":\{"messageRenderers":\{"bkaEnforcementMessageViewModel.*?e\}\}\}\,/', , /playlist\?list=|player\?|watch\?v=/)
+www.youtube.com#@#+js(trusted-replace-xhr-response, '/("trackingParam":"kx_fmPxhoPZR)[-_0-9A-Za-z]{50}[-_0-9A-Za-z]+?([-_0-9A-Za-z]{55}lLKPQ-SS"\})/', $1$2, /playlist\?list=|player\?|watch\?v=/)
+www.youtube.com#@#+js(trusted-replace-xhr-response, '/("trackingParam":"k5DfmPxhoXpR)[-_0-9A-Za-z]{50}[-_0-9A-Za-z]+?([-_0-9A-Za-z]{151}lLKPQGiS"\})/', $1$2, /playlist\?list=|player\?|watch\?v=/)
+! re-add without quotes.
+www.youtube.com##+js(trusted-replace-fetch-response, /"auxiliaryUi":\{"messageRenderers":\{"bkaEnforcementMessageViewModel.*?e\}\}\}\,/, , player?)
+www.youtube.com##+js(trusted-replace-fetch-response, /("trackingParam":"kx_fmPxhoPZR)[-_0-9A-Za-z]{50}[-_0-9A-Za-z]+?([-_0-9A-Za-z]{55}lLKPQ-SS"\})/, $1$2, player?)
+www.youtube.com##+js(trusted-replace-fetch-response, /("trackingParam":"k5DfmPxhoXpR)[-_0-9A-Za-z]{50}[-_0-9A-Za-z]+?([-_0-9A-Za-z]{151}lLKPQGiS"\})/, $1$2, player?)
+www.youtube.com##+js(trusted-replace-xhr-response, /"auxiliaryUi":\{"messageRenderers":\{"bkaEnforcementMessageViewModel.*?e\}\}\}\,/, , /playlist\?list=|player\?|watch\?v=/)
+www.youtube.com##+js(trusted-replace-xhr-response, /("trackingParam":"kx_fmPxhoPZR)[-_0-9A-Za-z]{50}[-_0-9A-Za-z]+?([-_0-9A-Za-z]{55}lLKPQ-SS"\})/, $1$2, /playlist\?list=|player\?|watch\?v=/)
+www.youtube.com##+js(trusted-replace-xhr-response, /("trackingParam":"k5DfmPxhoXpR)[-_0-9A-Za-z]{50}[-_0-9A-Za-z]+?([-_0-9A-Za-z]{151}lLKPQGiS"\})/, $1$2, /playlist\?list=|player\?|watch\?v=/)
 ! CNAME: account.adobe.com
 @@||account.adobe.com^
 ! CNAME: pol.dk


### PR DESCRIPTION
Interium fix for WIndows 7/8

Removing ' ' quotes on Youtube rules and convert to escape \, to prevent crashing.