### PR TITLE
Fix ads on timesofindia.indiatimes.com

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -2361,6 +2361,8 @@ timesofindia.indiatimes.com##.relatedVideoWrapper
 timesofindia.indiatimes.com##[data-aff-type]
 timesofindia.indiatimes.com##.topBand_adwrapper
 timesofindia.indiatimes.com##[data-contentprimestatus]
+timesofindia.indiatimes.com##.d_jsH.mPws3
+timesofindia.indiatimes.com##[data-scrollga="spotlight_banner_widget"]
 ! marketscreener.com
 marketscreener.com###zppMiddle2
 marketscreener.com###zppRight2

--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -303,6 +303,7 @@ grubhub.com,dashboard.razorpay.com,joinhoney.com#@##credential_picker_container
 ##.ad-slot-top
 ##.ad-slot-wrapper
 ##.ad-space
+##.ad-spacing
 ##.ad-splash
 ##.ad-sponsor
 ##.ad-standard
@@ -2270,10 +2271,6 @@ france24.com##.m-block-ad
 france24.com##[data-tms-ad-container]
 ! timesofisrael.com
 timesofisrael.com##.banner-placeholder
-! timesofindia.com
-timesofindia.com##.phShimmer
-timesofindia.com##div[class^="ATF_container_"]
-timesofindia.com##div[id^="custom_ad_"]
 ! gadgetsnow.com
 gadgetsnow.com##._1edxh
 gadgetsnow.com##._1pjMr
@@ -2353,6 +2350,10 @@ mashable.com##section.mt-4 > div
 ! kotaku.com
 kotaku.com##.japmJB
 ! timesofindia.indiatimes.com
+||indiatimes.com/toiads_
+timesofindia.com##.phShimmer
+timesofindia.com##div[class^="ATF_container_"]
+timesofindia.com##div[id^="custom_ad_"]
 timesofindia.indiatimes.com##.CeUoi
 timesofindia.indiatimes.com##.mgid_second_mrec_parent
 timesofindia.indiatimes.com##.paisa-wrapper


### PR DESCRIPTION
1. Fix cosmetic ads on `##.ad-spacing`  `https://www.indiatimes.com/`

2. `||indiatimes.com/toiads_` prevents the ads from loading on `timesofindia.indiatimes.com`, address: https://community.brave.com/t/advertisements-being-displayed-on-timesofindia-website/556127

3. Sync timesofindia.indiatimes.com Cosmetics from Easylist
