### PR TITLE
Fix bloomberg warning message

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -200,6 +200,8 @@ www.google.ac,www.google.ae,www.google.at,www.google.be,www.google.bg,www.google
 thebetterindia.com##.vspl__gtap-notification-content
 thebetterindia.com##.vspl__gtap-notification-overlay
 grubhub.com,dashboard.razorpay.com,joinhoney.com#@##credential_picker_container
+! https://www.reddit.com/r/brave_browser/comments/1krresc/when_using_brave_browser_on_mobile_bloomberg/
+bloomberg.com##.unsupported-browser-notification-container
 ! 
 ###ad--article-top-wrapper
 ###ad--sidebar


### PR DESCRIPTION
Address https://www.reddit.com/r/brave_browser/comments/1krresc/when_using_brave_browser_on_mobile_bloomberg/

Trying to reach out; https://x.com/fanboynz/status/1925304883630285066

Ensure its applied, why its in this list and not ios-specific.