### PR TITLE
Strip s_campaign from URLs

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -510,6 +510,7 @@
             "ml_subscriber",
             "ml_subscriber_hash",
             "mc_cid",
+            "s_campaign",
             "ss_campaign_id",
             "ss_campaign_name",
             "ss_campaign_sent_date",


### PR DESCRIPTION
This parameter appears to be related to Adobe Analytics (see page 225 of [this integration guide](https://terrynwinter.com/wp-content/uploads/2020/04/adobe-analytics-tips-to-clear-developer-exam-post-03-implementation-variables-document.pdf)) and is often seen in combination with [Salesforce's `et_rid`](https://github.com/brave/adblock-lists/pull/1680).

Sample URLs:
- https://www.instagram.com/indigofrancais/?s_campaign=organic-social-French-Facebook-Feed-FrenchIG
- https://www.chapters.indigo.ca/en-ca/books/sacred-ecology/9780415517324-item.html?s_campaign=goo-DSA_Books&gclid=CjwKCAjwo4mIBhBsEiwAKgzXOFBVk1B9Wyai8I_sPJdJWjpw-bcNJ7C55CjJG29EWGHvfWCrMuOXbxoCFNQQAvD_BwE&gclsrc=aw.ds
- https://ri-department-of-health-covid-19-data-rihealth.hub.arcgis.com/?et_rid=788089403&s_campaign=rhodemap:newsletter
- https://www.cff.org/search?s_campaign=bostonglobe%3Amobileapp&theme=light&pathAuthJWT=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOiIyNDI4ODMzIiwiYXV0aFRva2VuIjoiZGFmOThkMzItZDNlZC00MjVjLTkxNjktODAxZGUwOTUxOTQ0In0.-NRf_t3Tb9KZ-nE6fIug4-1cbNPFPL-dgLP-PIp9mdU&f%5B0%5D=topic%3A341&f%5B1%5D=topic%3A2246&page=4
- https://www.nobelprize.org/prizes/economic-sciences/1976/friedman/biographical/?et_rid=738247152&s_campaign=arguable:newsletter
- https://rockefeller.dartmouth.edu/events/event?event=72113&et_rid=961271383&s_campaign=NH:newsletter
- https://www.commentarymagazine.com/articles/joseph-epstein/am-i-charming/?et_rid=528603379&s_campaign=arguable:newsletter
- https://is.gd/SEnek9?s_campaign=Email:PHH&bc_em=*%7CEMAIL%7C*