### PR TITLE
Fixed youtube subscription page for desktop

### DIFF
--- a/brave-lists/experimental.txt
+++ b/brave-lists/experimental.txt
@@ -31,7 +31,6 @@ twitch.tv##+js(no-fetch-if, edge.ads.twitch.tv)
 ! Grid layout
 www.youtube.com##ytd-rich-grid-renderer:style(--ytd-rich-grid-items-per-row: 6 !important; --ytd-rich-grid-posts-per-row: 12 !important; --ytd-rich-grid-gutter-margin: 0px !important; --ytd-rich-grid-row-margin: 24px !important; )
 www.youtube.com###contents.ytd-rich-grid-renderer:style(--ytd-rich-grid-item-margin: 11px !important; margin: 0 5px !important; width: auto !important; justify-content: center !important;)
-www.youtube.com##ytd-rich-item-renderer:style(min-width: 264px !important;) 
 ! Item layout
 ! www.youtube.com###video-title-link.ytd-rich-grid-media:style(margin-left: 42px !important;)
 ! www.youtube.com###meta.ytd-rich-grid-media:style(margin-left: -42px !important; margin-bottom: -4px !important;)


### PR DESCRIPTION
With the rule applied I get this:
<img width="1490" alt="image" src="https://github.com/user-attachments/assets/1df20e33-93a2-43d9-a276-47cf4e86772d" />

Without the rule it returns to normal:
<img width="1493" alt="image" src="https://github.com/user-attachments/assets/99abccf8-6286-43bd-83be-b032d725405f" />