### PR TITLE
Address clicks.trx-hub.com debounce

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -84,6 +84,15 @@
   },
   {
     "include": [
+      "*://clicks.trx-hub.com/xid/*"
+    ],
+    "exclude": [
+    ],
+    "action": "redirect",
+    "param": "q"
+  },
+  {
+    "include": [
       "*://www.zenaps.com/rclick.php*"
     ],
     "exclude": [


### PR DESCRIPTION
From https://www.mensjournal.com/gear/best-casio-watches

`
https://clicks.trx-hub.com/xid/arena_0b263_mensjournal?event_type=click&q=https%3A%2F%2Fgo.skimresources.com%2F%3Fid%3D106246X1712071%26xs%3D1%26xcust%3DMj-bestcasiowatches-abible-1024%26url%3Dhttps%253A%252F%252Fwww.casio.com%252Fus%252Fwatches%252Fgshock%252Fproduct.MRG-BF1000B-1A%252F&p=https%3A%2F%2Fwww.mensjournal.com%2Fgear%2Fbest-casio-watches&ContentId=ci02e8495b300024a9&author=Christopher+Friedmann&page_type=Article+Page&section=Gear&site_id=cs02b334a3f0002583&mc=www.mensjournal.com&ref=https%3A%2F%2Fwww.mensjournal.com%2F&exp=tempest-9188-aff%3Aa%7Ctempest-9188-brnd%3Aa&mcor=8314662660334384
`

Could change the "*://clicks.trx-hub.com/xid/*&ref=" and use "ref" param