### PR TITLE
Resolving Albertsons search issue

### DIFF
--- a/brave-lists/webcompat-exceptions.json
+++ b/brave-lists/webcompat-exceptions.json
@@ -27,7 +27,6 @@
       "*://www.vons.com/*"
     ],
     "exceptions": [
-      "font",
       "language"
     ],
     "issue": "https://github.com/brave/brave-browser/issues/48655"

--- a/brave-lists/webcompat-exceptions.json
+++ b/brave-lists/webcompat-exceptions.json
@@ -10,10 +10,25 @@
   },
   {
     "include": [
-      "*://www.safeway.com/*"
+      "*://www.acmemarkets.com/*", 
+      "*://www.albertsons.com/*", 
+      "*://www.balduccis.com/*",
+      "*://www.carrsqc.com/*", 
+      "*://www.haggen.com/*", 
+      "*://www.jewelosco.com/*", 
+      "*://www.kingsfoodmarkets.com/*", 
+      "*://www.pavilions.com/*", 
+      "*://www.randalls.com/*", 
+      "*://www.safeway.com/*", 
+      "*://www.shaws.com/*", 
+      "*://www.shopamigos.com/*", 
+      "*://www.starmarket.com/*", 
+      "*://www.tomthumb.com/*", 
+      "*://www.vons.com/*"
     ],
     "exceptions": [
-      "font"
+      "font",
+      "language"
     ],
     "issue": "https://github.com/brave/brave-browser/issues/48655"
   },


### PR DESCRIPTION
Albertsons (and banner stores such as safeway, vons, etc) have an issue with their search not working when the language fingerprinting feature is active. This fix will exclude language fingerprinting on these sites to restore search functionality.