### PR TITLE
Remove unnecessary parameters on dice.fm

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -598,6 +598,19 @@
     },
     {
         "include": [
+            "*://dice.fm/event/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "cid1",
+            "cid2",
+            "pid"
+        ]
+    },
+    {
+        "include": [
             "*://*.nytimes.com/*"
         ],
         "exclude": [


### PR DESCRIPTION
Sample URL: https://dice.fm/event/q2okdo-melkbelly-w-paper-mice-gerund-14th-dec-sleeping-village-chicago-tickets?cid1=&cid2=42257129&pid=f5e6ac52&utm_medium=partners_api