### PR TITLE
Debounce cc.zdtc.app

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -1,6 +1,7 @@
 [
   {
     "include": [
+      "*://cc.zdtc.app/v1/otc/*",
       "*://lcmspubcontact.lc.ca.gov/PublicLCMS/LinkTracking.php?*",
       "*://cc.zdnet.com/v1/otc/*",
       "*://cc.cnet.com/v1/otc/*",


### PR DESCRIPTION
`https://au.lifehacker.com/tech/116943/roundup/the-best-gaming-handhelds-of-2025`

from 
```
https://cc.zdtc.app/v1/otc/039wD5177sOv0IpbBGkVHCa?url=https%3A%2F%2Fwww.amazon.com.au%2Fdp%2FB0FB33FW8J%3Fth%3D1&cd62=04gb9wFuRxhOJPlkvabMZ4m&cd63=01GTNYlj38jBjqnvYuNz8bV&merchant=02OG5kdXYOVJBok6gALJvmp&tag=pcmagau08-22&ascsubtag=u%7Ctech%7C116943%7Croundup%7Cthe-best-gaming-handhelds-of-2025
```