### PR TITLE
Fixes music.youtube.com popup

### DIFF
--- a/brave-lists/experimental.txt
+++ b/brave-lists/experimental.txt
@@ -20,6 +20,8 @@ www.youtube.com##tp-yt-paper-dialog[style-target="host"][role="dialog"][tabindex
 www.youtube.com##tp-yt-paper-dialog[style-target="host"][role="dialog"][tabindex][syle*="border-box; max-height: 320px;"]
 ! its cable reimagined
 www.youtube.com##tp-yt-paper-dialog[style-target="host"][role="dialog"][tabindex][syle*="border-box; max-height: 206"]
+! Youtube music popup
+music.youtube.com##tp-yt-paper-dialog[style-target="host"][role="dialog"][tabindex][syle*="border-box; max-height: 0px; max-width: 1534"]
 
 ! Youtube Original (based on https://github.com/sepehrkiller/FixYoutubeUI/)
 ! Old UI

--- a/brave-lists/experimental.txt
+++ b/brave-lists/experimental.txt
@@ -21,7 +21,8 @@ www.youtube.com##tp-yt-paper-dialog[style-target="host"][role="dialog"][tabindex
 ! its cable reimagined
 www.youtube.com##tp-yt-paper-dialog[style-target="host"][role="dialog"][tabindex][syle*="border-box; max-height: 206"]
 ! Youtube music popup
-music.youtube.com##tp-yt-paper-dialog[style-target="host"][role="dialog"][tabindex][syle*="border-box; max-height: 0px; max-width: 1534"]
+music.youtube.com##ytmusic-mealbar-promo-renderer.ytmusic-popup-container[enable-bauhaus-style][dialog="true"][tabindex]
+
 
 ! Youtube Original (based on https://github.com/sepehrkiller/FixYoutubeUI/)
 ! Old UI


### PR DESCRIPTION
Fix "Try 1 month free of Music Premium to listen to music ad-free, offline, and with your screen off"

![yt-prem-popup](https://github.com/brave/adblock-lists/assets/1659004/60961411-36b4-4b49-a429-3d44cbf8bde2)
