### PR TITLE
Cover goto.walmart.com clean url

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -475,6 +475,18 @@
     },
     {
         "include": [
+            "*://goto.walmart.com/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+           "sharedid",
+	   "partnerpropertyid"
+        ]
+    },
+    {
+        "include": [
             "*://*.nytimes.com/*"
         ],
         "exclude": [


### PR DESCRIPTION
https://goto.walmart.com/c/159047/565706/9383?&sharedid=cnet&partnerpropertyid=235399&u=https%3A%2F%2Fwww.walmart.com%2Fip%2FApple-Lightning-to-3-5-mm-Headphone-Jack-Adapter%2F54738078%3F&subId1=cn-bbdb4f53b6d64a02b50d53c6343ce6a2-dtp-oo

```
https://goto.walmart.com/c/159047/565706/9383?&sharedid=cnet&partnerpropertyid=235399&u=https%3A%2F%2Fwww.walmart.com%2Fip%2FApple-Lightning-to-3-5-mm-Headphone-Jack-Adapter%2F54738078%3F&subId1=cn-bbdb4f53b6d64a02b50d53c6343ce6a2-dtp-oo
```
->

```
https://goto.walmart.com/c/159047/565706/9383?&u=https%3A%2F%2Fwww.walmart.com%2Fip%2FApple-Lightning-to-3-5-mm-Headphone-Jack-Adapter%2F54738078%3F&subId1=cn-bbdb4f53b6d64a02b50d53c6343ce6a2-dtp-oo
```