### PR TITLE
Remove ref from EventBrite

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -374,6 +374,7 @@
             "email_referrer",
             "email_subject",
             "link_id",
+            "ref",
             "source"
         ]
     },


### PR DESCRIPTION
Sample URL: https://www.eventbrite.ca/e/2024-vancouver-british-car-show-at-vandusen-garden-presented-by-hagerty-tickets-861181997537?locale=fr_CA&ref=eemailordconf&view=listing