### PR TITLE
Fix garmin first-party hang due to first-party tracking script.

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -14,6 +14,7 @@
 /plugins/advanced-ads/*$domain=~wordpress.org
 /prebid/*$script
 /webads.
+/fbevents.js
 ! imported from uBO
 /api/users/*&ev=$script
 ! Admiral anti adblock

--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -14,6 +14,7 @@
 /plugins/advanced-ads/*$domain=~wordpress.org
 /prebid/*$script
 /webads.
+! https://github.com/brave/adblock-lists/pull/1974
 /fbevents.js
 ! imported from uBO
 /api/users/*&ev=$script


### PR DESCRIPTION
Discussed here: https://community.brave.com/t/garmin-connect-https-connect-garmin-com-not-working-in-brave/564106

Created an account and was reproducible. There was a hang in standard shields mode.

Caused by `https://static.garmin.com/tealium/fbevents.js` 

Fix: import `/fbevents.js` from Easyprivacy. 