### PR TITLE
Move more pageview checks over to specific.txt

### DIFF
--- a/brave-lists/brave-specific.txt
+++ b/brave-lists/brave-specific.txt
@@ -48,6 +48,11 @@ alltrails.com##+js(trusted-set-local-storage-item, banner-dismissal-date, $now$)
 ! YouTube navigation fix scriptlet rule
 youtube.*##+js(brave-youtube-navigation-fix)
 
+! pageview-api detection
+music.youtube.com##+js(brave-video-bg-play)
+jiocinema.com,wnyc.org,wqxr.org,kusc.org,kdfc.com,wfmt.com,wfmu.org,spectrumsportsnet.com,fanatiz.com,plex.tv,tntdrama.com,ballysports.com,nba.com,altitudenow.com,gaana.com,jiosaavn.com,play.anghami.com,app.idagio.com,wynk.in,radio.de,totallyradio.com.au,podcasts-online.org,podbay.fm,spreaker.com,player.fm,tuner.bonneville.com,kera.org,ukradiolive.com,fmstream.org,listnr.com,weather.com,accuradio.com,mytuner-radio.com,awa.fm,radiko.jp,watch.jme.tv,play.asti.ga,app.hzp.co,boomplay.com,radio.net,live365.com,radioparadise.com,streema.com,radio.garden,yourclassical.org,audacy.com,internet-radio.com,di.fm,fmradiofree.com,beinsports.com,plus.nasa.gov,c-span.org,protonradio.com,ted.com,vimeo.com,radioonline.fm,jango.com,littlive.com,freefy.app,france.tv,rova.nz,radio-stations.co.nz,onlineradiobox.com,digitalradioplus.com.au,radio-australia.org,radioau.net,radio-uk.co.uk,liveradio.uk,ukonlineradio.com,liveradiouk.com,globalplayer.com,radioside.com,nebula.tv,britbox.com,freely.co.uk,bbc.co.uk,itv.com,dazn.com,nowtv.com,vudu.com,primevideo.com,pluto.tv,espn.com,xfinity.com,viaplay.com,rakuten.tv,joyn.de,canalplus.com,starplus.com,tubitv.com,dstv.com,directv.com,9now.com.au,10play.com.au,7plus.com.au,hayu.com,iview.abc.net.au,amcplus.com,neontv.co.nz,kick.com,docplay.com,acorn.tv,mubi.com,vix.com,nfl.com,foxsports.com,nbcsports.com,qobuz.com,iheart.com,music.amazon.com,liveone.com,tunein.com,tencentmusic.com,cnn.com,music.youtube.com,channel4.com,crunchyroll.com,fubo.tv,gem.cbc.ca,shudder.com,watch.att.com,crave.ca,tvnz.co.nz,threenow.co.nz,foxtel.com.au,stan.com.au,binge.com.au,skygo.co.nz,hulu.com,disneyplus.com,max.com,paramountplus.com,peacocktv.com,pandora.com,deezer.com,slingtv.com,discoveryplus.com,curiositystream.com,spotify.com,netflix.com,tidal.com,soundcloud.com,music.apple.com,nicovideo.jp,tiktok.com,twitch.tv,nzherald.co.nz##+js(brave-disable-pageview-api)
+
+
 ! Used for Brave QA tests
 ?335962573013224749$image,xhr,domain=dev-pages.brave.software|dev-pages.bravesoftware.com
 ! Rules for testing cosmetic filters in frames

--- a/brave-lists/experimental.txt
+++ b/brave-lists/experimental.txt
@@ -6,7 +6,7 @@
 ! counter page visibility checks on youtube.com/twitch
 tv.youtube.com,www.youtube.com,m.youtube.com##+js(brave-video-bg-play)
 
