### PR TITLE
Remove redundant YT cosmetics

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -45,7 +45,7 @@ google.com##.Ryrdad:has-text(Please help us improve)
 google.com##div[jsname="wA2P2b"]:has-text(How helpful were the results)
 ! youtube popups
 music.youtube.com##tp-yt-paper-dialog.ytmusic-popup-container:-has-text(/family plan|Premium|ad-free|background play|kept playing/)
-www.youtube.com##tp-yt-paper-dialog.ytd-popup-container:-has-text(/Become a member|How are your|How interested|Live TV|Wish videos|background play|better TV|cable box|cable reimagined|hidden fees|of YouTube TV|on YouTube TV|unlimited DVR|with YouTube TV|without the ads|try this feature/)
+www.youtube.com##tp-yt-paper-dialog.ytd-popup-container:has-text(/Become a member|Free trial|How are your|How interested|Live TV|Wish videos|background play|better TV|cable box|cable reimagined|hidden fees|of YouTube TV|on YouTube TV|unlimited DVR|with YouTube TV|without the ads|try this feature|Terms apply/)
 ! sentry.io warning
 sentry.io##.loading-message > p:last-child
 ! tioeroge.blogspot.com (anti-adblock)

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -109,33 +109,6 @@ collegeconfidential.com##body:style(overflow: auto !important; max-height: 1px !
 reddit.com##+js(trusted-set-local-storage-item, xpromo-consolidation, $currentDate$)
 ! Fix preloader (facebook check)
 igniteunmc.com##.preloader
-! youtube
-youtube.com#@##masthead-ad
-youtube.com#@##player-ads
-! youtube.com#@##shorts-inner-container > .ytd-shorts:has(> .ytd-reel-video-renderer > ytd-ad-slot-renderer)
-youtube.com#@#.ytd-merch-shelf-renderer
-youtube.com#@#.ytp-suggested-action > button.ytp-suggested-action-badge
-! m.youtube.com#@#lazy-list > ad-slot-renderer
-youtube.com#@#ytd-ad-slot-renderer
-! youtube.com#@#ytd-rich-item-renderer:has(> #content > ytd-ad-slot-renderer)
-youtube.com#@#ytd-search-pyv-renderer
-! m.youtube.com#@#ytm-companion-slot[data-content-type] > ytm-companion-ad-renderer
-! m.youtube.com#@#ytm-rich-item-renderer > ad-slot-renderer
-! youtube (previous)
-youtube.com###items > ytd-ad-slot-renderer
-youtube.com###panels > [target-id="engagement-panel-ads"]
-youtube.com###related > div#player-ads
-youtube.com###content > ytd-ad-slot-renderer
-youtube.com###contents.style-scope.ytd-search-pyv-renderer
-youtube.com###main > #banner.ytd-merch-shelf-renderer
-youtube.com###masthead-ad > .ytd-rich-grid-renderer
-youtube.com###scroll-container > #items.ytd-merch-shelf-renderer
-youtube.com###ytd-player button.ytp-suggested-action-badge
-youtube.com##.ytp-chrome-top-buttons > .ytp-cards-teaser
-m.youtube.com##lazy-list > ad-slot-renderer
-youtube.com##ytd-ad-slot-renderer.style-scope.ytd-item-section-renderer
-youtube.com##ytd-rich-item-renderer:has(> .ytd-rich-item-renderer > ytd-ad-slot-renderer)
-youtube.com##ytd-rich-item-renderer:has(ytd-display-ad-renderer)
 !
 ! Brave-social (temp)
 ! List used by Brave for preventing social elements from loading


### PR DESCRIPTION
- Get rid of the latest NBA nag; 

![nba-yt](https://github.com/user-attachments/assets/fa767e28-1a01-4231-a8df-a2762894c4ba)

- Remove old YT cosmetics.
