### PR TITLE
Remove two parameters on shared NYT articles

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -543,6 +543,8 @@
 
         ],
         "params": [
+            "referringSource",
+            "sgrp",
             "smid",
             "ugrp"
         ]


### PR DESCRIPTION
Sample URL: https://www.nytimes.com/2024/08/27/opinion/google-monopoly-ruling-break-up.html?unlocked_article_code=...&referringSource=articleShare&sgrp=c-cb

Also on Adguard's list: https://github.com/AdguardTeam/AdguardFilters/blob/9c46e89e35b0bf664509c4ed187452f6d15771b4/TrackParamFilter/sections/specific.txt#L138-L139
