### PR TITLE
Dfsfdsfdsfds

### DIFF
--- a/brave-lists/brave-checks.txt
+++ b/brave-lists/brave-checks.txt
@@ -9,6 +9,7 @@ teamstream.gg
 twitchtracker.com
 solarservicing.myaccountinfo.com
 myaccountinfo.com
+septakey.org
 gosugamers.net
 colamanga.com
 github.io

--- a/brave-lists/brave-checks.txt
+++ b/brave-lists/brave-checks.txt
@@ -1,6 +1,6 @@
 aa.com
 vanguard.com
-connect.intuit.com
+intuit.com
 escharts.com
 multistre.am
 twitchtheater.tv
@@ -27,7 +27,6 @@ hltv.org
 footybite.cc
 twitchls.com
 southwest.com
-support.southwest.com
 thestreamerawards.com
 thegameawards.com
 casthill.net


### PR DESCRIPTION
Fixes septakey.org ios UA checks

connect.intuit.com -> intuit.com

support.southwest.com -> Removed (southwest.com already added)