### PR TITLE
Bad filter visualwebsiteoptimizer.com rules

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -1266,6 +1266,12 @@ mycima.biz##+js(acis, parseInt, break;case $.)
 ||pubmatic.com^$badfilter
 ||appsflyer.com^$badfilter
 ||tapfiliate.com^$badfilter
+||dev.visualwebsiteoptimizer.com^$badfilter
+||rec5.visualwebsiteoptimizer.com^$badfilter
+||dacdn.visualwebsiteoptimizer.com^$badfilter
+||r1.visualwebsiteoptimizer.com^$badfilter
+||r2.visualwebsiteoptimizer.com^$badfilter
+||r3.visualwebsiteoptimizer.com^$badfilter
 ! Fix blank page on flipp.com
 @@||wishabi.net^$image,domain=flipp.com
 ! Fix "Alien Warning" script check on dslreports.com https://community.brave.com/t/alien-script-detected-inline-code-at-dslreports-com-speedtest/173716/


### PR DESCRIPTION
With the clean up previously  https://github.com/easylist/easylist/commit/8c7d2df6

Peter Lowes rules aren't needed and will cause some webcompat issues. 

Came from a discussion on a fix on https://github.com/uBlockOrigin/uAssets/commit/b0155b00687db9211bd3507c79e292e7e32e56b7

Still blocked, just specific scripts and not sub domains

```
easyprivacy/easyprivacy_thirdparty.txt:||visualwebsiteoptimizer.com/dyn
easyprivacy/easyprivacy_thirdparty.txt:||visualwebsiteoptimizer.com/ee.gif?
easyprivacy/easyprivacy_thirdparty.txt:||visualwebsiteoptimizer.com/gv.gif?
easyprivacy/easyprivacy_thirdparty.txt:||visualwebsiteoptimizer.com/server-side/track-user?
```
