### PR TITLE
Fixes Ad-shield on tbsradio.jp

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -25,6 +25,11 @@ firstthings.com##+js(set-cookie, pum_popup_14631_page_views, 1)
 ! meet.google.com https://github.com/brave/brave-browser/issues/44754
 @@||play.google.com/log?$domain=meet.google.com
 
+! Ad-Shield fix
+@@||html-load.com^$script,xhr,domain=tbsradio.jp|ondemandkorea.com|tbsradio.jp
+! Unsupported counters ad-shield, but also breaks when combined. Countering this:
+! *$document,csp=script-src-attr 'none',to=m.economictimes.com|ondemandkorea.com|tbsradio.jp
+
 ! play.nova.bg anti-adblock
 ! https://play.nova.bg/video/hells-kitchen/season-7/hells-kitchen-2025-04-24-1/645838 
 @@||ssl.p.jwpcdn.com/player/*/googima.js$xhr,domain=play.nova.bg


### PR DESCRIPTION
Breakage on https://www.tbsradio.jp/a6j/

Due to unsupported *$document,csp=script-src-attr 'none',to=m.economictimes.com|ondemandkorea.com|tbsradio.jp

which is used in combine with `||html-load.com^$script,xhr,domain=tbsradio.jp|ondemandkorea.com|tbsradio.jp`. Only way around this is just to `@@||html-load.com^$script,xhr,domain=tbsradio.jp|ondemandkorea.com|tbsradio.jp`
