### PR TITLE
Leave Proofpoint redirect URLs untouched

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -603,7 +603,7 @@
             "*://*/*"
         ],
         "exclude": [
-
+            "https://urldefense.com/v3/*"
         ],
         "params": [
             "_branch_referrer",


### PR DESCRIPTION
Proofpoint appears to sign the URLs in their redirector and so changing anything will break the signature and the redirect.

See https://github.com/brave/brave-browser/issues/41134 for more details.