### PR TITLE
Remove Spotify's share ID

### DIFF
--- a/brave-lists/clean-urls-permissions.json
+++ b/brave-lists/clean-urls-permissions.json
@@ -2,6 +2,7 @@
     "js_api": [
         "*://*.youtube.com/*",
         "*://*.instagram.com/*",
+        "*://open.spotify.com/*",
         "*://www.tumblr.com/*",
         "https://boocmp.github.io/clipboard/*"
     ]

--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -365,6 +365,17 @@
     },
     {
         "include": [
+            "*://open.spotify.com/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "si"
+        ]
+    },
+    {
+        "include": [
             "*://youtu.be/*",
             "*://*.youtube.com/watch?*"
         ],


### PR DESCRIPTION
Sample URL: https://open.spotify.com/episode/5ptaZpDG37acwqRai4rwZK?si=IVRRpRuLQc6wyjMV4WEKbw

This ID gets added when clicking on _Copy Episode Link_:
![Screenshot from 2024-10-10 10-01-22](https://github.com/user-attachments/assets/d4c22365-4621-4868-a4c3-dc7f7dcc14da)
