### PR TITLE
Fix AI button on google.com

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -22,6 +22,10 @@ sinensistoon.com##+js(aopr, block_ads)
 ! YT ads fallback on snippet
 ||googlevideo.com/videoplayback*ctier=L&*%2Cxpc%2Cctier%2C$domain=m.youtube.com|music.youtube.com
 
+! www.google.com AI button not working
+! https://github.com/brave/brave-core/pull/31152
+www.google.com##+js(aeld, resize, .blur())
+
 ! cvs.com app banner  cvs.com##cvs-smart-app-banner  not being applied
 cvs.com##+js(trusted-set-local-storage-item, appBannerClosed, $now$)
 


### PR DESCRIPTION
Fixes AI button on google.com

Fix https://github.com/brave/brave-browser/issues/54870

- Ask AI on google.com is unusable in Brave iOS: tapping the "Ask anything" textarea opens the composer, then immediately dismisses it. Google's viewport handler listens for visualViewport resize events and, when it detects df = innerHeight - visualViewport.height - offsetTop === 0 on a focused input, calls activeElement.blur() — which closes the keyboard and the composer with it.

- This fires on every focus in Brave iOS because the WebView reports innerHeight === visualViewport.height regardless of keyboard state, the same broken-viewport-units behavior tracked in #47891 and partially addressed by PR #31152. Sites correctly reading viewport dimensions get df = 0, hit the "keyboard dismissed" branch, and tear down their UI.

- Confirmed workaround via uBO filter google.com##+js(aeld, resize, .blur())

Repro: google.com on Brave iOS → tap Ask AI → composer flashes open then closes.