### PR TITLE
Fixes cookie message on cv-library.co.uk

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -2900,3 +2900,5 @@ stripes.com###MidPageAd
 ||zazzle.fr/svc/px
 ||zillow.com/HYx10rg3/init.js
 ||zoominfo.com/osx7m0dx/init.js
+! Prevents cookie messages from launching
+||cv-library.co.uk/cdn-cgi/zaraz/


### PR DESCRIPTION
1p cookie message launcher/tracker.  Blocking this 1p url prevents the cookie message from loading. 