### PR TITLE
Fix Ad-shield issues on ios

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -40,7 +40,8 @@ sinensistoon.com##+js(aopr, block_ads)
 ! ||html-load.com/loader.min.js$domain=ndtvprofit.com|javatpoint.com
 ! ||html-load.com^$redirect=noopjs,domain=raenonx.cc
 
-@@/loader.min.js$xhr,script,domain=etoday.co.kr|genshinlab.com|dogdrip.net|thestar.co.uk|yorkshirepost.co.uk|indiatimes.com|blog.esuteru.com|pravda.com.ua
+! @@/loader.min.js$xhr,script,domain=etoday.co.kr|genshinlab.com|dogdrip.net|thestar.co.uk|yorkshirepost.co.uk|indiatimes.com|blog.esuteru.com|pravda.com.ua
+@@||html-load.com^
 ! thesaurus.net##+js(nostif, loader.min.js)
 ! *$doc,csp=script-src-attr 'none',to=badmouth1.com|hoyme.jp|jin115.com|lamire.jp|picrew.me
 ! ||html-load.com/loader.min.js$domain=badmouth1.com|hoyme.jp|jin115.com|lamire.jp|picrew.me


### PR DESCRIPTION
Issues occuring on ios Ad-shield, for the time being just allow the domain on ios until we have some debug options on why its breaking.
Fixing:

![simulator_screenshot_-_iphone_15_-_2024-08-29_at_11 25 43](https://github.com/user-attachments/assets/ed6a8210-0d47-481d-aaa6-ed972d1ab134)
