### PR TITLE
Initial test FOP sorting config

### DIFF
--- a/.fopconfig
+++ b/.fopconfig
@@ -1,0 +1,38 @@
+# FOP Configuration File
+# Place in current directory or ~/.fopconfig
+
+# Skip commit prompt
+no-commit = false
+
+# Skip commit message format validation (M:/A:/P:)
+no-msg-check = true
+
+# Process all files (ignore IGNORE_FILES/IGNORE_DIRS)
+disable-ignored = false
+
+# Skip sorting (only tidy and combine rules)
+no-sort = false
+
+# Keep empty lines in output
+keep-empty-lines = true
+
+# Alternative sorting (by selector for all rule types)
+alt-sort = false
+
+# All enable PR (prompt for title)
+create-pr = true
+
+# Sort hosts file entries (0.0.0.0/127.0.0.1 domain)
+localhost = false
+
+# Disable colored output
+no-color = false
+
+# Additional directories to ignore (comma-separated, partial names supported)
+ignoredirs = tools
+
+# Additional files to ignore (comma-separated, partial names supported)
+ignorefiles = .json,.backup,.bak,.swp,.gz,localhost-permission-allow-list.txt,brave-social.txt,https-upgrade-exceptions-list.txt,filters-mirror.txt,brave-sugarcoat.txt,brave-firstparty-cname.txt
+
+# Testing, ignore all files except:
+ignore-all-but = brave-firstparty-regional.txt


### PR DESCRIPTION
Will just sort for testing `brave-firstparty-regional.txt` (initial sort test)  Closed, https://github.com/brave/adblock-lists/pull/2718
 
Ignore sorting: 

- localhost-permission-allow-list.txt
- brave-social.txt
- https-upgrade-exceptions-list.txt
- filters-mirror.txt
- brave-sugarcoat.txt
- brave-firstparty-cname.txt
- tools/ directory
- .json files

Forces PR to be created with `./fop`

Why [FOP is needed? ](https://www.npmjs.com/package/fop-cli)
* Will remove any empty characters, pre or post blank 
* Combine any of the same cosmetic or network rules into to one. 
* Remove any duplicate rules
* Make it easy to submit changes
* Used on Easylist already