### PR TITLE
Remove the Tangerine exceptions

### DIFF
--- a/brave-lists/webcompat-exceptions.json
+++ b/brave-lists/webcompat-exceptions.json
@@ -102,16 +102,6 @@
    },
    {
     "include": [
-      "*://www.tangerine.ca/*"
-    ],
-    "exceptions": [
-      "font",
-      "screen"
-    ],
-     "issue": "https://github.com/brave/brave-browser/issues/42600"
-   },
-   {
-    "include": [
       "*://www.fedex.com/*"
     ],
     "exceptions": [


### PR DESCRIPTION
After testing with full fingerprinting protections for two months, it looks like this exception is no longer needed.

The exception was added in https://github.com/brave/brave-browser/issues/42600.