### PR TITLE
Only require Anton/Shivan review for brave-specific.txt

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,6 @@
-# Default: all filter list changes require review unless specified otherwise.
-brave-lists/** @ShivanKaul @antonok-edm
+# Default: all filter list changes require Ryan review unless specified otherwise.
+brave-lists/** @ryanbr
 # debounce.json can rely on sec-team approval.
 brave-lists/debounce.json @brave/sec-team
-# Experimental list needs Ryan's approval.
-brave-lists/experimental.txt @ryanbr
-# List of sites that we hide Sec-CH-UA from needs Ryan's approval.
-brave-lists/brave-checks.txt @ryanbr
+# Brave-critical lists need Shivan and Anton review.
+brave-lists/brave-specific.txt @ShivanKaul @antonok-edm


### PR DESCRIPTION
To speed things up, @ryanbr is the codeowner for all Brave lists (and can ship things independently), and only brave-specific.txt requires @antonok-edm and @ShivanKaul review.