### PR TITLE
Improve video loading speed on hdontap.com

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -19,6 +19,7 @@
 /webads.
 /adcgi?
 /aclib.js$script,1p
+-contrib-ads.$~stylesheet
 ! Various uBO 1p network items. (START)
 /adc-ads-lib|$script
 ! https://github.com/uBlockOrigin/uAssets/blob/master/filters/filters-2024.txt#L767


### PR DESCRIPTION
Reported by a user, a delay videos loading on `hdontap.com` 

Blocking the 1p Ad script should help. (sync with existing EL rule)