### PR TITLE
Remove referral param from TicketWeb properties

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -122,6 +122,20 @@
     },
     {
         "include": [
+            "*://*.ticketweb.ca/*",
+            "*://*.ticketweb.com/*",
+            "*://*.ticketweb.ie/*",
+            "*://*.ticketweb.uk/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "REFERRAL_ID"
+        ]
+    },
+    {
+        "include": [
             "*://*.imdb.com/*"
         ],
         "exclude": [


### PR DESCRIPTION
Sample URL: https://www.ticketweb.ca/event/foundation-v120-with-bonobo-vancouver-convention-centre-tickets/13796863?REFERRAL_ID=tmfeed