### PR TITLE
Revert YT fixes, adjust with new rules

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -97,6 +97,33 @@ collegeconfidential.com##body:style(overflow: auto !important; max-height: 1px !
 reddit.com##+js(trusted-set-local-storage-item, xpromo-consolidation, $currentDate$)
 ! Fix preloader (facebook check)
 igniteunmc.com##.preloader
+! youtube
+youtube.com#@##masthead-ad
+youtube.com#@##player-ads
+youtube.com#@##shorts-inner-container > .ytd-shorts:has(> .ytd-reel-video-renderer > ytd-ad-slot-renderer)
+youtube.com#@#.ytd-merch-shelf-renderer
+youtube.com#@#.ytp-suggested-action > button.ytp-suggested-action-badge
+m.youtube.com#@#lazy-list > ad-slot-renderer
+youtube.com#@#ytd-ad-slot-renderer
+youtube.com#@#ytd-rich-item-renderer:has(> #content > ytd-ad-slot-renderer)
+youtube.com#@#ytd-search-pyv-renderer
+m.youtube.com#@#ytm-companion-slot[data-content-type] > ytm-companion-ad-renderer
+m.youtube.com#@#ytm-rich-item-renderer > ad-slot-renderer
+! youtube (previous)
+youtube.com###items > ytd-ad-slot-renderer
+youtube.com###panels > [target-id="engagement-panel-ads"]
+youtube.com###related > div#player-ads
+youtube.com###content > ytd-ad-slot-renderer
+youtube.com###contents.style-scope.ytd-search-pyv-renderer
+youtube.com###main > #banner.ytd-merch-shelf-renderer
+youtube.com###masthead-ad > .ytd-rich-grid-renderer
+youtube.com###scroll-container > #items.ytd-merch-shelf-renderer
+youtube.com###ytd-player button.ytp-suggested-action-badge
+youtube.com##.ytp-chrome-top-buttons > .ytp-cards-teaser
+m.youtube.com##lazy-list > ad-slot-renderer
+youtube.com##ytd-ad-slot-renderer.style-scope.ytd-item-section-renderer
+youtube.com##ytd-rich-item-renderer:has(> .ytd-rich-item-renderer > ytd-ad-slot-renderer)
+youtube.com##ytd-rich-item-renderer:has(ytd-display-ad-renderer)
 !
 ! Brave-social (temp)
 ! List used by Brave for preventing social elements from loading


### PR DESCRIPTION
Re-apply old rules from https://github.com/brave/adblock-lists/commit/0006e3e188f945dd44f35e52b58eb66dab962da8

And update with newer YT filters, Had a report of anti-adblock. Possibly one of the new rules is being baited. Pre-emptive fix.

ref: https://community.brave.com/t/youtube-being-jerks-again/545194/6