### PR TITLE
Add xexplorer.io to brave-checks for iOS UA seeing blank page

### DIFF
--- a/brave-lists/brave-checks.txt
+++ b/brave-lists/brave-checks.txt
@@ -323,3 +323,4 @@ rdrama.net
 redscarepod.net
 wenku8.net
 test-website-b.pages.dev
+cexplorer.io


### PR DESCRIPTION
Brave UA | Safari UA
--|--
<img width="300" alt="Brave UA" src="https://github.com/user-attachments/assets/4327b2b0-8292-4aaf-8ae9-f1b54de3659f" />|<img width="300" alt="Safari UA" src="https://github.com/user-attachments/assets/7dc3226a-d598-4943-988a-8be653494f3b" />
