### PR TITLE
Remove `source` parameter on Brave Search

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -550,6 +550,7 @@
     },
     {
         "include": [
+            "*://search.brave.com/*",
             "*://actionnetwork.org/*",
             "*://*.bamboohr.com/careers/*",
             "*://www.tumblr.com/*",


### PR DESCRIPTION
Sample URLs:
- https://search.brave.com/search?q=totp+in+golang&source=desktop&summary=1&conversation=b63dfcbcf41a80bc666804
- https://search.brave.com/search?q=totp+in+golang&source=web&summary=1&conversation=b71576183d7f0c68a714af