### PR TITLE
Test openinapp YT fix

### DIFF
--- a/brave-lists/experimental.txt
+++ b/brave-lists/experimental.txt
@@ -16,6 +16,10 @@ www.google.com,www.google.ca,www.google.com.au,www.google.co.nz,www.google.co.uk
 ! https://www.alphr.com/disable-google-recommends/
 www.google.com,www.google.ca,www.google.com.au,www.google.co.nz,www.google.co.uk,www.google.ie,www.google.fr,www.google.nl,www.google.pt,www.google.de##iframe[src^="https://ogs.google."][src*="/widget/callout?prid="]
 
+! Test rule to prevent open-in-app on mobile
+m.youtube.com##+js(trusted-click-element, button.yt-spec-button-shape-next, , 1500)
+m.youtube.com##+js(trusted-click-element, button.yt-spec-button-shape-next, , 3000)
+
 ! Twitch test rules
 twitch.tv##+js(vaft-ublock-origin)
 


### PR DESCRIPTION
Not sure how well this will work. 

Open `https://www.youtube.com/watch?v=5Swey1Pe3-w&list=RD5Swey1Pe3-w&start_radio=1` (Mobile UA)

But attempting to fake click the:
![ytpppop](https://github.com/user-attachments/assets/2f9ba69e-246c-4260-b0ce-62d5e7b9edb2)
