### PR TITLE
Fix debounce buy.gen.us

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -437,7 +437,7 @@
   },
   {
      "include": [
-     "https://buy.geni.us/Proxy.ashx?*"
+       "https://buy.geni.us/Proxy.ashx?*"
      ],
      "exclude": [
      ],

--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -436,6 +436,15 @@
     "param": "^/amp/s/(.*)$"
   },
   {
+     "include": [
+     "https://buy.geni.us/Proxy.ashx?*"
+     ],
+     "exclude": [
+     ],
+     "action": "redirect",
+     "param": "GR_URL"
+  },
+  {
     "include": [
       "https://dev-pages.brave.software/navigation-tracking/error.html?*",
       "https://dev-pages.bravesoftware.com/navigation-tracking/error.html?*"


### PR DESCRIPTION
From https://www.cnet.com/tech/best-amazon-prime-day-live-deals-2024-07-17/

`https://buy.geni.us/Proxy.ashx?TSID=365160&GR_URL=https%3A%2F%2Fwww.amazon.com%2FSony-Headphones-Bluetooth-Microphone-Cappuccino%2Fdp%2FB0BSGQL41X%3Fgeniuslink%3Dtrue%26th%3D1%26tag%3Dcnet-buy-button-20%26ascsubtag%3D__COM_CLICK_ID__%7Cee0cf2ba-f340-4730-94be-cc2b3790620d%7Cdtp%7Ccn&dtb=1`