### PR TITLE
Add typo'd version of the utm_* params that Eventbrite uses

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -473,6 +473,13 @@
 
         ],
         "params": [
+            "utm-campaign",
+            "utm-content",
+            "utm-experiment",
+            "utm-medium",
+            "utm-share-source",
+            "utm-source",
+            "utm-term",
             "aff",
             "can_id",
             "email_referrer",


### PR DESCRIPTION
The real `utm*` parameters use underscores, not hyphens. But Eventbrite is using these for some reason.

Sample URL: https://www.eventbrite.com/e/support-proactive-rezoning-on-broadway-in-person-meeting-tickets-1032932869017?aff=ebdsshcopyurl&utm-campaign=social&utm-content=attendeeshare&utm-medium=discovery&utm-term=organizer-profile&utm-share-source=organizer-profile