### PR TITLE
Fix washingtonpost.com cosmetics

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -2992,6 +2992,8 @@ newatlas.com###desktop_article_2
 newatlas.com###desktop_article_3
 newatlas.com##.OcelotAdModule
 ! washingtonpost.com
+washingtonpost.com##.adslot-c
+washingtonpost.com##.wpds-c-gtAqRp
 washingtonpost.com###leaderboard-overlay
 washingtonpost.com###leaderboard-wrapper
 washingtonpost.com##.border-box.dn-hp-sm-to-mx


### PR DESCRIPTION
Fix empty top header