### PR TITLE
Add wenku8.net to brave-checks due to user-agent block on iOS

### DIFF
--- a/brave-lists/brave-checks.txt
+++ b/brave-lists/brave-checks.txt
@@ -319,3 +319,4 @@ capitaloneoffers.com
 capitalone.com
 rdrama.net
 redscarepod.net
+wenku8.net


### PR DESCRIPTION
<img width="300" src="https://github.com/user-attachments/assets/4567b72f-e73a-406b-8af9-16b91441e862" />

Any mention of `Brave` in user agent results in block:
<img width="800" src="https://github.com/user-attachments/assets/e8b52766-7180-4029-980a-0999eb0481bd" />

User report:
https://www.reddit.com/r/brave_browser/comments/1sdrjly/ios_brave_cannot_access_specific_website_windows/