### PR TITLE
Youtube ads fallback on ios

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -15,6 +15,9 @@ sinensistoon.com##+js(aopr, block_ads)
 ! https://aws.amazon.com/vpc/pricing/ Expansion elements not work on iOS
 /web-vitals.$script,redirect-rule=noopjs,domain=amazon.com
 
+! YT ads fallback on snippet
+||googlevideo.com/videoplayback*ctier=L&*%2Cxpc%2Cctier%2C$domain=m.youtube.com|music.youtube.com|www.youtube.com
+
 ! cvs.com app banner  cvs.com##cvs-smart-app-banner  not being applied
 cvs.com##+js(trusted-set-local-storage-item, appBannerClosed, $now$)
 


### PR DESCRIPTION
Restored a updated rule, if the YT scriptlet fails to block the ads.