### PR TITLE
Update brave-disable-pageview-api domains

### DIFF
--- a/brave-lists/experimental.txt
+++ b/brave-lists/experimental.txt
@@ -5,7 +5,7 @@
 
 ! counter page visibility checks on youtube.com/twitch
 youtube.com##+js(brave-video-bg-play)
-spotify.com,netflix.com,tidal.com,soundcloud.com,music.apple.com,youtube.com##+js(brave-disable-pageview-api)
+disneyplus.com,max.com,paramountplus.com,peacocktv.com,pandora.com,deezer.com,youtube.com##+js(brave-disable-pageview-api)
 !
 ! Google precision popup
 www.google.com,www.google.ca,www.google.com.au,www.google.co.nz,www.google.co.uk,www.google.ie,www.google.fr,www.google.nl,www.google.pt,www.google.de##.gTMtLb.fp-nh[style="visibility: visible;"]

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -23,7 +23,7 @@ search.brave.com###search-ad
 ! community.brave.com
 @@||community.brave.com^$ghide
 ! pageview-api detection
-nicovideo.jp,tiktok.com,twitch.tv,nzherald.co.nz##+js(brave-disable-pageview-api)
+spotify.com,netflix.com,tidal.com,soundcloud.com,music.apple.com,nicovideo.jp,tiktok.com,twitch.tv,nzherald.co.nz##+js(brave-disable-pageview-api)
 ! 
 ! win7/8 YT crashes
 ! Exception rule for the current YT


### PR DESCRIPTION
New Experimental; 

- disneyplus.com
- max.com
- paramountplus.com
- peacocktv.com
- pandora.com
- deezer.com

Move to unbreak:
- spotify.com 
- netflix.com
- tidal.com
- soundcloud.com
- music.apple.com