### PR TITLE
Debounce Selzy link tracker

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -351,6 +351,15 @@
   },
   {
     "include": [
+      "*://link.emlmind.com/en/mail_link_tracker?*"
+    ],
+    "exclude": [
+    ],
+    "action": "base64,redirect",
+    "param": "url"
+  },
+  {
+    "include": [
       "*://www.googleadservices.com/pagead/aclk?*"
     ],
     "exclude": [


### PR DESCRIPTION
This is the link tracker used by this email marketing platform: https://selzy.com/

Sample URL: https://link.emlmind.com/en/mail_link_tracker?hash=66c5ibqsukgp7ikdzwu4ujmw7y7boyubuqqmaq86u5sjqdohiizkiackas9r171wq1go8tfs5eongbftyy5rh47j45mgawwfzgn66xho&url=aHR0cHM6Ly93d3cubWVsb3R0b2dyb3VwLmNvbS9zY2hlZHVsZQ~~&uid=Njg1OTgwOA~~&ucs=88ff10da1ab90c2435eec8aa3fb9fb04