### PR TITLE
Remove trk param from a media site

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -87,6 +87,18 @@
     },
     {
         "include": [
+            "*://*.linkedin.com/*",
+            "*://therecord.media/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+             "trk"
+        ]
+    },
+    {
+        "include": [
             "*://www.zoopla.co.uk/*"
         ],
         "exclude": [
@@ -277,8 +289,7 @@
         ],
         "params": [
             "mcid",
-            "src",
-            "trk"
+            "src"
         ]
     },
     {


### PR DESCRIPTION
Sample URL:
- https://therecord.media/meta-texas-facial-recognition-settlement?trk=feed_main-feed-card_feed-article-content
- https://www.linkedin.com/posts/brendaneich_privacyprotection-activity-6446307324519940096-W-Xf?trk=public_profile