### PR TITLE
Add zdnet/cnet debounce

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -1,6 +1,8 @@
 [
   {
     "include": [
+      "*://cc.zdnet.com/v1/otc/*",
+      "*://cc.cnet.com/v1/otc/*",
       "*://cc.mashable.com/v1/*",
       "*://howl.me/link/?*",
       "*://www.pntrac.com/t/*",


### PR DESCRIPTION
Debounce; 
https://www.cnet.com/tech/home-entertainment/lg-c5-oled-tv-review-great-picture-now-wait-for-the-price-drop/
https://www.zdnet.com/article/best-fitness-ring/

```
https://cc.zdnet.com/v1/otc/00hQi47eqnEWQ6T9d4QLBUc?element=PRECAP&element_label=Evie+Ring+%7C+Best+fitness+ring+for+women&group_uuid=1fb414a7-1868-441c-b08c-24abf3cb2ce3&module=BUTTON&object_type=precap&object_uuid=7054cbb3-7dac-4291-8aac-fde7dfa49ae3&position=5&product_uuid=98fe2037-385c-4969-988f-00c1299e742f&template=article&url=https%3A%2F%2Feviering.com%2F&view_instance_uuid=eab6636f-2da2-4476-b7f5-92a9abdfad39&track_code=a85235fc114c48f2acafbeb72ecd8709-oo

https://cc.cnet.com/v1/otc/04Yxjj1rHOmYAxbnVDhvKNn?element_label=LG+OLED83C5PUA+%2883-inch%29&group_uuid=7a14f3a0-e0ae-47da-963a-80f6d2adb818&module=LINK&object_uuid=bbcec0d8-f25f-4f9e-96ec-a554ab0ffcf9&template=article&track_code=d10ab460012949f3a858355059e4d1d9&url=https%3A%2F%2Fbestbuy.7tiv.net%2Fc%2F159047%2F614286%2F10014%3F%26sharedid%3Dcnet%26partnerpropertyid%3D235399%26u%3Dhttps%253A%252F%252Fwww.bestbuy.com%252Fsite%252Flg-65-class-c5-series-oled-evo-ai-4k-uhd-smart-webos-tv-2025%252F6621824.p%253FskuId%253D6621824%26subId1%3Dcn-d10ab460012949f3a858355059e4d1d9-dtp-oo&view_instance_uuid=7081e9da-7d26-42f7-a0b8-50c941ec4bc4
```