### PR TITLE
Remove mbid from Condé Nast sites

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -407,6 +407,36 @@
     },
     {
         "include": [
+            "*://arstechnica.com/*",
+            "*://pitchfork.com/*",
+            "*://www.allure.com/*",
+            "*://www.architecturaldigest.com/*",
+            "*://www.bonappetit.com/*",
+            "*://www.cntraveler.com/*",
+            "*://www.epicurious.com/*",
+            "*://www.glamour.com/*",
+            "*://www.gq.com/*",
+            "*://www.gq-magazine.co.uk/*",
+            "*://www.gqitalia.it/*",
+            "*://www.gqmagazine.fr/*",
+            "*://www.newyorker.com/*",
+            "*://www.self.com/*",
+            "*://www.them.us/*",
+            "*://www.teenvogue.com/*",
+            "*://www.vanityfair.com/*",
+            "*://www.vogue.com/*",
+            "*://www.wired.com/*",
+            "*://www.wired.co.uk/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "mbid"
+        ]
+    },
+    {
+        "include": [
             "*://*/*"
         ],
         "exclude": [


### PR DESCRIPTION
Both the Firefox and [Adguard lists](https://github.com/AdguardTeam/AdguardFilters/blob/eb8393435818ba55620e7028b4b949d92c890f8e/TrackParamFilter/sections/specific.txt#L1366-L1368) have this parameter as a site-specific one. While they only remove it from 3 domains, I have found it on most Condé Nast sites.

Given it's used for the [MusicBrainz ID](https://musicbrainz.org/doc/MusicBrainz_API) and seemingly in a [product called "MotionBoard"](https://cs.wingarc.com/manual/mb/6.4/en/UUID-8313fded-914f-68e2-250e-8413b5456b39.html), it's too generic to be stripped from all sites.

Sample URLs:
- https://www.allure.com/topic/beautyblender?mbid=synd_teenvogue&page=3
- http://www.architecturaldigest.com/gallery/10-hauntingly-beautiful-views-of-the-arctic-melting?mbid=social_facebook
- https://arstechnica.com/information-technology/2015/10/this-11-year-old-is-selling-cryptographically-secure-passwords-for-2-each/?mbid=synd_moz_bizfinbiznews1
- https://www.bonappetit.com/story/parchment-hack?utm_brand=ba&utm_medium=social&utm_source=facebook&utm_social-type=owned&mbid=social_facebook
- https://www.cntraveler.com/readers-choice-awards/caribbean-atlantic/caribbean-top-resorts?mbid=synd_msn_rss
- https://www.epicurious.com/recipes/food/views/shredded-cabbage-salad-with-pomegranate-and-tomatoes-56390059?mbid=synd_msn_rss
- https://www.glamour.com/story/short-wedding-dresses-trend-is-booming?mbid=synd_yahoo_rss
- https://www.gq.com/style/201506/pitti-uomo-street-style-italian-suits?mbid=social_facebook
- https://www.gq-magazine.co.uk/profile/charlie-burton?mbid=synd_gq
- https://www.gqmagazine.fr/mode/style/diaporama/charles-aznavour-etait-une-icone-de-style/53083?page=3&mbid=synd_yahoo_rss
- https://www.gqitalia.it/lifestyle/gallery/i-fantastici-20-di-victoria-beckham?mbid=synd_flipboard_rss&page=2
- https://www.newyorker.com/cartoons/random/?mbid=social_digg
- https://pitchfork.com/news/killer-mike-announces-first-solo-album-in-a-decade-shares-new-song-with-el-p-listen?utm_brand=p4k&utm_social-type=owned&utm_source=twitter&mbid=social_twitter&utm_medium=social
- https://www.self.com/gallery/five-minute-arm-workout?mbid=social_twitter
- https://www.teenvogue.com/story/kim-kardashian-would-wear-a-diaper-in-the-name-of-fashion?mbid=synd_msn_rss
- https://www.them.us/story/2021-inauguration-memes-bernie-sanders-lady-gaga-and-more?utm_source=msn&utm_medium=syndication&mbid=synd_msn_rss
- https://www.vanityfair.com/vf-hollywood/x-men-cast-impressions?mbid=social_twitter
- https://www.vogue.com/fashion-shows/copenhagen-fall-2021/baum-und-pferdgarten/slideshow/collection?mbid=social_onsite_pinterest
- https://www.wired.co.uk/article/tag-heuer-connected-super-mario?utm_social-type=owned&utm_brand=wired&utm_source=twitter&mbid=social_twitter&utm_medium=social
- https://www.wired.com/story/fda-weight-loss-drugs/?utm_medium=social&utm_social-type=owned&mbid=social_twitter&utm_brand=wired&utm_source=twitter