### PR TITLE
Validate that exceptions in `webcompat-exceptions.json` are supported

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,8 +25,11 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Install yajl-tools
-        run: sudo apt-get install -qq yajl-tools
+      - name: Install list-validation tools
+        run: sudo apt-get update -qq && sudo apt-get install -qq yajl-tools jq
 
       - name: Check that JSON lists are valid
         run: for f in $GITHUB_WORKSPACE/brave-lists/*.json; do json_verify < $f ; done
+
+      - name: Validate webcompat exceptions
+        run: bash tools/validate_webcompat.sh

--- a/tools/validate_webcompat.sh
+++ b/tools/validate_webcompat.sh
@@ -24,8 +24,8 @@ file_path="${repo_root}/${target_file}"
 allowed_regex="^($(printf '%s|' "${allowed[@]}" | sed 's/|$//'))$"
 
 # Collect any unknown values into a variable.
-unknown=$(jq -r '..|objects|select(has("exceptions"))|.exceptions[]' "$file_path" \
-          | grep -Ev "$allowed_regex" || true)
+exceptions=$(jq -r '..|objects|select(has("exceptions"))|.exceptions[]' "$file_path")
+unknown=$(printf '%s\n' "$exceptions" | grep -Ev "$allowed_regex" || true)
 
 if [[ -n "$unknown" ]]; then
   echo "::error::Unknown value(s) found in exceptions array:"

--- a/tools/validate_webcompat.sh
+++ b/tools/validate_webcompat.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# tools/validate_webcompat.sh
+set -euo pipefail
+
+# ------- configuration -------
+allowed=(
+  all-fingerprinting audio canvas device-memory eventsource-pool
+  font hardware-concurrency keyboard language media-devices plugins
+  referrer screen speech-synthesis usb-device-serial-number user-agent
+  webgl webgl2 websockets-pool
+)
+
+target_file="brave-lists/webcompat-exceptions.json"
+# -----------------------------
+
+# Resolve repo root so the script works from any current directory
+repo_root=$(git -C "$(dirname "$0")" rev-parse --show-toplevel)
+file_path="${repo_root}/${target_file}"
+
+# Build a single regex like ^(audio|canvas|...)$
+allowed_regex="^($(printf '%s|' "${allowed[@]}" | sed 's/|$//'))$"
+
+# Collect any unknown values into the variable "unknown"
+unknown=$(jq -r '..|objects|select(has("exceptions"))|.exceptions[]' "$file_path" \
+          | grep -Ev "$allowed_regex" || true)
+
+if [[ -n "$unknown" ]]; then
+  echo "::error::Unknown value(s) found in exceptions array:"
+  echo "$unknown" | sed 's/^/  - /'
+  exit 1
+fi
+
+echo "✅  webcompat-exceptions.json contains only allowed values for exceptions key."

--- a/tools/validate_webcompat.sh
+++ b/tools/validate_webcompat.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
-# tools/validate_webcompat.sh
+
+# This script validates the contents of webcompat-exceptions.json
+# to ensure it only contains allowed values for the exceptions key.
+
+# Exit loudly and early on error.
 set -euo pipefail
 
-# ------- configuration -------
+# This is from kWebcompatNamesToType in webcompat_exceptions_service.cc
 allowed=(
   all-fingerprinting audio canvas device-memory eventsource-pool
   font hardware-concurrency keyboard language media-devices plugins
@@ -11,16 +15,15 @@ allowed=(
 )
 
 target_file="brave-lists/webcompat-exceptions.json"
-# -----------------------------
 
-# Resolve repo root so the script works from any current directory
+# Resolve repo root so the script works from any current directory.
 repo_root=$(git -C "$(dirname "$0")" rev-parse --show-toplevel)
 file_path="${repo_root}/${target_file}"
 
 # Build a single regex like ^(audio|canvas|...)$
 allowed_regex="^($(printf '%s|' "${allowed[@]}" | sed 's/|$//'))$"
 
-# Collect any unknown values into the variable "unknown"
+# Collect any unknown values into a variable.
 unknown=$(jq -r '..|objects|select(has("exceptions"))|.exceptions[]' "$file_path" \
           | grep -Ev "$allowed_regex" || true)
 


### PR DESCRIPTION
Adds a new GitHub Action task to validate that all listed `exceptions` in `webcompat-exceptions.json` are supported (listed in https://github.com/brave/brave-core/blob/master/components/webcompat/content/browser/webcompat_exceptions_service.cc). We can improve this script to add additional validations later. Update: also validates that `jq` runs correctly.

I tested the Action locally with `act`.

This will fail until we resolve https://github.com/brave/adblock-lists/pull/2520 (done)