### PR TITLE
localhost-permission-allow-list.txt: pcarrier.com

### DIFF
--- a/brave-lists/localhost-permission-allow-list.txt
+++ b/brave-lists/localhost-permission-allow-list.txt
@@ -65,3 +65,6 @@ driverhub.asus.com
 
 # https://github.com/brave/brave-browser/issues/43050
 pcsupport.lenovo.com
+
+# https://pcarrier.com/jerkmonpro/
+pcarrier.com


### PR DESCRIPTION
Would like this tool to work in Brave. It connects to a local app on 127.0.0.1:12345.