### PR TITLE
remove invisible cookie modal backdrop on xm.com

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -1565,6 +1565,5 @@ livejournal.com##+js(aopr, webpackJsonpSSPjs)
 @@||ad.pr.ameba.jp/tpc/$xmlhttprequest
 @@||amebame.com/pub/ads/$domain=ameblo.jp
 @@||stat100.ameba.jp/blogportal/img/banner/$image
-
 ! xm.com webcompat fix
 xm.com##.cdk-overlay-container:has(xm-cookie-modal-main)

--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -1565,3 +1565,6 @@ livejournal.com##+js(aopr, webpackJsonpSSPjs)
 @@||ad.pr.ameba.jp/tpc/$xmlhttprequest
 @@||amebame.com/pub/ads/$domain=ameblo.jp
 @@||stat100.ameba.jp/blogportal/img/banner/$image
+
+! xm.com webcompat fix
+xm.com##.cdk-overlay-container:has(xm-cookie-modal-main)


### PR DESCRIPTION
Fixed a WebCompat issue on xm.com where Brave's cookie-blocking component successfully hides the visual aspect of the cookie consent modal, but leaves the underlying backdrop wrapper (.cdk-overlay-container) active in the DOM. This invisible container blankets the viewport and traps mouse events, preventing users from clicking "Start Trading" or interacting with the page in general.

Steps to Reproduce (STR)
1. Clear all cookies/site data for xm.com.
2. Enable Brave Shields and load xm.com .
3. Attempt to click "Start Trading" or the hamburger menu.
4. Result: Click events are swallowed by the invisible overlay container.

Fix
Added a procedural filter targeting .cdk-overlay-container only when it contains xm-cookie-modal-main to clear the un-clickable layout layer without interfering with other potential system modals.