### PR TITLE
Update Ad-Shield

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -92,7 +92,8 @@ ft.com##+js(rc, sp-message-open, html, stay)
 ! Ad-shield test
 ! syosetu.com,game8.jp##+js(remove-node-text, script, html-load.com)
 ! ||html-load.com^$script,domain=game8.jp|syosetu.com
-@@||html-load.com^
+@@||07c225f3.online^$third-party
+@@||html-load.com^$third-party
 
 ! Ad-shield
 ! ||html-load.com^$~css,domain=etoday.co.kr|genshinlab.com|dogdrip.net|thestar.co.uk|yorkshirepost.co.uk|indiatimes.com


### PR DESCRIPTION
Quick-fixes blocks some 1pt requests of `html-load.com` with `*$~script,~frame,~xhr,domain=07c225f3.online|content-loader.com|css-load.com|html-load.com|img-load.com` and it doesn't depend on any advanced features like scriptlet. This PR allows to keep them blocked. Also if you need the `html-load.com` exception, you'll also need an exception for their legacy domain `07c225f3.online` used e.g. on `sportalkorea.com`.