### PR TITLE
Test disabling ad-shield exception rule

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -96,7 +96,7 @@ ft.com##+js(rc, sp-message-open, html, stay)
 ! Ad-shield test
 ! syosetu.com,game8.jp##+js(remove-node-text, script, html-load.com)
 ! ||html-load.com^$script,domain=game8.jp|syosetu.com
-@@||html-load.com^
+! @@||html-load.com^
 
 ! Ad-shield
 ! ||html-load.com^$~css,domain=etoday.co.kr|genshinlab.com|dogdrip.net|thestar.co.uk|yorkshirepost.co.uk|indiatimes.com


### PR DESCRIPTION
Disable exception rule and falls back to uAssets rule. See [Slack thread](https://bravesoftware.slack.com/archives/C2FQMN4AD/p1761858211829839?thread_ts=1761830799.905319&cid=C2FQMN4AD) for more context.