### PR TITLE
Hiding ads on imdb.com for iOS

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -380,6 +380,10 @@ fmovies.co###ics
 ! dailymail.co.uk
 dailymail.co.uk##+js(abort-on-property-read, Notification)
 
+! imdb.com
+||media-amazon.com/images/S/sash/$domain=imdb.com
+||imdbtv.amazon.dev/2021-01-01/ads?$domain=imdb.com
+
 ! https://github.com/easylist/easylist/commit/d3a2c54ac
 @@||app.posthog.com/decide/
 


### PR DESCRIPTION
These filters are a part of https://github.com/easylist/easylist/blob/master/easylist/easylist_specific_block.txt

They block the ads on desktop and Android, but not iOS, because iOS does not have this list. I have added the filters to the iOS specific filter list.