### PR TITLE
Remove Threads' XMT Tracker

### DIFF
--- a/brave-lists/clean-urls-permissions.json
+++ b/brave-lists/clean-urls-permissions.json
@@ -5,6 +5,7 @@
         "*://open.spotify.com/*",
         "*://www.gofundme.com/*",
         "*://www.tumblr.com/*",
+        "*://*.threads.net/*",
         "https://boocmp.github.io/clipboard/*"
     ]
 }

--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -843,6 +843,17 @@
     },
     {
         "include": [
+            "*://*.threads.net/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "xmt"
+        ]
+    },
+    {
+        "include": [
             "https://dev-pages.bravesoftware.com/clean-urls/*"
         ],
         "exclude": [
@@ -851,17 +862,6 @@
         "params": [
             "brave_testing1",
             "brave_testing2"
-        ]
-    },
-    {
-        "include": [
-            "*://*.threads.net/*"
-        ],
-        "exclude": [
-
-        ],
-        "params": [
-            "xmt"
         ]
     }
 ]

--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -852,5 +852,16 @@
             "brave_testing1",
             "brave_testing2"
         ]
+    },
+    {
+        "include": [
+            "*://*.threads.net/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "xmt"
+        ]
     }
 ]


### PR DESCRIPTION
Remove the xmt-tracker from Threads' "copy link" button.

Resolves https://github.com/brave/brave-browser/issues/42345