### PR TITLE
Add Radio-Canada param related to its Facebook app

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -189,6 +189,18 @@
     },
     {
         "include": [
+            "*://ici.radio-canada.ca/*",
+            "*://radio-canada.ca/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "partageApp"
+        ]
+    },
+    {
+        "include": [
             "*://actionnetwork.org/*",
             "*://*.bamboohr.com/careers/*",
             "*://medium.com/*"


### PR DESCRIPTION
Sample URL: http://radio-canada.ca/nouvelle/2083771/melissa-robbie-dunn-orthophoniste-comox?partageApp=rcca_appmobile_appinfo_android