### PR TITLE
Add brave-auto-pip scriptlet rules for YouTube and Brave Talk

### DIFF
--- a/brave-lists/experimental.txt
+++ b/brave-lists/experimental.txt
@@ -42,7 +42,7 @@ www.google.com,www.google.ca,www.google.com.au,www.google.co.nz,www.google.co.uk
 m.youtube.com##+js(rc, paused-mode, , stay)
 
 ! YouTube auto picture-in-picture scriptlet rule
-! www.youtube.*##+js(brave-auto-pip)
+www.youtube.*##+js(brave-auto-pip)
 
 ! Twitch test rules
 ! twitch.tv##+js(vaft-ublock-origin)


### PR DESCRIPTION
Applies the brave-auto-pip scriptlet to automatically enable picture-in-picture functionality on youtube.com

This provides seamless automatic picture-in-picture experience for video content on these platforms.
