### PR TITLE
Add another laylo domain for email redirects

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -7,6 +7,7 @@
       "*://track.flexlinks.com/a.ashx?*",
       "*://www.wordseed.com/go/*",
       "*://visit.ws/visit/*",
+      "*://laylo.co/e/*",
       "*://llo.to/e/*",
       "*://g-o-media.digidip.net/visit?*",
       "*://www.dpbolvw.net/click-*",


### PR DESCRIPTION
Sample URLs:
- https://bonobo.laylo.co/e/AJ5rUH/kazfAAD?url=https%3A%2F%2Fyoutu.be%2F_ohaWv-v6Ws%3Ffeature%3Dshared
- https://bonobo.laylo.co/e/AJ5rUH/kazfAAD?url=https%3A%2F%2Flazarusanime.lnk.to%2Fdarkwillfall

Like https://github.com/brave/adblock-lists/pull/1936 but with a new domain.