### PR TITLE
fixes cvs.com app banner

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -16,6 +16,9 @@
 sinensistoon.com##+js(aopr, block_ads)
 ||adskeeper.co.uk^
 
+! cvs.com app banner  cvs.com##cvs-smart-app-banner  not being applied
+cvs.com##+js(trusted-set-local-storage-item, appBannerClosed, $now$)
+
 ! https://github.com/brave/brave-browser/issues/39296
 ! For iOS 15 users, was fix post ios 15: https://github.com/brave/brave-core/pull/24472
 @@||youtube.com/youtubei/v1/log_event


### PR DESCRIPTION
cvs.com cosmetic not being applied. As a work around, we can work around with storage item

![cvs-app-header](https://github.com/user-attachments/assets/dc111477-60e9-462f-9659-7cdcaa8266f7)
