### PR TITLE
Tweak YT shorts rules

### DIFF
--- a/brave-lists/yt-shorts.txt
+++ b/brave-lists/yt-shorts.txt
@@ -8,12 +8,15 @@ youtube.com##ytd-reel-shelf-renderer:has(a[href^="/shorts/"])
 youtube.com##ytm-reel-shelf-renderer
 youtube.com##.media-item-thumbnail-container[aria-hidden][href^="/shorts/"]
 youtube.com##ytm-media-item:has(a[href^="/shorts/"])
-youtube.com##ytd-rich-shelf-renderer[is-shorts]
+youtube.com##.ytd-rich-shelf-renderer
 youtube.com##ytd-video-renderer > .ytd-video-renderer:has(a[href^="/shorts/"])
+youtube.com##.rich-section-content.fresh-feeds-dismissals
 ! side shorts
 youtube.com###items.yt-horizontal-list-renderer > ytd-reel-item-renderer
 ! shorts icons (desktop and mobile)
 youtube.com##.pivot-shorts.pivot-bar-item-tab
 youtube.com##.yt-simple-endpoint[title="Shorts"]
 ! Updated rules
-youtube.com##.ytGridShelfViewModelHost:has-text(Shorts)
+youtube.com##.ytGridShelfViewModelHost
+! Shorts search header button
+youtube.com##.ytChipShapeHost:has-text(Shorts)


### PR DESCRIPTION
Tweak YT Shorts rules, simplify some rules.

- Simplfy

```
youtube.com##.ytd-rich-shelf-renderer
youtube.com##.ytGridShelfViewModelHost
```

- Imported from https://github.com/easylist/easylist/blob/master/custom-lists/youtube-shorts.txt

```
youtube.com##.rich-section-content.fresh-feeds-dismissals
```

- Fix Shorts icon from showing (Causing reload issues). Lets remove it.

```
youtube.com##.ytChipShapeHost:has-text(Shorts)
```