### PR TITLE
Hiding mobile app modal on rotten tomatoes iOS

### DIFF
--- a/brave-lists/brave-specific.txt
+++ b/brave-lists/brave-specific.txt
@@ -72,6 +72,7 @@ linkedin.com##+js(trusted-set-session-storage-item, blocking-upsell_lastUpdatedA
 ! Rotten tomatoes app recommendations
 rottentomatoes.com##+js(trusted-set-session-storage-item, mobileAppModal, '{"wasClosed":true}')
 rottentomatoes.com##+js(trusted-set-session-storage-item, mobileAndroidBanner, '{"wasClosed":true}')
+rottentomatoes.com##+js(trusted-set-local-storage-item, RtAppManager, '{"nextOpen":9999999999999,"wasClosed":true}')
 
 ! thegatewaypundit.com (images fix)
 @@||ruamupr.com^$script,domain=thegatewaypundit.com


### PR DESCRIPTION
Rotten Tomatoes has updated their modal visibility logic here. Now, the modal shows to US users only, on their first visit or 24 hours since the timer was last reset (through a "nextOpen" variable that is set to unix time of now + 24 hours). 

To get around this, we can set the "nextOpen" value to a value indefinitely in the future and set the "wasClosed" value to true. This will prevent the dialog from ever appearing.