### PR TITLE
Remove Amazon params added by GeniusLink

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -28,8 +28,10 @@
 
         ],
         "params": [
+            "ascsubtag",
             "dib",
             "dib_tag",
+            "geniuslink",
             "keywords",
             "th",
             "content-id",


### PR DESCRIPTION
Sample URL: https://www.amazon.ca/s?k=apple+watch+series+9+smartwatch+with+pink+aluminum+case+with+light+pink+sport+band+s+m+fitness+tracker+ecg+apps+always+on+retina+display+water+resistant&ascsubtag=68365c2365fc41a58531c3ab65af6eb5%7Ca081c57e-53ff-417b-90cb-7c0e983e9848%7Cmwb%7Ccn&geniuslink=true