### PR TITLE
Fix consents on golf-live.at

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -21,6 +21,8 @@ cvs.com##+js(trusted-set-local-storage-item, appBannerClosed, $now$)
 
 ! golf-live.at consent prereq
 ||storage.googleapis.com/adtags/
+||themoneytizer.com^$3p
+||ioam.de^$3p
 
 ! Scroll fix
 cnn.com##body,html:style(overflow: auto !important; position: initial !important;)

--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -19,6 +19,9 @@ sinensistoon.com##+js(aopr, block_ads)
 ! cvs.com app banner  cvs.com##cvs-smart-app-banner  not being applied
 cvs.com##+js(trusted-set-local-storage-item, appBannerClosed, $now$)
 
+! golf-live.at consent prereq
+||storage.googleapis.com/adtags/
+
 ! Scroll fix
 cnn.com##body,html:style(overflow: auto !important; position: initial !important;)
 


### PR DESCRIPTION
`||storage.googleapis.com/adtags/`

prequest for cookie consent to show. Used in Easylist.