### PR TITLE
Debounce Cision redirector

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -211,6 +211,7 @@
   },
   {
     "include": [
+      "*://c212.net/c/link/?*",
       "*://*.c9ftyd.net/c/*",
       "*://*.iyhh.net/c/*",
       "*://*.glg9ob.net/c/*",


### PR DESCRIPTION
Sample URL: https://c212.net/c/link/?t=0&l=en&o=4227734-1&h=740056537&u=https%3A%2F%2Fwww.td.com%2Fca%2Fen%2Finvesting%2Fdirect-investing%2Fpartial-shares&a=td.com%2Fpartialshares

This domain is part of the [Cision](https://www.cision.ca/) platform which provides tracking related to press releases.