### PR TITLE
Cover popads fake css rule

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -29,10 +29,13 @@ reliabletv.me##+js(rpnt, script, /const doRedirect = 1;[\s\S]*(?=const doAuthChe
 ! /^https?:\/\/(?:www\.|[0-9a-z]{7,10}\.)?[-0-9a-z]{5,}\.com\/\/?(?:[0-9a-z]{2}\/){2,3}[0-9a-f]{32}\.js/$script,3p,redirect-rule=noop.js,to=com
 ! /^https:\/\/[a-z]{3,5}\.[a-z]{10,14}\.top\/[a-z]{10,16}\/[a-z]{5,6}(?:\?d=\d)?$/$script,3p,match-case,to=top
 ! /^https?:\/\/[a-z]{8,15}\.com\/$/$xhr,3p,method=head,header=access-control-expose-headers:/X-DirectionPartner-Id/,to=com
+! ://www.*.css|$script,3p,header=link:/\/>;rel=preconnect/,to=com
 /^https:\/\/[a-z]{8,12}\.com\/en\/(?:[a-z]{2,5}\/){0,2}[a-z]{2,}\?(?:[a-z]+=(?:\d+|[a-z]+)&)*?id=[12]\d{6}/$script,3p
 /^https:\/\/[a-z]{3,5}\.[a-z]{10,14}\.top\/[a-z]{10,16}\/[a-z]{5,6}(?:\?d=\d)?$/$script,xhr,3p
 /^https?:\/\/(?:www\.|[0-9a-z]{7,10}\.)?[-0-9a-z]{5,}\.com\/\/?(?:[0-9a-z]{2}\/){2,3}[0-9a-f]{32}\.js/$script,3p,redirect-rule=noop.js
 /^https?:\/\/[a-z]{8,15}\.com\/$/$xhr,3p
+/^https:\/\/www\.[a-z]{8,16}\.com\/[a-z]{4,7}-[a-z]{4,7}\.min\.css$/$script,3p
+/^https:\/\/www\.[a-z]{8,16}\.com\/[a-z]{4,14}\.min\.css$/$script,3p
 
 ! southparkstudios.com
 ! https://community.brave.com/t/southparkstudios-com-adblock-detected/581673/7


### PR DESCRIPTION
Address https://community.brave.com/t/brave-unable-to-block-new-window-pop-ups/588156

Fix unsupported rule `://www.*.css|$script,3p,header=link:/\/>;rel=preconnect/,to=com` with regex.

.min.css fake css, being a script file.

Sample:

```
https://www.axdbzqorym.com/coidc-client.min.css
https://www.axdbzqorym.com/cpixi.min.css
```

