### PR TITLE
Fix Twitch embed issues on `destiny.gg`

### DIFF
--- a/brave-lists/brave-checks.txt
+++ b/brave-lists/brave-checks.txt
@@ -316,3 +316,4 @@ capitaloneoffers.com
 capitalone.com
 rdrama.net
 redscarepod.net
+destiny.gg


### PR DESCRIPTION
One of the pages (https://www.destiny.gg/bigscreen) allows users to embed 3rd party streams to watch; adding the domain to the `checks` list to make the Twitch ones work on Brave.