### PR TITLE
Fixes rottentomatoes.com app nags

### DIFF
--- a/brave-lists/brave-specific.txt
+++ b/brave-lists/brave-specific.txt
@@ -69,6 +69,10 @@ search.brave.com###search-ad
 linkedin.com##+js(trusted-set-session-storage-item, blocking-upsell, '"DISMISSED"')
 linkedin.com##+js(trusted-set-session-storage-item, blocking-upsell_lastUpdatedAt, $now$)
 
+! Rotten tomatoes app recommendations
+rottentomatoes.com##+js(trusted-set-session-storage-item, mobileAppModal, '{"wasClosed":true}')
+rottentomatoes.com##+js(trusted-set-session-storage-item, mobileAndroidBanner, '{"wasClosed":true}')
+
 ! thegatewaypundit.com (images fix)
 @@||ruamupr.com^$script,domain=thegatewaypundit.com
 


### PR DESCRIPTION
Fixes (2) in-app nags for rottentomatoes.com, trusted rules most reliable for this website. 

<img width="1372" height="1003" alt="rottentomotes" src="https://github.com/user-attachments/assets/d2ac99ca-3d6f-4e7d-9b5e-ba771342e0db" />

Desktop unaffected, video plays.