### PR TITLE
Campaign and link tracking used on CBS properties

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -115,6 +115,24 @@
     },
     {
         "include": [
+            "*://*.cbsnews.com/*",
+            "*://*.cbssports.com/*",
+            "*://*.cnet.com/*",
+            "*://*.gamespot.com/*",
+            "*://*.insideedition.com/*",
+            "*://*.paramountplus.com/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+             "ftag",
+             "intcid",
+             "linkId"
+        ]
+    },
+    {
+        "include": [
             "*://www.zoopla.co.uk/*"
         ],
         "exclude": [


### PR DESCRIPTION
Sample URLs:
- https://www.cbsnews.com/news/world-bank-advertising-elon-musk-x-racism-pro-nazi-accounts/?ftag=CNM-00-10aab7e&linkId=561635594
- https://www.cbsnews.com/colorado/news/world-bank-advertising-elon-musk-x-racism-pro-nazi-accounts/?intcid=CNR-02-0623
- https://www.paramountplus.com/account/signup/live-tv/?intcid=CIA85fa358
- https://www.cbsnews.com/news/antiracist-not-racist-difference/?ftag=CNM-00-10aab7e&linkId=92079144
- https://www.cbssports.com/watch/nfl?ftag=CBS-16-10adb4f
- https://www.insideedition.com/live?ftag=ETM-16-10aab3h
- https://www.paramountplus.com/gb/interstitial/1/?ftag=IPP-11-10aeg0g
- https://www.cnet.com/news/spacex-falcon-heavy-elon-musk-clear-launch-tower-kennedy-space-center/?ftag=CAD-03-10aaj8j
- https://www.gamespot.com/articles/overwatch-2-details-new-maps-hero-changes-and-hud-adjustments/1100-6491854/?ftag=ftag%3DGSS-05-10aab8e