### PR TITLE
Adding Youtube SABR delay fix to experimental list

### DIFF
--- a/brave-lists/experimental.txt
+++ b/brave-lists/experimental.txt
@@ -31,3 +31,6 @@ m.youtube.com##+js(rc, paused-mode, , stay)
 
 ! filters.txt
 *_ad_$media,domain=youtube.com,3p
+
+! Youtube sabr delay fix
+youtube.*##+js(brave-yt-sabr-fix)

--- a/brave-lists/experimental.txt
+++ b/brave-lists/experimental.txt
@@ -33,4 +33,4 @@ m.youtube.com##+js(rc, paused-mode, , stay)
 *_ad_$media,domain=youtube.com,3p
 
 ! Youtube sabr delay fix
-youtube.*##+js(brave-yt-sabr-fix)
+www.youtube.*##+js(brave-yt-sabr-fix)


### PR DESCRIPTION
This adds the scriptlet fix to the SABR related Youtube delays that have been causing issues. This will be added to the experimental list as there is some room for improvement (doesn't fix 100% of SABR related Youtube delays)

The PR defining the scriptlet is here: https://github.com/brave/adblock-resources/pull/321