### PR TITLE
Add various streaming services to brave-disable-pageview-api

### DIFF
--- a/brave-lists/experimental.txt
+++ b/brave-lists/experimental.txt
@@ -5,7 +5,7 @@
 
 ! counter page visibility checks on youtube.com/twitch
 youtube.com##+js(brave-video-bg-play)
-disneyplus.com,max.com,paramountplus.com,peacocktv.com,pandora.com,deezer.com,youtube.com##+js(brave-disable-pageview-api)
+channel4.com,crunchyroll.com,fubo.tv,gem.cbc.ca,shudder.com,watch.att.com,crave.ca,tvnz.co.nz,threenow.co.nz,foxtel.com.au,stan.com.au,binge.com.au,skygo.co.nz,hulu.com,primevideo.com,pluto.tv,plus.espn.com,music.youtube.com,tv.youtube.com,disneyplus.com,max.com,paramountplus.com,peacocktv.com,pandora.com,deezer.com,youtube.com##+js(brave-disable-pageview-api)
 !
 ! Google precision popup
 www.google.com,www.google.ca,www.google.com.au,www.google.co.nz,www.google.co.uk,www.google.ie,www.google.fr,www.google.nl,www.google.pt,www.google.de##.gTMtLb.fp-nh[style="visibility: visible;"]

--- a/brave-lists/experimental.txt
+++ b/brave-lists/experimental.txt
@@ -5,7 +5,7 @@
 
 ! counter page visibility checks on youtube.com/twitch
 youtube.com##+js(brave-video-bg-play)
-channel4.com,crunchyroll.com,fubo.tv,gem.cbc.ca,shudder.com,watch.att.com,crave.ca,tvnz.co.nz,threenow.co.nz,foxtel.com.au,stan.com.au,binge.com.au,skygo.co.nz,hulu.com,primevideo.com,pluto.tv,plus.espn.com,music.youtube.com,tv.youtube.com,disneyplus.com,max.com,paramountplus.com,peacocktv.com,pandora.com,deezer.com,youtube.com##+js(brave-disable-pageview-api)
+channel4.com,crunchyroll.com,fubo.tv,gem.cbc.ca,shudder.com,watch.att.com,crave.ca,tvnz.co.nz,threenow.co.nz,foxtel.com.au,stan.com.au,binge.com.au,skygo.co.nz,hulu.com,primevideo.com,pluto.tv,plus.espn.com,music.youtube.com,tv.youtube.com,disneyplus.com,max.com,paramountplus.com,peacocktv.com,pandora.com,deezer.com,www.youtube.com,m.youtube.com##+js(brave-disable-pageview-api)
 !
 ! Google precision popup
 www.google.com,www.google.ca,www.google.com.au,www.google.co.nz,www.google.co.uk,www.google.ie,www.google.fr,www.google.nl,www.google.pt,www.google.de##.gTMtLb.fp-nh[style="visibility: visible;"]


### PR DESCRIPTION
Add video streaming sites from

UK, Canada, Australia, NZ, US. 

Also split up yotube.com into seperate domains `music.youtube.com`, `tv.youtube.com`, `m.youtube.com`, `www.youtube.com`