### PR TITLE
Remove two more seemingly unnecessary Amazon parameters

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -47,6 +47,8 @@
             "pf_rd_t",
             "qid",
             "ref",
+            "refinements",
+            "rnid",
             "social_share",
             "sprefix"
         ]


### PR DESCRIPTION
Sample URL: https://www.amazon.ca/Anker-Charger-GaNPrime-Compact-Foldable/dp/B09W2PNLX7/ref=sr_1_1?refinements=p_123%3A3271&rnid=119962390011&s=electronics&sr=1-1

Note that both `s` and `sr` are listed on AdGuard as causing webcompat problems: https://github.com/AdguardTeam/AdguardFilters/blob/a51bbe17b2f679e649241ac04a1d3f24174ea882/TrackParamFilter/sections/specific.txt#L1558-L1559