### PR TITLE
Remove itid from Washington Post

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -167,6 +167,17 @@
     },
     {
         "include": [
+            "*://*.washingtonpost.com/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "itid"
+        ]
+    },
+    {
+        "include": [
             "*://*.ticketweb.ca/*",
             "*://*.ticketweb.com/*",
             "*://*.ticketweb.ie/*",


### PR DESCRIPTION
Sample URL: https://www.washingtonpost.com/technology/2024/09/27/chrome-safari-privacy-setting-law-google-apple/?itid=ap_shiraovide