### PR TITLE
Test rules for msftconnecttest.com redirect issues

### DIFF
--- a/brave-lists/https-upgrade-exceptions-list.txt
+++ b/brave-lists/https-upgrade-exceptions-list.txt
@@ -63,6 +63,7 @@ fuw.edu.pl
 fxmconnect.com
 genki365.net
 globalnoticias.pt
+go.microsoft.com
 hentasis1.top
 hmlan.com
 hokkoku.co.jp
@@ -86,6 +87,7 @@ lvmama.com
 lyricstraining.com
 magichue.net
 mnet.bg
+msftconnecttest.com
 nexylan.net
 ngui.cc
 slither.io

--- a/brave-lists/https-upgrade-exceptions-list.txt
+++ b/brave-lists/https-upgrade-exceptions-list.txt
@@ -63,7 +63,6 @@ fuw.edu.pl
 fxmconnect.com
 genki365.net
 globalnoticias.pt
-go.microsoft.com
 hentasis1.top
 hmlan.com
 hokkoku.co.jp


### PR DESCRIPTION
Reported issues regarding redirections from `msftconnecttest.com/redirect`

```
1. http://www.msftconnecttest.com/redirect
2. http://go.microsoft.com/fwlink/?LinkID=211272&clcid=0x412
3. https://go.microsoft.com/fwlink/?LinkID=211272&clcid=0x412
4. https://www.msn.com/?ocid=wispr&pc=u477
5. https://www.msn.com/en-nz?ocid=wispr&pc=u412
```