### PR TITLE
Add brave-auto-pip scriptlet rules for YouTube and Brave Talk

### DIFF
--- a/brave-lists/experimental.txt
+++ b/brave-lists/experimental.txt
@@ -24,6 +24,9 @@ www.google.com,www.google.ca,www.google.com.au,www.google.co.nz,www.google.co.uk
 ! Test rule to prevent open-in-app on mobile
 m.youtube.com##+js(rc, paused-mode, , stay)
 
+! YouTube auto picture-in-picture scriptlet rule
+www.youtube.*##+js(brave-auto-pip)
+
 ! Twitch test rules
 ! twitch.tv##+js(vaft-ublock-origin)
 ! Twitch counter for anti-adblock


### PR DESCRIPTION
Applies the brave-auto-pip scriptlet to automatically enable picture-in-picture functionality on:
- All YouTube domains (youtube.*)

This provides seamless automatic picture-in-picture experience for video content on these platforms.

Resource PR: https://github.com/brave/adblock-resources/pull/273