### PR TITLE
Fixes ytsleeptimer.com and delta.com

### DIFF
--- a/brave-lists/brave-checks.txt
+++ b/brave-lists/brave-checks.txt
@@ -80,6 +80,8 @@ watchfooty.live
 streameast.ga
 tech4auto.in
 starlightnet.work
+delta.com
+ytsleeptimer.com
 nflbox.me
 nbabox.co
 nhlbox.me


### PR DESCRIPTION
Delta.com (ios checks)
ytsleeptimer.com (embedded twitch)
<img width="1170" height="2532" alt="IMG_6248" src="https://github.com/user-attachments/assets/74991761-8ade-488a-8774-0ed830a810ef" />
