### PR TITLE
Debounce y2u.be URLs to youtube.com

### DIFF
--- a/brave-lists/debounce.json
+++ b/brave-lists/debounce.json
@@ -573,7 +573,7 @@
     "exclude": [
     ],
     "action": "regex-path-template",
-    "param": "^/(.+)$",
+    "param": "^/([^/]+)$",
     "redirect_url_template": "https://www.youtube.com/watch?v=$1"
   }
 ]


### PR DESCRIPTION
To actually address the redirection reported in https://github.com/brave/brave-browser/issues/18756.
Will only work on Brave clients that have https://github.com/brave/brave-core/pull/34805 (for everyone else it's a no-op since it's an unrecognized `action`, tests for that already exist in brave-core).
We have additional CI tests for the debounce rules file after https://github.com/brave/adblock-lists/pull/2817.