### PR TITLE
Improve adblocking on IOS xhamster.com (NSFW)

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -2173,6 +2173,9 @@ pornhub.com,pornhub.net,youporn.com###pb_template
 /_xa/ads_
 /ht.js?site_
 ##a[href^="https://a.adtng.com/"]
+! xhamster.com
+||marine.xhamster.com^
+||alaska.xhamster.com^
 ! tube8
 tube8.com,tube8.es,tube8.fr##main.row > aside.col-4 > div[class]
 tube8.com,tube8.es,tube8.fr##input + div:has(.adsbytrafficjunky)

--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -41,6 +41,7 @@
 ||adforcast.com^
 ||zimpolo.com^
 ||d3v3bqdndm4erx.cloudfront.net^
+||tsyndicate.com^
 ||friendshipmale.com^
 ||carpfreshtying.com^
 ||profitablegatecpm.com^


### PR DESCRIPTION
Fixes ads on  `xhamster.com` (NSFW)

Address: https://github.com/brave-experiments/web-compat-reports/issues/310