### PR TITLE
Remove ad-shield exception from brave-ios-specific

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -111,7 +111,6 @@ ft.com##+js(rc, sp-message-open, html, stay)
 ! Ad-shield test
 ! syosetu.com,game8.jp##+js(remove-node-text, script, html-load.com)
 ! ||html-load.com^$script,domain=game8.jp|syosetu.com
-@@||html-load.com^
 
 ! Ad-shield
 ! ||html-load.com^$~css,domain=etoday.co.kr|genshinlab.com|dogdrip.net|thestar.co.uk|yorkshirepost.co.uk|indiatimes.com


### PR DESCRIPTION
Ad-shield rules are included in slim-list now, exception shouldn't be needed.