### PR TITLE
Fixes Bloomberg.com cookie popup

### DIFF
--- a/brave-lists/brave-cookie-specific.txt
+++ b/brave-lists/brave-cookie-specific.txt
@@ -34,4 +34,4 @@ lidl.co.uk,lidl.fr,lidl.de,lidl.nl,lidl.dk,lidl.se,lidl.fi,lidl.at,lidl.ch,lidl.
 
 arvopaperi.fi,iltalehti.fi,kauppalehti.fi,mediuutiset.fi,mikrobitti.fi,talouselama.fi,tekniikkatalous.fi,tivi.fi,uusisuomi.fi###alma-cmpv2-container
 
-
+bloomberg.com##+js(trusted-click-element, button[title="Reject All"], , 1000)


### PR DESCRIPTION
uBo was unable to change or add similar rule.
Resolves: 
![bloomber](https://github.com/brave/adblock-lists/assets/1659004/67ae5613-d036-4bc8-b22d-4095895897ec)
