### PR TITLE
Block Shorts tab on YouTube channel pages

### DIFF
--- a/brave-lists/yt-shorts.txt
+++ b/brave-lists/yt-shorts.txt
@@ -17,6 +17,7 @@ youtube.com###items.yt-horizontal-list-renderer > ytd-reel-item-renderer
 ! shorts icons (desktop and mobile)
 youtube.com##.pivot-shorts.pivot-bar-item-tab
 youtube.com##.yt-simple-endpoint[title="Shorts"]
+youtube.com##yt-tab-shape:has-text(Shorts)
 ! Updated rules
 youtube.com##.ytGridShelfViewModelHost
 ! Shorts search header button


### PR DESCRIPTION
## Description
Adds a filter rule to block the Shorts tab on YouTube channel pages.

## Changes
- Added `youtube.com##yt-tab-shape:has-text(Shorts)` to `brave-lists/yt-shorts.txt` (line 20)

## Motivation
Currently, the Shorts tab on YouTube channel pages (e.g., `youtube.com/@username/shorts`) is not blocked by the existing filter list. Users can still navigate to a channel's Shorts content via this tab.

This is currently the case on both Desktop and Android. I haven't tested it on iOS but I am sure it will be the case there as well. Its pretty easy to replicate:

1. Go to any channel on YouTube using the brave browser such as youtube.com/@arbeanie with the "Block YouTube Shorts" filter applied.
2. You can then see that the YouTube shorts tab is still visisble. Such as:
<img width="1385" height="749" alt="image" src="https://github.com/user-attachments/assets/02e2ba2e-5649-44b8-acf5-b4d39887fd7c" />


## Implementation
The new rule follows the same pattern as other navigation blocking rules (lines 18-19) by using text-based matching with `:has-text(Shorts)`. This approach is more robust than positional selectors and will work regardless of tab order.

## Testing
- Tested locally using `brave://adblock/` custom filters
- Verified the Shorts tab is hidden on channel pages (e.g., youtube.com/@arbeanie)
- Confirmed other tabs (Videos, Playlists, etc.) remain visible
- No console errors or broken functionality observed

No more Shorts tab:
<img width="1357" height="763" alt="image" src="https://github.com/user-attachments/assets/e7e24d9c-040b-4454-8b07-6faacbd70d44" />
<img width="924" height="893" alt="image" src="https://github.com/user-attachments/assets/e47dcb61-a275-4428-9412-dfe97470fb4c" />
