### PR TITLE
Add another Amazon param

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -38,6 +38,7 @@
             "linkCode",
             "tag",
             "crid",
+            "pd_rd_i",
             "pd_rd_r",
             "pd_rd_w",
             "pd_rd_wg",


### PR DESCRIPTION
Sample URL: https://www.amazon.ca/New-World-Foods-Sugar-Free-Muesli/dp/B00LTFZBV8?pd_rd_i=B00LTFZBV8&psc=1&ref_=pd_bap_d_grid_rp_0_9_scp_i

It's also in AdGuard: https://github.com/AdguardTeam/AdguardFilters/blob/7303a3b8c64dc6dda74fc03e330d7b9c064049de/TrackParamFilter/sections/specific.txt#L1710

Note: `ref_` is linked to [webcompat problems](https://github.com/AdguardTeam/AdguardFilters/issues/88627).