### PR TITLE
include Google Maps highway sign rendering fix

### DIFF
--- a/brave-lists/brave-specific.txt
+++ b/brave-lists/brave-specific.txt
@@ -17,6 +17,9 @@
 ! De-AMP rule that uses the De-AMP scriptlet
 google.*##+js(de-amp)
 
+! Google Maps highway sign rendering fix
+google.*##+js(brave-google-maps-fix)
+
 ! YouTube theater mode fix scriptlet rule
 youtube.*##+js(brave-youtube-theater-fix)
 


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/37075

This should be merged AFTER https://github.com/brave/adblock-resources/pull/174