### PR TITLE
Fix ads on kompas.com

### DIFF
--- a/brave-lists/brave-firstparty-regional.txt
+++ b/brave-lists/brave-firstparty-regional.txt
@@ -1142,6 +1142,9 @@ elperiodico.com###intext-desktop-2
 elperiodico.com###intext-desktop-3
 elperiodico.com###intext-desktop-4
 elperiodico.com##.may-interest
+!! Indonesian sites
+kompas.com#@#.video-box-wrap
+kompas.com##.gate-kgplus
 !! Italian sites
 corriere.it#@#.ad__container
 corriere.it##.adv


### PR DESCRIPTION
Fixes video not showing;

https://video.kompas.com/watch/1853962/gaya-trump-saat-gubernur-california-menyerang-soal-kerusuhan-imigran-la?accountid=9262bf2590d558736cac4fff7978fcb1&domain_referral=kompascom&source=KOMPASCOM&position=detail_sidebar__thumbnail_1

kompas.com##.video-box-wrap. removes the video ^

Removes ad upgrade text:
kompas.com##.gate-kgplus. safe to use to remove the "Ad upgrade text" ?