### PR TITLE
Remove subscriber ID in convertkit links

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -698,6 +698,7 @@
             "cm_mmca13",
             "cm_mmca14",
             "cm_mmca15",
+            "ck_subscriber_id",
             "hsa_acc",
             "hsa_ad",
             "hsa_cam",


### PR DESCRIPTION
Sample URL: https://blog.gitbutler.com/how-git-core-devs-configure-git/?ck_subscriber_id=39351234