### PR TITLE
Hiding ads on gigafile.nu

### DIFF
--- a/brave-lists/brave-firstparty-regional.txt
+++ b/brave-lists/brave-firstparty-regional.txt
@@ -1428,6 +1428,9 @@ game8.jp##div[id^="g8-ad-placement"]
 ||game8.jp/api/ad/advertisement_placements?
 ||game8.jp/assets/*/ads/
 ||game8.jp/assets/pc/jack_ad/
+! gigafile.nu
+gigafile.nu##.gf-bottom-panel-left
+gigafile.nu##.pr_area_sp
 ! Japanese first-party (exception rules)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/150552
 @@||ads.nicovideo.jp/assets/js/ads2.js$domain=com.nicovideo.jp


### PR DESCRIPTION
This is a Japanese only site. These ads are also served by the site itself and are not third-party.