### PR TITLE
Remove `media devices` from list of exceptions

### DIFF
--- a/brave-lists/webcompat-exceptions.json
+++ b/brave-lists/webcompat-exceptions.json
@@ -184,7 +184,6 @@
      ],
      "exceptions": [
        "keyboard",
-       "media devices",
        "plugins"
      ],
       "issue": "https://github.com/brave/brave-browser/issues/42874"


### PR DESCRIPTION
Not supported (should be `media-devices`). If it's not supported, seems fine to remove.