### PR TITLE
Remove beehiiv link ID

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -599,6 +599,7 @@
             "_hsenc",
             "_hsmi",
             "hsCtaTracking",
+            "_bhlid",
             "cm_cr",
             "cm_me",
             "cm_re",


### PR DESCRIPTION
Sample URLs:
- https://winnipeg-digest.beehiiv.com/p/free-manitoba-parks-entry-weekend?_bhlid=22ba2deac78828960ee1ef01a631450a69e47743&utm_campaign=free-manitoba-parks-entry-this-weekend&utm_medium=newsletter&utm_source=winnipeg-digest.beehiiv.com
- https://news.gov.mb.ca/news/index.html?item=64737&posted=2024-08-26&utm_source=winnipeg-digest.beehiiv.com&utm_medium=newsletter&utm_campaign=free-manitoba-parks-entry-this-weekend&_bhlid=d7685c39176da0dd2e98918ffb55ec06572c2067

Also added to default filter in https://github.com/brave/brave-core/pull/25364.