### PR TITLE
Reorganize CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 brave-lists/** @ShivanKaul @antonok-edm
 # debounce.json can rely on sec-team approval.
 brave-lists/debounce.json @brave/sec-team
-# Experimental list doesn't need code owner approval.
+# Experimental list needs Ryan's approval.
 brave-lists/experimental.txt @ryanbr


### PR DESCRIPTION
- By default, all filter lists need Shivan or Anton approval
- debounce.json needs sec team approval
- Experimental list needs Ryan approval

Codeowner approval is also now required at the repo-level.