### PR TITLE
Remove CIBC and Simplii from needing `screen` exceptions

### DIFF
--- a/brave-lists/webcompat-exceptions.json
+++ b/brave-lists/webcompat-exceptions.json
@@ -103,16 +103,6 @@
    },
    {
      "include": [
-       "*://online.simplii.com/*",
-       "*://www.simplii.com/*"
-     ],
-     "exceptions": [
-       "screen"
-     ],
-      "issue": "https://github.com/brave/brave-browser/issues/42600"
-   },
-   {
-     "include": [
        "*://vc.larksuite.com/*",
        "*://vc-jp.larksuite.com/*",
        "*://vc-sg.larksuite.com/*"
@@ -122,16 +112,6 @@
        "plugins"
      ],
       "issue": "https://github.com/brave/brave-browser/issues/42874"
-   },
-   {
-    "include": [
-      "*://www.cibconline.cibc.com/*",
-      "*://www.cibc.com/*"
-   ],
-   "exceptions": [
-     "screen"
-   ],
-    "issue": "https://github.com/brave/brave-browser/issues/42600"
    },
    {
     "include": [


### PR DESCRIPTION
Works based on internal testing, no screen exceptions required.

https://bravesoftware.slack.com/archives/C2FQMN4AD/p1750706016118449?thread_ts=1750705963.241529&cid=C2FQMN4AD