### PR TITLE
Stop redirection on cnnespanol.cnn.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -693,6 +693,7 @@ cnn.com,kefayde.com,careersides.com,nayisahara.com,wikifilmia.com,infinityskull.
 ! Anti-Brave checks (aopw)
 cnnespanol.cnn.com##+js(aopw, window.navigator.brave)
 cnnespanol.cnn.com##+js(aopr, window.navigator.brave)
+cnnespanol.cnn.com##+js(rmnt, script, location.replace)
 !
 ! Standard blocking of Bing mouselog tracker (is blocked in Aggressive)
 ||bing.com/mouselog$script,redirect-rule=noopjs,domain=bing.com


### PR DESCRIPTION
Update counter for: Mitigate the `location.replace`

```
if (
	typeof window.WM.UserConsent.isInRegion !== "undefined" &&
	window.WM.UserConsent.isInRegion("global") !== true &&
	( window.navigator && window.navigator.brave && typeof window.navigator.brave.isBrave === "function" ) &&
	location.pathname.search( "^/navegador-no-compatible/?$" ) === -1
	) {
	location.replace("https://cnnespanol.cnn.com/navegador-no-compatible");
}
```