### PR TITLE
Remove more YouTube params in shared URLs

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -251,10 +251,12 @@
 
         ],
         "params": [
+            "app",
             "embeds_euri",
             "embeds_loader_url_for_pings",
             "embeds_origin",
             "feature",
+            "pp",
             "si",
             "source_ve_path"
         ]


### PR DESCRIPTION
Sample URLs:
- https://m.youtube.com/watch?v=T3F0Nt6ssLU&pp=ygURZXhwbG9kaW5nIGtpdHRlbnM
- https://www.youtube.com/watch?app=desktop&v=T3F0Nt6ssLU