### PR TITLE
Revert https://github.com/brave/adblock-lists/commit/37168034f9d0bf5eca5897071c736a57c8e8ab3f

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -96,7 +96,7 @@ ft.com##+js(rc, sp-message-open, html, stay)
 ! Ad-shield test
 ! syosetu.com,game8.jp##+js(remove-node-text, script, html-load.com)
 ! ||html-load.com^$script,domain=game8.jp|syosetu.com
-! @@||html-load.com^
+@@||html-load.com^
 
 ! Ad-shield
 ! ||html-load.com^$~css,domain=etoday.co.kr|genshinlab.com|dogdrip.net|thestar.co.uk|yorkshirepost.co.uk|indiatimes.com


### PR DESCRIPTION
Reverting this, still causing issues on ios. we'll need a better/alternative fix for Ad-shield on ios.