### PR TITLE
Cleanup bloomberg.com

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -2245,11 +2245,11 @@ linkedin.com##.feed-shared-update-v2:has(a[aria-label*="广告|プロモーシ�
 linkedin.com##.ad-banner
 ! bloomberg.com
 bloomberg.com##.BaseAd_baseAd-dXBqvbLRJy0-
-bloomberg.com##.leaderboard-wrapper
+bloomberg.com##.dvz-v0-ad
 bloomberg.com##[class^="FullWidthAd_"]
 bloomberg.com##[data-component="in-body-ad"]
-bloomberg.com##[data-component="broker-box-ad"]
-bloomberg.com##[data-ad-status="rendering"]
+bloomberg.com##div[class^="media-ui-BaseAd"]
+bloomberg.com##div[class^="media-ui-FullWidthAd"]
 ! thebaltimorebanner.com
 thebaltimorebanner.com###leaderboard-ad-v2
 thebaltimorebanner.com##.block-ad-zone

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -778,8 +778,6 @@ cnet.com##+js(rc, c-adSkyBox, , stay)
 cnet.com##+js(rc, c-adSkyBox_expanded, , stay)
 reuters.com##+js(rc, ad-slot__container__FEnoz, , stay)
 darkreading.com##*:style(opacity: 1 !important;)
-bloomberg.com##+js(rc, leaderboard-wrapper, , stay)
-bloomberg.com##+js(rc, FullWidthAd_fullWidthAdWrapper-fClHZteIk3k-, , stay)
 npr.org##[aria-label="advertisement"]
 npr.org##+js(rc, ad-standard, , stay)
 imdb.com+js(ra, id="inline20_wrapper", , stay)


### PR DESCRIPTION
Cleanup bloomberg.com rules. 

- Helps with the empty space on the site. 
- Removes unused unbreak rules.