### PR TITLE
Disable screen fingerprinting protection on YouTube

### DIFF
--- a/brave-lists/webcompat-exceptions.json
+++ b/brave-lists/webcompat-exceptions.json
@@ -65,6 +65,18 @@
   },
   {
     "include": [
+      "*://www.youtube.com/*",
+      "*://m.youtube.com/*",
+      "*://music.youtube.com/*",
+      "*://tv.youtube.com/*"
+      ],
+     "exceptions": [
+      "screen"
+    ],
+    "issue": "https://github.com/brave/brave-browser/issues/49842"
+  },
+  {
+    "include": [
       "*://workspace.google.com/*"
     ],
     "exceptions": [


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/49842.

May or may not help the recent issues, but screen fingerprinting was interfering in my testing.