### PR TITLE
Strip "source" from bamboohr share URLs

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -183,7 +183,8 @@
     },
     {
         "include": [
-            "*://actionnetwork.org/*"
+            "*://actionnetwork.org/*",
+            "*://medium.com/*"
         ],
         "exclude": [
 
@@ -255,17 +256,6 @@
             "feature",
             "si",
             "source_ve_path"
-        ]
-    },
-    {
-        "include": [
-            "*://medium.com/*"
-        ],
-        "exclude": [
-
-        ],
-        "params": [
-            "source"
         ]
     },
     {

--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -184,6 +184,7 @@
     {
         "include": [
             "*://actionnetwork.org/*",
+            "*://*.bamboohr.com/careers/*",
             "*://medium.com/*"
         ],
         "exclude": [


### PR DESCRIPTION
Sample URL: https://sharesies.bamboohr.com/careers/263?source=aWQ9Nw%3D%3D