### PR TITLE
Test counter rules, only temp

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -22,6 +22,9 @@ discord.com#@#+js(no-xhr-if, discord.com/api/v9/science)
 
 ! test rule
 @@||youtube.com/api/stats/atr?
+! just some test rules
+@@||youtube.com/api/stats/qoe?
+@@||youtube.com/ptracking?
 
 ! fixes
 ! https://www.reddit.com/r/brave_browser/comments/1l6jnjq/captcha_on_every_google_search/


### PR DESCRIPTION
Just some temp rules to see why reports are currently elevated.  May/Maynot  be related too. 

```
||youtube.com/api/stats/atr?ns=*&ver=2&cmt=1.*&fs=0&*&euri&lact=$xhr,method=post
||youtube.com/api/stats/qoe?*page&ns=yt&fexp=v1%*&event=streamingstats&$xhr,method=post
||youtube.com/ptracking?html5=1&video_id=*&cpn=*&ei=*&ptk=youtube_*&pltype=content$xhr,method=get
```