### PR TITLE
Fix regex on  https://vidsrc.net/embed/movie?imdb=tt0425210

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -30,12 +30,14 @@ reliabletv.me##+js(rpnt, script, /const doRedirect = 1;[\s\S]*(?=const doAuthChe
 ! /^https:\/\/[a-z]{3,5}\.[a-z]{10,14}\.top\/[a-z]{10,16}\/[a-z]{5,6}(?:\?d=\d)?$/$script,3p,match-case,to=top
 ! /^https?:\/\/[a-z]{8,15}\.com\/$/$xhr,3p,method=head,header=access-control-expose-headers:/X-DirectionPartner-Id/,to=com
 ! ://www.*.css|$script,3p,header=link:/\/>;rel=preconnect/,to=com
+! (non-working) /^https?:\/\/(?:[a-z]{2}\.)?[0-9a-z]{5,16}\.[a-z]{3,7}\/[a-z](?=[a-z]{0,25}[0-9A-Z])[0-9a-zA-Z]{3,26}\/\d{4,6}(?:\?[_a-z]=[-0-9a-z]+)?$/$script,3p,match-case
 /^https:\/\/[a-z]{8,12}\.com\/en\/(?:[a-z]{2,5}\/){0,2}[a-z]{2,}\?(?:[a-z]+=(?:\d+|[a-z]+)&)*?id=[12]\d{6}/$script,3p
 /^https:\/\/[a-z]{3,5}\.[a-z]{10,14}\.top\/[a-z]{10,16}\/[a-z]{5,6}(?:\?d=\d)?$/$script,xhr,3p
 /^https?:\/\/(?:www\.|[0-9a-z]{7,10}\.)?[-0-9a-z]{5,}\.com\/\/?(?:[0-9a-z]{2}\/){2,3}[0-9a-f]{32}\.js/$script,3p,redirect-rule=noop.js
 /^https?:\/\/[a-z]{8,15}\.com\/$/$xhr,3p
 /^https:\/\/www\.[a-z]{8,16}\.com\/[a-z]{4,7}-[a-z]{4,7}\.min\.css$/$script,3p
 /^https:\/\/www\.[a-z]{8,16}\.com\/[a-z]{4,14}\.min\.css$/$script,3p
+/^https?:\/\/(?:[a-z]{2}\.)?[0-9a-z]{5,16}\.(xyz|shop|top|club|live|click|life|fun)\/[a-z0-9]{3,18}\/[0-9]{2,8}$/$script,3p,match-case
 
 ! idjav.info (NSFW) Work around
 ! *$xhr,3p,redirect-rule=nooptext:-1,method=head,to=~adblockanalytics.com|~doubleclick.net|~pagead2.googlesyndication.com


### PR DESCRIPTION
`/^https?:\/\/(?:[a-z]{2}\.)?[0-9a-z]{5,16}\.[a-z]{3,7}\/[a-z](?=[a-z]{0,25}[0-9A-Z])[0-9a-zA-Z]{3,26}\/\d{4,6}(?:\?[_a-z]=[-0-9a-z]+)?$/$script,3p,match-case`

Matching url: `https://swamperhyphens.shop/r6779cfb13857e/108734`

Causing popups since the regex isn't being properly parsed. 

Reported in https://community.brave.com/t/new-tab-popup-ads-not-being-blocked/588503

Simplified the regex a bit.