### PR TITLE
Add shopping.yahoo.com debounce

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -430,6 +430,15 @@
   },
   {
     "include": [
+      "*://shopping.yahoo.com/rdlw?*"
+    ],
+    "exclude": [
+    ],
+    "action": "redirect",
+    "param": "gcReferrer"
+  },
+  {
+    "include": [
       "*://www.google.com/amp/s/*"
     ],
     "pref": "brave.de_amp.enabled",


### PR DESCRIPTION
Fixes shopping.yahoo.com debounce

`https://shopping.yahoo.com/rdlw?merchantId=1e71dc69-0ad7-47e7-abf5-dc3926557fa3&siteId=us-engadget&pageId=pnr-product-module&featureId=manual-entry&merchantName=Sonos&custData=eyJzb3VyY2VOYW1lIjoiV2ViLURlc2t0b3AtVmVyaXpvbiIsImxhbmRpbmdVcmwiOiJodHRwczovL3d3dy5zb25vcy5jb20vZW4tdXMvc2hvcC9lcmEtMTAwIiwiY29udGVudFV1aWQiOiIzYWNmNTQ0ZS1mN2M1LTQxMmUtOWI5Ni01M2NmMmQyNGM2ZjgiLCJvcmlnaW5hbFVybCI6Imh0dHBzOi8vd3d3LnNvbm9zLmNvbS9lbi11cy9zaG9wL2VyYS0xMDAifQ&signature=AQAAAUxQJoQwr882Bxyw1_kNswSjpJuUA42fcAxSej47bvdb&gcReferrer=https%3A%2F%2Fwww.sonos.com%2Fen-us%2Fshop%2Fera-100&itemName=Sonos+Era+100+Smart+Speaker&contentUuid=3acf544e-f7c5-412e-9b96-53cf2d24c6f8`