### PR TITLE
Remove `device memory` related exception for rockstargames

### DIFF
--- a/brave-lists/webcompat-exceptions.json
+++ b/brave-lists/webcompat-exceptions.json
@@ -219,15 +219,6 @@
    },
    {
     "include": [
-      "*://www.rockstargames.com/*"
-    ],
-    "exceptions": [
-      "device memory"
-    ],
-    "issue": "https://github.com/brave/brave-browser/issues/45956"
-   },
-   {
-    "include": [
       "*://ospfranco.com/*"
     ],
     "exceptions": [


### PR DESCRIPTION
Not needed, and not even applying since the exception needs to be `device-memory`.