### PR TITLE
Add more unnecessary reddit parameters

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -320,6 +320,9 @@
 
         ],
         "params": [
+            "%24deep_link",
+            "post_index",
+            "target_user",
             "correlation_id",
             "post_fullname",
             "ref",


### PR DESCRIPTION
This reddit URL: https://www.reddit.com/r/AISearchAnalytics/comments/1r1iexd/bing_launches_ai_performance_geo_report_inside/?%24deep_link=true&correlation_id=72133ada-1f36-47c4-936a-0fb3418a2175&post_fullname=t3_1r1iexd&post_index=4&ref=email_digest&ref_campaign=email_digest&ref_source=email&target_user=BraveAndyIntl&utm_content=post_title

still has these parameters after getting "cleaned" by Brave:
- `%24deep_link=true`
- `post_index=4`
- `target_user=BraveAndyIntl`

All of those are present in the AdGuard list: https://github.com/AdguardTeam/AdguardFilters/blob/057f0999f8f274cb9f7e2198e731c0a4739a1661/TrackParamFilter/sections/specific.txt#L767-L772