### PR TITLE
address https://community.brave.com/t/topic/579932/3

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -933,6 +933,8 @@ cube365.net##+js(aopr, bootbox.alert)
 ||pushsar.com^
 ||offerimage.com^
 ||rtmark.net^
+! Revolving adservers (regex workaround)
+*$script,3p,denyallow=addtoany.com|cloudflare.net|jsdelivr.net,domain=manga-mate.org
 ! adManager popups (regex workaround)
 xasiat.com##+js(rmnt, script, adManager)
 ! ios popups


### PR DESCRIPTION
Rust limitation of regex, ads can appear if EL didn't catch up revolving servers. `cloudflare.net` is a CNAME of `jsdelivr.net`.