### PR TITLE
Remove unnecessary Gamefound parameters

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -155,6 +155,18 @@
     },
     {
         "include": [
+            "*://gamefound.com/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "ref",
+            "refcode"
+        ]
+    },
+    {
+        "include": [
             "*://*.ticketweb.ca/*",
             "*://*.ticketweb.com/*",
             "*://*.ticketweb.ie/*",


### PR DESCRIPTION
Sample URLs:
- https://gamefound.com/en/projects/dragori-games/dragori-games-store?refcode=K8j2_7tgsEWmso3KF_PK6A&utm_campaign=tanares_feast&utm_medium=email&utm_source=RD%20Station
- https://gamefound.com/en/projects/go-on-board/cyberpunk-2077-the-board-game?ref=recommendation_projectHome_1