### PR TITLE
Include thegameawards for twitch checks

### DIFF
--- a/brave-lists/brave-checks.txt
+++ b/brave-lists/brave-checks.txt
@@ -25,6 +25,7 @@ twitchls.com
 southwest.com
 support.southwest.com
 thestreamerawards.com
+thegameawards.com
 multitwitch.tv
 reddit.com
 lolesports.com


### PR DESCRIPTION
On the chance the `thegameawards.com` host the twitch stream on the site. Preemptive fix. 

Similar to `thestreamerawards.com` fix.