### PR TITLE
add debounce for lcmspubcontact.lc.ca

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -1,6 +1,7 @@
 [
   {
     "include": [
+      "*://lcmspubcontact.lc.ca.gov/PublicLCMS/LinkTracking.php?*",
       "*://cc.zdnet.com/v1/otc/*",
       "*://cc.cnet.com/v1/otc/*",
       "*://cc.mashable.com/v1/*",


### PR DESCRIPTION
sample URL: https://lcmspubcontact.lc.ca.gov/PublicLCMS/LinkTracking.php?id=662215&eaid=412612&url=http%3A%2F%2Fdemocrats.senate.ca.gov%2Fredirect%3Furl%3Dhttps%3A%2F%2Fwww.nytimes.com%2F2025%2F07%2F07%2Fus%2Fcalifornia-high-speed-rail-funding.html&tid=SD11C1399110629