### PR TITLE
Remove the Klaviyo click identifier from URLs

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -960,6 +960,7 @@
             "_hsmi",
             "hsCtaTracking",
             "_bhlid",
+            "_kx",
             "cm_cr",
             "cm_me",
             "cm_re",


### PR DESCRIPTION
While we [had it in the Brave query string filter](https://github.com/brave/brave-browser/issues/53588), we decided to [remove it](https://github.com/brave/brave-core/pull/34693) in case it breaks some unsubscribe links.

Given we don't have any evidence of webcompat problems, it seems safe enough to remove it while cleaning URLs for sharing.

Sample URL:
- https://www.mynewroots.org/?_kx=WVo-HABVGg9W_fe6fYM9oOGNU5r3ToZkzLDIEUrSmxk.W53BcJ