### PR TITLE
Add missing YT shorts element

### DIFF
--- a/brave-lists/yt-shorts.txt
+++ b/brave-lists/yt-shorts.txt
@@ -2,6 +2,7 @@
 ! Main page
 youtube.com##ytd-rich-section-renderer:has(a[href^="/shorts/"])
 m.youtube.com##.rich-section-content
+m.youtube.com##.big-shorts-singleton
 ! Trending page
 youtube.com##ytd-reel-shelf-renderer:has(a[href^="/shorts/"])
 ! Search/Trending page (Android)


### PR DESCRIPTION
Possibly address https://github.com/brave/brave-browser/issues/51083