### PR TITLE
Update Shorts on m.youtube.com

### DIFF
--- a/brave-lists/yt-shorts.txt
+++ b/brave-lists/yt-shorts.txt
@@ -1,6 +1,7 @@
 ! Youtube Shorts
 ! Main page
 youtube.com##ytd-rich-section-renderer:has(a[href^="/shorts/"])
+m.youtube.com##.rich-section-content
 ! Trending page
 youtube.com##ytd-reel-shelf-renderer:has(a[href^="/shorts/"])
 ! Search/Trending page (Android)


### PR DESCRIPTION
Specific to m.youtube.com, to cover a new YT Shorts div.

Discussed in https://community.brave.com/t/yt-short-on-android/562712/8

Can confirm it works.