### PR TITLE
Cover IOS google Search by voice

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -41,6 +41,9 @@ kissanime.co,kissanime.sx,kissanime.org.ru,kissanime.com.ru,kisscartoon.sh,kissa
 kissanime.co,kissanime.sx,kissanime.org.ru,kissanime.com.ru,kisscartoon.sh,kissanime.com.ru,kissasian.video,kickassanime.com.ru,kickassanime.mx,kissasian.dad##+js(window.open-defuser)
 kissanime.co,kissanime.sx,kissanime.org.ru,kissanime.com.ru,kisscartoon.sh,kissanime.com.ru,kissasian.video,kickassanime.com.ru,kickassanime.mx,kissasian.dad##+js(set, check_adblock, true)
 
+! wildcard
+www.google.ac,www.google.ae,www.google.at,www.google.be,www.google.bg,www.google.by,www.google.ca,www.google.ch,www.google.cl,www.google.co.id,www.google.co.il,www.google.co.in,www.google.co.jp,www.google.co.ke,www.google.co.kr,www.google.co.nz,www.google.co.th,www.google.co.uk,www.google.co.ve,www.google.co.za,www.google.com,www.google.com.ar,www.google.com.au,www.google.com.br,www.google.com.co,www.google.com.ec,www.google.com.eg,www.google.com.hk,www.google.com.mx,www.google.com.my,www.google.com.pe,www.google.com.ph,www.google.com.pk,www.google.com.py,www.google.com.sa,www.google.com.sg,www.google.com.tr,www.google.com.tw,www.google.com.ua,www.google.com.uy,www.google.com.vn,www.google.cz,www.google.de,www.google.dk,www.google.dz,www.google.ee,www.google.es,www.google.fi,www.google.fr,www.google.gr,www.google.hr,www.google.hu,www.google.ie,www.google.it,www.google.lt,www.google.lv,www.google.nl,www.google.no,www.google.pl,www.google.pt,www.google.ro,www.google.rs,www.google.ru,www.google.se,www.google.sk##[aria-label="Search by voice"]
+
 ! https://github.com/brave/brave-browser/issues/39296
 ! For iOS 15 users, was fix post ios 15: https://github.com/brave/brave-core/pull/24472
 @@||youtube.com/youtubei/v1/log_event


### PR DESCRIPTION
Followup from https://github.com/brave/adblock-lists/pull/2179 

iOS specific 