### PR TITLE
Add Amazon ref_

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -54,6 +54,7 @@
             "pf_rd_t",
             "qid",
             "ref",
+	    "ref_",
             "refinements",
             "rnid",
             "social_share",


### PR DESCRIPTION
Amazon appends an underscore to ref, making it ref_ and prevents clean link from working correctly. 

Another issue, but worth noting:
Amazon also sometimes add ref as part of the url path, completely bypassing this method of prevention. Example:

`https://www.amazon.com/dp/B09LJ1ZWXP/ref=sspa_dk_detail_1?psc=1&sp_csd=d2lkZ2V0TmFtZT1zcF9kZXRhaWxfdGhlbWF0aWM`