### PR TITLE
add tradingpaints + paintbuilder to localhost permission list

### DIFF
--- a/brave-lists/localhost-permission-allow-list.txt
+++ b/brave-lists/localhost-permission-allow-list.txt
@@ -65,3 +65,7 @@ driverhub.asus.com
 
 # https://github.com/brave/brave-browser/issues/43050
 pcsupport.lenovo.com
+
+# https://help.tradingpaints.com/general/why-is-trading-paints-asking-to-look-for-and-connect-to-any-device-on-my-local-network/
+tradingpaints.com
+paintbuilder.tradingpaints.com


### PR DESCRIPTION
Trading Paints (and it's related site Paint Builder) communicate with a local desktop application in order to refresh users selected paints as they navigate the website as well as allow them to preview their works in progress directly in the iRacing Paint Shop or iRacing Simulator.  

Before attempting accessing the local service, the user is prompted via a notification bar/modal informing them why Trading Paints is asking for this access and allowing them to choose to allow it or not.

Currently Brave doesn't implement the local-network-access permission correctly and in "Shields Up" mode blocks requests with seemingly no way to add a site to an allow list and in "Shields Down" always returns "prompt" without ever actually prompting the user to allow or reject the local network access and allows the request.

More Info as to how the permission is used: https://help.tradingpaints.com/general/why-is-trading-paints-asking-to-look-for-and-connect-to-any-device-on-my-local-network/