### PR TITLE
Add various Ita news sites

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -384,6 +384,12 @@
     },
     {
         "include": [
+            "*://www.limesonline.com/*",
+            "*://www.lastampa.it/*",
+            "*://laprovinciapavese.gelocal.it/*",
+            "*://lasentinella.gelocal.it/*",
+            "*://www.huffingtonpost.it/*",
+            "*://www.ilsecoloxix.it/*",
             "*://eprint.iacr.org/*",
             "*://*.goodreads.com/*",
             "*://hackernoon.com/*",


### PR DESCRIPTION
Was reported by a user;

```
https://www.limesonline.com/articoli/libano-hezbollah-israele-italia-onu-17275108/?ref=LHTP-BH-I16726669-P1-S1-F
https://www.lastampa.it/economia/2024/10/03/news/giorgetti_nuova_tassa_borsa-14686044/?ref=LSHA-BH-P1-S1-T1
https://laprovinciapavese.gelocal.it/pavia/cronaca/2024/10/03/news/fuori_strada_stradella_grave_35enne-14686729/?ref=PPA-M6-S1-T1
https://lasentinella.gelocal.it/ivrea/cronaca/2024/10/03/news/ivrea_nuovo_macchinario_aiutare_donne_operate_seno-14683202/?ref=SENCA-M6-S1-T1
https://www.huffingtonpost.it/economia/2024/10/03/news/tasse-17282232/?ref=HHTP-BH-I17171560-P1-S1-T1
https://www.ilsecoloxix.it/genova/2024/10/03/news/valpolcevera_operaio_cade_gravissimo-14686256/?ref=SEC-M6-S1-F
```