### PR TITLE
Add lucid.app to localhost permission allow-list

### DIFF
--- a/brave-lists/localhost-permission-allow-list.txt
+++ b/brave-lists/localhost-permission-allow-list.txt
@@ -65,3 +65,6 @@ driverhub.asus.com
 
 # https://github.com/brave/brave-browser/issues/43050
 pcsupport.lenovo.com
+
+# https://developer.lucid.co/docs/extension-api-getting-started#debug-your-editor-extension
+lucid.app


### PR DESCRIPTION
Lucidchart and Lucidspark have a "Load local extension" feature that developers can use when working with the Extension SDK. This requires making a connection to `http://localhost:9900`. See [the Extension SDK documentation](https://developer.lucid.co/docs/extension-api-getting-started#debug-your-editor-extension) for more details.

Figma, a similar SaaS product, is already on the list.