### PR TITLE
Merge https://github.com/brave/adblock-lists/pull/2758 from experimental for ios

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -8,6 +8,10 @@
 ! Prevent googlefunding error message (ios)
 ||fundingchoicesmessages.google.com^$third-party,badfilter
 
+! https://github.com/brave/adblock-lists/pull/2758
+youtube.com#@#+js(brave-video-bg-play)
+youtube.com##+js(brave-video-bg-play-update)
+
 ! https://community.brave.app/t/ads-not-being-blocked-and-sites-denying-access-to-content/551667
 sinensistoon.com##+js(aopr, block_ads)
 ||adskeeper.co.uk^


### PR DESCRIPTION
Allow IOS users to use the new updated `brave-video-bg-play-update.js` script to counter more background checks from other websites.

Exception needed for Brave-unbreak for the time being

Ref: https://github.com/brave/adblock-resources/pull/292