### PR TITLE
Remove search_identifier from Zoopla

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -63,6 +63,17 @@
     },
     {
         "include": [
+            "*://www.zoopla.co.uk/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+             "search_identifier"
+        ]
+    },
+    {
+        "include": [
             "*://*.bandcamp.com/*"
         ],
         "exclude": [


### PR DESCRIPTION
Stripping that parameter does change the destination of the "Back to search results" link, but that seems like a desirable outcome since users sharing links of properties may not want to expose their full search parameters via an opaque parameter.

Sample URL: https://www.zoopla.co.uk/for-sale/details/66418574/?search_identifier=2773bba8310ad9de14477f7fce09f486e20b95d72a09b3de8ee21a40111b40ee