### PR TITLE
Financial Times also uses the trk param

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -88,6 +88,7 @@
     },
     {
         "include": [
+            "*://www.ft.com/*",
             "*://*.linkedin.com/*",
             "*://therecord.media/*"
         ],


### PR DESCRIPTION
Sample URL: https://www.ft.com/content/07611b74-3d69-4579-9089-f2fc2af61baa?trk=feed_main-feed-card_feed-article-content