### PR TITLE
Remove unnecessary params from Narvar tracking URLs

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -379,6 +379,22 @@
     },
     {
         "include": [
+            "*://ctr.narvar.com/*/tracking/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "destination_country",
+            "dzip",
+            "order_number",
+            "origin_country",
+            "ozip",
+            "service"
+        ]
+    },
+    {
+        "include": [
             "*://*.nytimes.com/*"
         ],
         "exclude": [


### PR DESCRIPTION
Sample URL: https://ctr.narvar.com/canadiantire/tracking/canadapost?tracking_numbers=29000068&order_number=124058&service=EP&ozip=V1Z%202S3&dzip=V1A4B2&locale=en_CA&origin_country=CA&destination_country=CA

Only `tracking_numbers` and `locale` appear to be necessary for the page to work.