### PR TITLE
Fixes Coindesk login resets

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -879,6 +879,7 @@ mycima.biz##+js(acis, parseInt, break;case $.)
 ! nytimes.com (fixes no images)
 @@||securepubads.g.doubleclick.net/tag/js/gpt.js$script,domain=nytimes.com
 ! Peter Lowe fixes
+||awstrack.me^$badfilter
 ||blockthrough.com^$badfilter
 ||criteo.com^$badfilter
 ||app.pendo.io^$badfilter


### PR DESCRIPTION
Breaking due to Peter Lowes list, have notified uBO. Update our list.

Coindesk password reset was linking through `awstrack.me` which was causing breakage, passwords are unable to be reset.