### PR TITLE
Re-add YouTube trusted-rpnt exception to fix video playback

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -18,6 +18,12 @@ spankbang.com#@#+js(set, send_recommendation_event, noopFunc)
 @@||cdn.ziffstatic.com/pg/maxroll.prebid.js$domain=maxroll.gg
 @@||cdn.ziffstatic.com/jst/zdconsent.js$domain=maxroll.gg
 
+! YouTube "content not available" / no playback due to upstream uBO trusted-rpnt rule
+! https://github.com/brave/brave-browser/issues/53017
+! https://github.com/brave/brave-browser/issues/52778
+! https://github.com/brave/brave-browser/issues/52761
+www.youtube.com#@#+js(trusted-rpnt, script, (function serverContract(), (()=>{if("YOUTUBE_PREMIUM_LOGO"===ytInitialData?.topbar?.desktopTopbarRenderer?.logo?.topbarLogoRenderer?.iconImage?.iconType)return void(ytcfg.data_.INNERTUBE_CONTEXT.client.userAgent=ytcfg.data_.INNERTUBE_CONTEXT.client.userAgent.replace?.(/(Mozilla\/5\.0 \([^)]+)/\,"$1; premium"));if(location.href.startsWith("https://www.youtube.com/tv#/")||location.href.startsWith("https://www.youtube.com/embed/"))return;document.addEventListener("DOMContentLoaded"\,(function(){const e=()=>{const e=document.getElementById("movie_player");if(!e)return;const t=e.getProgressState?.()\,o=e.getPlayerResponse?.();if(t&&t.duration>0&&(t.loaded<t.duration||t.duration-t.current>1)||o?.videoDetails?.isLive){if(!e.getStatsForNerds?.()?.debug_info?.startsWith?.("SSAP\, AD")){const t=o.videoDetails?.videoId;return void("UNPLAYABLE"!==o?.playabilityStatus?.status||o?.playabilityStatus?.errorScreen?.playerErrorMessageRenderer?.playerCaptchaViewModel||"WEB_PAGE_TYPE_UNKNOWN"!==o?.playabilityStatus?.errorScreen?.playerErrorMessageRenderer?.subreason?.runs?.[0]?.navigationEndpoint?.commandMetadata?.webCommandMetadata?.webPageType||"https://support.google.com/youtube/answer/3037019"!==o?.playabilityStatus?.errorScreen?.playerErrorMessageRenderer?.subreason?.runs?.[0]?.navigationEndpoint?.commandMetadata?.webCommandMetadata?.url||e.loadVideoById(t\,o.playerConfig?.playbackStartConfig?.startSeconds??0))}t.duration>0&&e.seekTo?.(t.duration)}};e()\,new MutationObserver((()=>{e()})).observe(document\,{childList:!0\,subtree:!0})}));const e={apply:(e\,t\,o)=>{const r=o[0];return"function"==typeof r&&r.toString().includes("onAbnormalityDetected")&&(o[0]=function(){})\,Reflect.apply(e\,t\,o)}};window.Promise.prototype.then=new Proxy(window.Promise.prototype.then\,e)})();(function serverContract(), sedCount, 1)
+
 ! https://github.com/uBlockOrigin/uAssets/issues?q=is%3Aissue%20discord.com%20science%20
 discord.com#@#+js(no-xhr-if, discord.com/api/v9/science)
 


### PR DESCRIPTION
## Summary

- Re-adds the `#@#+js(trusted-rpnt, ...)` exception rule for YouTube that was accidentally removed in commit 227a321 (PR #2784)
- The upstream uBO `trusted-rpnt` scriptlet targeting `serverContract()` breaks video playback for users in YouTube's anti-adblock experimental groups, causing "content not available" or blank video screens
- This exception was originally added by @ryanbr in commit 315a27c (PR #2777) on Feb 11, 2026, but was inadvertently replaced by the maxroll.gg fix on Feb 17

## Test plan

- [ ] Open YouTube with Brave Shields enabled
- [ ] Verify videos play normally (no "content not available" or black screen)
- [ ] Verify ads are still blocked (network-level blocking, `json-prune-fetch-response`, and other scriptlet rules remain active)
- [ ] Verify maxroll.gg fix from PR #2784 is still intact

Fixes https://github.com/brave/brave-browser/issues/53017
Fixes https://github.com/brave/brave-browser/issues/52778
Fixes https://github.com/brave/brave-browser/issues/52761

🤖 Generated with [Claude Code](https://claude.com/claude-code)