### PR TITLE
Fixes in app warning from m.youtube.com

### DIFF
--- a/brave-lists/brave-specific.txt
+++ b/brave-lists/brave-specific.txt
@@ -101,6 +101,9 @@ google.*##+js(de-amp)
 ! YouTube theater mode fix scriptlet rule
 youtube.*##+js(brave-youtube-theater-fix)
 
+! Fixes open-in-app warning
+m.youtube.com##+js(trusted-click-element, button.yt-spec-button-shape-next[aria-label="Close"][aria-disabled="false"], , 2000)
+
 ! Trusted open-in-app notices
 alltrails.com##+js(trusted-set-local-storage-item, banner-dismissal-date, $now$)
 


### PR DESCRIPTION
Address in-app popup

- Hiding the element broke the scroll. Faking click the safest bet
- Limit to m.youtube.com also

![img_2991](https://github.com/user-attachments/assets/67b15967-5739-4fa5-801b-ca63bac84afb)

![screenshot_2025-03-03_at_5 59 53___pm](https://github.com/user-attachments/assets/cc4e1102-eedb-4caf-a085-657b0dd169b1)
