### PR TITLE
Fixes pageview checks on cnn.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -24,7 +24,7 @@ search.brave.com###search-ad
 @@||community.brave.com^$ghide
 ! pageview-api detection
 music.youtube.com##+js(brave-video-bg-play)
-music.youtube.com,channel4.com,crunchyroll.com,fubo.tv,gem.cbc.ca,shudder.com,watch.att.com,crave.ca,tvnz.co.nz,threenow.co.nz,foxtel.com.au,stan.com.au,binge.com.au,skygo.co.nz,hulu.com,disneyplus.com,max.com,paramountplus.com,peacocktv.com,pandora.com,deezer.com,slingtv.com,discoveryplus.com,curiositystream.com,spotify.com,netflix.com,tidal.com,soundcloud.com,music.apple.com,nicovideo.jp,tiktok.com,twitch.tv,nzherald.co.nz##+js(brave-disable-pageview-api)
+cnn.com,music.youtube.com,channel4.com,crunchyroll.com,fubo.tv,gem.cbc.ca,shudder.com,watch.att.com,crave.ca,tvnz.co.nz,threenow.co.nz,foxtel.com.au,stan.com.au,binge.com.au,skygo.co.nz,hulu.com,disneyplus.com,max.com,paramountplus.com,peacocktv.com,pandora.com,deezer.com,slingtv.com,discoveryplus.com,curiositystream.com,spotify.com,netflix.com,tidal.com,soundcloud.com,music.apple.com,nicovideo.jp,tiktok.com,twitch.tv,nzherald.co.nz##+js(brave-disable-pageview-api)
 ! https://github.com/easylist/easylist/issues/19234
 @@||mssl.fwmrm.net/libs/$domain=southpark.de|southparkstudios.co.uk|southparkstudios.com.br|southparkstudios.com
 @@||imasdk.googleapis.com/pal/sdkloader/pal.js$domain=southpark.de|southparkstudios.co.uk|southparkstudios.com.br|southparkstudios.com


### PR DESCRIPTION
Displaying video https://edition.cnn.com/politics/live-news/cnn-debate-trump-biden-06-27-24/index.html

Minimising video or changing tab. Video is muted.