### PR TITLE
Fix embedded twitch on techcrunch.com

### DIFF
--- a/brave-lists/brave-checks.txt
+++ b/brave-lists/brave-checks.txt
@@ -12,6 +12,7 @@ github.io
 fourleggedfriendsanimalhospital.com
 strafe.com
 edsby.com
+techcrunch.com
 esports.gg
 vlr.gg
 eventvods.com


### PR DESCRIPTION
Embedded twitch on https://techcrunch.com/2025/12/01/european-cops-shut-down-crypto-mixing-website-that-helped-launder-1-3-billion-euros/

Works fine in chrome, not in Brave