### PR TITLE
Fixing Apple Pay popup on camh.ca

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -49,6 +49,11 @@ x.com,twitter.com,eventbrite.com,wunderground.com,accuweather.com,formula1.com,l
 ! Scroll fix
 cnn.com##body,html:style(overflow: auto !important; position: initial !important;)
 
+! Fixing Apple Pay popup on camh.ca
+@@||app.blackbaud.net^$domain=camh.ca
+@@||stripe.com^$domain=camh.ca
+
+
 ! amgreatness.com
 ||ruamupr.com^
 ||hilerant.site^


### PR DESCRIPTION
The apple pay popup was not visible on this site. To fix this, it was found that both app.blackbaud.net and stripe.com needed to be allowlisted in order for the popup to display properly.

I attempted this with uBO on Safari and couldn't reproduce. This issue seems to be isolated to Brave on iOS