### PR TITLE
Cleanups of tools/debounce_validation/test_debounce_validation.py

### DIFF
--- a/tools/debounce_validation/test_debounce_validation.py
+++ b/tools/debounce_validation/test_debounce_validation.py
@@ -78,15 +78,15 @@ class DebounceTester(unittest.TestCase):
     def test_action_types_are_known(self):
         for i, rule in enumerate(self.raw_debounce):
             self.assertIn(
-                rule['action'], KNOWN_ACTIONS,
-                f"Rule {i} has unknown action '{rule['action']}'"
+                rule.get('action', ''), KNOWN_ACTIONS,
+                f"Rule {i} has unknown action '{rule.get('action', '')}'"
             )
 
     # For regex-path and regex-path-template rules, verify that the param
     # field compiles as a valid regular expression.
     def test_regex_param_is_valid(self):
         for i, rule in enumerate(self.raw_debounce):
-            if rule['action'] in REGEX_ACTIONS:
+            if rule.get('action') in REGEX_ACTIONS:
                 try:
                     re.compile(rule['param'])
                 except re.error as e:
@@ -98,7 +98,7 @@ class DebounceTester(unittest.TestCase):
     # otherwise brave-core has no template to substitute capture groups into.
     def test_regex_path_template_has_redirect_url_template(self):
         for i, rule in enumerate(self.raw_debounce):
-            if rule['action'] == 'regex-path-template':
+            if rule.get('action') == 'regex-path-template':
                 self.assertIn(
                     'redirect_url_template', rule,
                     f"Rule {i} has action 'regex-path-template' but is "
@@ -109,11 +109,11 @@ class DebounceTester(unittest.TestCase):
     # Its presence on other action types likely indicates a copy-paste error.
     def test_redirect_url_template_only_on_regex_path_template(self):
         for i, rule in enumerate(self.raw_debounce):
-            if rule['action'] != 'regex-path-template':
+            if rule.get('action') != 'regex-path-template':
                 self.assertNotIn(
                     'redirect_url_template', rule,
                     f"Rule {i} has 'redirect_url_template' but action is "
-                    f"'{rule['action']}', not 'regex-path-template'"
+                    f"'{rule.get('action', '')}', not 'regex-path-template'"
                 )
 
     # A redirect_url_template without any $1..$9 placeholders would always
@@ -132,7 +132,7 @@ class DebounceTester(unittest.TestCase):
     # regex only has 2 groups).
     def test_redirect_url_template_placeholders_match_capture_groups(self):
         for i, rule in enumerate(self.raw_debounce):
-            if rule['action'] != 'regex-path-template':
+            if rule.get('action') != 'regex-path-template':
                 continue
             template = rule.get('redirect_url_template', '')
             placeholders = {int(m) for m in re.findall(r'\$([1-9])', template)}

--- a/tools/debounce_validation/test_debounce_validation.py
+++ b/tools/debounce_validation/test_debounce_validation.py
@@ -146,5 +146,3 @@ class DebounceTester(unittest.TestCase):
                 f"regex only has {num_groups} capture group(s)"
             )
 
-if __name__ == '__main__':
-    unittest.main()

--- a/tools/debounce_validation/test_debounce_validation.py
+++ b/tools/debounce_validation/test_debounce_validation.py
@@ -42,8 +42,8 @@ class DebounceTester(unittest.TestCase):
     def loadRules(self, raw_rules):
         rules = []
         for ruleset in raw_rules:
-            rules.extend(ruleset['include'])
-            rules.extend(ruleset['exclude'])
+            rules.extend(ruleset.get('include', []))
+            rules.extend(ruleset.get('exclude', []))
         return rules
 
     def test_load_debounce_list_no_exceptions(self):

--- a/tools/debounce_validation/test_debounce_validation.py
+++ b/tools/debounce_validation/test_debounce_validation.py
@@ -145,3 +145,6 @@ class DebounceTester(unittest.TestCase):
                 f"Rule {i} template references ${max_placeholder} but "
                 f"regex only has {num_groups} capture group(s)"
             )
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION

**1st commit:**

- Add unittest.main() so test file can be run directly Without this,  exits silently without running any tests. Tests must be invoked via  instead, which is non-obvious.

**2nd commit:**

- Fix inverted condition in test_regex_path_template_has_redirect_url_template
  (was checking != instead of ==, testing the wrong rules)
- Fix inverted condition and unguarded access in test_redirect_url_template_has_placeholders
  (was checking action != regex-path-template instead of redirect_url_template presence)
- Fix inverted condition in test_redirect_url_template_placeholders_match_capture_groups
  (was skipping regex-path-template rules instead of processing them)
- Use rule.get('action', '') throughout to avoid KeyError if action field is missing

**3rd commit:**

- If a ruleset is missing 'include' or 'exclude', setUp would crash with a KeyError before test_required_fields_present could report the problem cleanly.