### PR TITLE
Address another login issue on Tangerine

### DIFF
--- a/brave-lists/webcompat-exceptions.json
+++ b/brave-lists/webcompat-exceptions.json
@@ -142,7 +142,8 @@
       "*://www.tangerine.ca/*"
     ],
     "exceptions": [
-      "font"
+      "font",
+      "screen"
     ],
      "issue": "https://github.com/brave/brave-browser/issues/42600"
    },


### PR DESCRIPTION
Further followup from https://github.com/brave/brave-browser/issues/42600

Screen exception needed for https://www.tangerine.ca/app  failing login after 2FA entered.