### PR TITLE
Update YT shorts icons

### DIFF
--- a/brave-lists/yt-shorts.txt
+++ b/brave-lists/yt-shorts.txt
@@ -11,3 +11,6 @@ youtube.com##ytd-rich-shelf-renderer[is-shorts]
 youtube.com##ytd-video-renderer > .ytd-video-renderer:has(a[href^="/shorts/"])
 ! side shorts
 youtube.com###items.yt-horizontal-list-renderer > ytd-reel-item-renderer
+! shorts icons (desktop and mobile)
+m.youtube.com##.pivot-shorts.pivot-bar-item-tab
+www.youtube.com###endpoint.ytd-guide-entry-renderer[title="Shorts"]


### PR DESCRIPTION
Include hiding of YT Shorts icons on desktop and mobile.

Address:
https://github.com/brave/brave-browser/issues/36465#issuecomment-2093474959


Won't collapse (shift left or right) the missing shorts icon. But will hide it.