### PR TITLE
Strip out utm_internal

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -805,6 +805,7 @@
             "utm_emcid",
             "utm_emmid",
             "utm_id",
+            "utm_internal",
             "utm_keyword",
             "utm_mailing",
             "utm_marketing_tactic",


### PR DESCRIPTION
Sample URLs:
- https://platform.billtobox.be/login2/users/registration?utm_internal=commercialsite&amp;_ga=2.203742230.707792121.1633425719-1654755149.1633425719
- https://www.plex.tv/blog/plex-pro-week-24-does-your-server-suck-energy/?utm_internal=pro_week_tim_blog_24

Not a very common one, but it's also in https://github.com/jparise/chrome-utm-stripper/issues/65