### PR TITLE
Drop parameter from shared Tumblr links

### DIFF
--- a/brave-lists/clean-urls-permissions.json
+++ b/brave-lists/clean-urls-permissions.json
@@ -2,6 +2,7 @@
     "js-api": [
         "*://*.youtube.com/*",
         "*://*.instagram.com/*",
+        "*://www.tumblr.com/*",
         "https://boocmp.github.io/clipboard/*"
     ]
 }

--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -203,6 +203,7 @@
         "include": [
             "*://actionnetwork.org/*",
             "*://*.bamboohr.com/careers/*",
+            "*://www.tumblr.com/*",
             "*://medium.com/*"
         ],
         "exclude": [


### PR DESCRIPTION
Sample URL generated using the in-page "Copy link" functionality: https://www.tumblr.com/pizza-and-ramen/696959487758745600/tumblr-is-tracking-shared-links?source=share