### PR TITLE
Fixes eventbrite.com signin

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -89,8 +89,8 @@ crunchyroll.com##+js(set-local-storage-item, /_evidon_consent_ls_\d+/, $remove$)
 ||pdfjs.robwu.nl
 ! GPC issues 
 ! weather.com https://github.com/brave/brave-browser/issues/35431
-weather.com##+js(set, Navigator.prototype.globalPrivacyControl, false)
-weather.com##+js(set, navigator.globalPrivacyControl, false)
+eventbrite.com,weather.com##+js(set, Navigator.prototype.globalPrivacyControl, false)
+eventbrite.com,weather.com##+js(set, navigator.globalPrivacyControl, false)
 ! Soft anti-adblock
 maxroll.gg##+js(trusted-set-local-storage-item, adBlockWarning, '{"value":true}')
 ! Scroll bar-consent


### PR DESCRIPTION
Google signin doesn't work on https://www.eventbrite.com/signin/

No google login popup shows due to GPC checks by `https://cdntranscend.eventbrite.com/cm/f2747157-cf59-4ef1-8703-018defe51764/airgap.js`