### PR TITLE
Temp revert https://github.com/brave/adblock-lists/pull/2179

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -26,7 +26,8 @@ photopea.com##.app.flexrow > div:has-text(Ad blocking detected)
 ! imported from uBO
 /api/users/*&ev=$script
 ! https://github.com/brave/brave-browser/issues/42416
-www.google.*##[aria-label="Search by voice"]
+! Affecting Android, which can use voice
+! www.google.*##[aria-label="Search by voice"]
 ! first-party ads scripts
 ||2024tv.ru/lib.js
 ||soccerinhd.com/aclib.js


### PR DESCRIPTION
https://old.reddit.com/r/brave_browser/comments/1h2pvin/google_voice_search_button_not_showing_in_brave/

Android can search, IOS/Desktop can't. Reverted this for time being

https://github.com/brave/brave-browser/issues/42416