### PR TITLE
Fix regex on https://doujindesu.tv/ (NSFW)

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -788,6 +788,10 @@ davidstea.com,ibotta.com,polovniautomobili.com##+js(rc, async-hide, , stay)
 @@||api.ebay.com^$xmlhttprequest,subdocument
 ! env fixes
 novinky.cz#@#+js(aost, Math, inlineScript)
+! Regex fix (doujindesu.tv)
+/gpuo/xcea/*
+/lko?id=$script,3p
+/xcea/lko?
 ! Regex fix (counter complex ubo regex)
 $xhr,3p,domain=nxbrew.com
 $script,3p,domain=animixplay.to|animepahe.ru|nxbrew.com


### PR DESCRIPTION
Fixes regex issue on `https://doujindesu.tv/` for domain: `https://osharvrziafx.com/en/gpuo/xcea/lko?id=2013574`

`/^https:\/\/[a-z]{10,12}\.com\/[\/a-z]{2,}\?id=[12]\d{6}$/$script,3p,match-case`

Reported https://community.brave.com/t/nsfw-doujindesu-tv-pop-up/550469