### PR TITLE
Import from uBO to fix Anti-adblock on dailymail.co.uk

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -98,6 +98,8 @@ fmovies.co###ics
 /fret/meow4/*$script,3p
 /i/npage/*$script,3p
 
+! dailymail.co.uk
+dailymail.co.uk##+js(abort-on-property-read, Notification)
 
 ! https://github.com/easylist/easylist/commit/d3a2c54ac
 @@||app.posthog.com/decide/


### PR DESCRIPTION
Should fix:

![img_20240715_144140](https://github.com/user-attachments/assets/c35a2067-bd4a-4f16-b9d7-5cf1ee28dd28)
