### PR TITLE
Use hyphens for multi-word exception strings

### DIFF
--- a/brave-lists/webcompat-exceptions.json
+++ b/brave-lists/webcompat-exceptions.json
@@ -119,7 +119,7 @@
      ],
      "exceptions": [
        "keyboard",
-       "media devices",
+       "media-devices",
        "plugins"
      ],
       "issue": "https://github.com/brave/brave-browser/issues/42874"


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/46652