### PR TITLE
Debounce page.link

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -407,6 +407,15 @@
   },
   {
     "include": [
+      "*://*.page.link/?*"
+    ],
+    "exclude": [
+    ],
+    "action": "redirect",
+    "param": "ofl"
+  },
+  {
+    "include": [
       "*://*.cdn.ampproject.org/c/s/*"
     ],
     "pref": "brave.de_amp.enabled",


### PR DESCRIPTION
Fix debounce for *.page.link/?

`https://topgolf.page.link/?link=https://tga.topgolfmedia.com/promo/SpecialOffer/2099-01-01&apn=com.topgolf.community&isi=646122534&ibi=com.wgt.TopGolfMobile&efr=1&ofl=https://topgolf.com/us/company/app/`  -> `https://topgolf.com/us/company/app/`

