### PR TITLE
Fix gap in mobile navigation for Shorts

### DIFF
--- a/brave-lists/yt-shorts.txt
+++ b/brave-lists/yt-shorts.txt
@@ -17,6 +17,8 @@ youtube.com###items.yt-horizontal-list-renderer > ytd-reel-item-renderer
 ! shorts icons (desktop and mobile)
 youtube.com##.pivot-shorts.pivot-bar-item-tab
 youtube.com##.yt-simple-endpoint[title="Shorts"]
+! Fix empty gap on mobile navigation
+m.youtube.com##ytm-pivot-bar-item-renderer:has(.pivot-shorts)
 ! Updated rules
 youtube.com##.ytGridShelfViewModelHost
 ! Shorts search header button


### PR DESCRIPTION
The current rule hides the Shorts icon but leaves an empty space on the mobile bottom navigation bar.

This addition removes the container element to fix the layout issue:
```m.youtube.com##ytm-pivot-bar-item-renderer:has(.pivot-shorts)```

Before:

<img width="393" height="58" alt="image" src="https://github.com/user-attachments/assets/0a2d74b2-267f-4894-bc6d-115a28e538c6" />

After:

<img width="394" height="52" alt="image" src="https://github.com/user-attachments/assets/a7fcf491-d362-41f0-a8a3-11ff095cf5a7" />
