### PR TITLE
github.com: strip `notification_referrer_id`

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -629,6 +629,17 @@
     },
     {
         "include": [
+            "*://*.github.com/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "notification_referrer_id"
+        ]
+    },
+    {
+        "include": [
             "*://arstechnica.com/*",
             "*://pitchfork.com/*",
             "*://www.allure.com/*",


### PR DESCRIPTION
Sample URL: `https://github.com/easylist/easylist/issues/21590?notification_referrer_id=NT_kwDOABlQfLMxNTY5OTU5NTEwMToxNjU5MDA0`