### PR TITLE
Prevent cnstrc.com from being accidentally domain-blocked again

### DIFF
--- a/brave-lists/brave-specific.txt
+++ b/brave-lists/brave-specific.txt
@@ -44,8 +44,7 @@ search.brave.com###search-ad
 ! Make sure the domain doesn't accidentally get added again.
 ! Was accidentally blocked twice leading to widespread breakage.
 ! See https://github.com/easylist/easylist/issues/22894
-! https://github.com/easylist/easylist/commit/543aeca
-@@||cnstrc.com^
+||cnstrc.com^$badfilter
 
 ! This is to make sure EasyList removal doesn't mess us up.
 ||search.brave.com/api/ads/


### PR DESCRIPTION
Accidentally blocking the whole domain `cnstrc.com` in EasyPrivacy broke auto-complete and searching for several e-commerce websites. This happened twice within 30 days. We need to make sure this doesn't happen again.

Note that we should still block any tracking from that domain, but we shouldn't break website search functionality.