### PR TITLE
Remove social share parameters on Amazon

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -46,6 +46,8 @@
             "pf_rd_s",
             "pf_rd_t",
             "qid",
+            "ref",
+            "social_share",
             "sprefix"
         ]
     },


### PR DESCRIPTION
Sample URL: https://www.amazon.ca/dp/B09V1JJ3D1?ref=cm_sw_r_cp_ud_dp_9BR6WQXZ1CQ507CPCJ7C&ref_=cm_sw_r_cp_ud_dp_9BR6WQXZ1CQ507CPCJ7C&social_share=cm_sw_r_cp_ud_dp_9BR6WQXZ1CQ507CPCJ7C

Note that AdGuard has found [webcompat problems related to removing `ref_`](https://github.com/AdguardTeam/AdguardFilters/issues/88627) and so we'll leave that one in for now.