### PR TITLE
Add press.barnesandnoble.com fingerprinting

### DIFF
--- a/brave-lists/webcompat-exceptions.json
+++ b/brave-lists/webcompat-exceptions.json
@@ -102,7 +102,8 @@
   },
   {
     "include": [
-      "*://www.barnesandnoble.com/*"
+      "*://www.barnesandnoble.com/*",
+      "*://press.barnesandnoble.com/*"
     ],
     "exceptions": [
       "screen"


### PR DESCRIPTION
Add press.barnesandnoble.com

Fixes endless loading due to screen. Address https://community.brave.com/t/brave-does-not-work-with-the-barnes-and-noble-sefl-publishing-site/592506