-podcasts-online.org,podbay.fm,spreaker.com,player.fm,tuner.bonneville.com,kera.org,wnyc.org,wqxr.org,kusc.org,kdfc.com,wfmt.com,wfmu.org,radiolisten.de,ascoltareradio.com,ieradio.org,radios.lu,nederlandseradio.nl,nettradionorge.com,radio.org.se,radio.pp.ru,onlineradio.pl,radioonline.com.pt,emisora.org.es,radio.co.dk,radios.co.at,ukradiolive.com,fmstream.org,listnr.com,totallyradio.com.au,tv.youtube.com,www.youtube.com,m.youtube.com,plex.tv,gaana.com,jiosaavn.com,play.anghami.com,app.idagio.com,wynk.in,radio.de,fanatiz.com,spectrumsportsnet.com,tntdrama.com,ballysports.com,nba.com,altitudenow.com##+js(brave-disable-pageview-api)
+radiolisten.de,ascoltareradio.com,ieradio.org,radios.lu,nederlandseradio.nl,nettradionorge.com,radio.org.se,radio.pp.ru,onlineradio.pl,radioonline.com.pt,emisora.org.es,radio.co.dk,radios.co.at,tv.youtube.com,www.youtube.com,m.youtube.com##+js(brave-disable-pageview-api)
 !
 ! Google precision popup
 www.google.com,www.google.ca,www.google.com.au,www.google.co.nz,www.google.co.uk,www.google.ie,www.google.fr,www.google.nl,www.google.pt,www.google.de##.gTMtLb.fp-nh[style="visibility: visible;"]

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -2,10 +2,6 @@
 ! Title: Brave Unbreak
 ! Expires: 12 hours
 
-! pageview-api detection
-music.youtube.com##+js(brave-video-bg-play)
-weather.com,accuradio.com,mytuner-radio.com,awa.fm,radiko.jp,watch.jme.tv,play.asti.ga,app.hzp.co,boomplay.com,radio.net,live365.com,radioparadise.com,streema.com,radio.garden,yourclassical.org,audacy.com,internet-radio.com,di.fm,fmradiofree.com,beinsports.com,plus.nasa.gov,c-span.org,protonradio.com,ted.com,vimeo.com,radioonline.fm,jango.com,littlive.com,freefy.app,france.tv,rova.nz,radio-stations.co.nz,onlineradiobox.com,digitalradioplus.com.au,radio-australia.org,radioau.net,radio-uk.co.uk,liveradio.uk,ukonlineradio.com,liveradiouk.com,globalplayer.com,radioside.com,nebula.tv,britbox.com,freely.co.uk,bbc.co.uk,itv.com,dazn.com,nowtv.com,vudu.com,primevideo.com,pluto.tv,espn.com,xfinity.com,viaplay.com,rakuten.tv,joyn.de,canalplus.com,starplus.com,tubitv.com,dstv.com,directv.com,9now.com.au,10play.com.au,7plus.com.au,hayu.com,iview.abc.net.au,amcplus.com,neontv.co.nz,kick.com,docplay.com,acorn.tv,mubi.com,vix.com,nfl.com,foxsports.com,nbcsports.com,qobuz.com,iheart.com,music.amazon.com,liveone.com,tunein.com,tencentmusic.com,cnn.com,music.youtube.com,channel4.com,crunchyroll.com,fubo.tv,gem.cbc.ca,shudder.com,watch.att.com,crave.ca,tvnz.co.nz,threenow.co.nz,foxtel.com.au,stan.com.au,binge.com.au,skygo.co.nz,hulu.com,disneyplus.com,max.com,paramountplus.com,peacocktv.com,pandora.com,deezer.com,slingtv.com,discoveryplus.com,curiositystream.com,spotify.com,netflix.com,tidal.com,soundcloud.com,music.apple.com,nicovideo.jp,tiktok.com,twitch.tv,nzherald.co.nz##+js(brave-disable-pageview-api)
-
 ! https://github.com/easylist/easylist/issues/19234
 @@||mssl.fwmrm.net/libs/$domain=southpark.de|southparkstudios.co.uk|southparkstudios.com.br|southparkstudios.com
 @@||imasdk.googleapis.com/pal/sdkloader/pal.js$domain=southpark.de|southparkstudios.co.uk|southparkstudios.com.br|southparkstudios.com


### PR DESCRIPTION
Move pageview checks  from experimental:  Also remove from unbreak to specific.

- wnyc.org
- wqxr.org
- kusc.org
- kdfc.com
- wfmt.com
- wfmu.org
- spectrumsportsnet.com
- fanatiz.com
- plex.tv
- tntdrama.com
- ballysports.com
- nba.com
- altitudenow.com
- gaana.com
- jiosaavn.com
- play.anghami.com
- app.idagio.com
- wynk.in,radio.de
- totallyradio.com.au
- podcasts-online.org
- podbay.fm
- spreaker.com
- player.fm
- tuner.bonneville.com
- kera.org
- ukradiolive.com
- fmstream.org
- listnr.com

Also add `jiocinema.com`