### PR TITLE
Allow Twitch clip media through filters (#2535)

### DIFF
--- a/brave-lists/brave-twitch.txt
+++ b/brave-lists/brave-twitch.txt
@@ -9,4 +9,9 @@
 !twitch.tv##+js(no-fetch-if, edge.ads.twitch.tv)
 !twitch.tv##+js(trusted-set, navigator.userAgent, '{"value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:139.0) Gecko/20100101 Firefox/139.0"}')
 !twitch.tv##+js(rmnt, script, navigator.userAgent)
++! Allow Twitch clips to play
++@@||clips-media-assets.twitch.tv/*$media,domain=clips.twitch.tv
++@@||distro.video.clips.twitch.tv/*$media,domain=clips.twitch.tv
++@@||d3vdj7etq0bi3b.cloudfront.net/*$media,domain=clips.twitch.tv
+
 


### PR DESCRIPTION
This pull request fixes issue #2535 by adding exception rules to allow Twitch clip media to load. Clip segments served from the following domains are no longer blocked:

clips-media-assets.twitch.tv

distro.video.clips.twitch.tv