### PR TITLE
Disable discord.com filter rule

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -14,6 +14,9 @@
 ! Fix no playback  https://github.com/uBlockOrigin/uAssets/pull/27006
 spankbang.com#@#+js(set, send_recommendation_event, noopFunc)
 
+! https://github.com/uBlockOrigin/uAssets/issues?q=is%3Aissue%20discord.com%20science%20
+discord.com#@#+js(no-xhr-if, discord.com/api/v9/science)
+
 ! paywall counter for /wp-content/plugins/leaky-paywall/js/leaky-paywall-cookie.js$script,1p
 ! https://firstthings.com/cardinal-mcelroy-and-immigration/ empty page
 /wp-content/plugins/leaky-paywall/js/leaky-paywall-cookie.js$script,1p,badfilter


### PR DESCRIPTION
Problem rule, reported by @Brave-Matt  Lets test this

> Seeing some weird behavior with Discord and Brave. If you have the Discord app on your device and you click a Discord link in Brave, it launches the web version of Discord. Here, I would expect to be prompted to open the link in the discord app, which does not happen.
> If I’m signed into Discord in Brave and the app on my machine, I do get the prompt where I can click Always open links of this type in app check box. However, after clicking that box you still have to be signed into Discord on Brave for it to launch the app when you click on a Discord link in the browser. You would expect that, once you checked that box, whether you’re signed in or not, these links should still automatically open in the app.
> Lastly, if you disable Block ads and trackers globally, the functionality works as intended and whether logged into Discord or not in the browser, clicking a link will launch the app.