### PR TITLE
Remove Google's Merchant Center conversion tracker

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -767,6 +767,7 @@
             "utm_umguk",
             "utm_userid",
             "utm_viz_id",
+            "srsltid",
             "gbraid",
             "wbraid",
             "gclsrc",


### PR DESCRIPTION
Sample URL: https://www.inbox.com.tr/iphone-13-128gb-blue-u-mlpk3tua?srsltid=AfmBOorg7t5JIxJXaO5QzRlZxr4m6nRhPZpzztargEt_QxYIrlGRTv70e9c

Also in AdGuard: https://github.com/AdguardTeam/AdguardFilters/issues/162080