### PR TITLE
Removed probo.biz, caused issues on https://workman.jp/shop/goods/search.aspx?q=%E3%82%B7%E3%83%A3%E3%83%84

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -1555,7 +1555,6 @@ livejournal.com##+js(aopr, webpackJsonpSSPjs)
 ||nikkei.com/.resources/static/nad/
 ||reemo-ad.jp^$third-party
 ||orca-pass.net^$third-party
-||probo.biz^$third-party
 ||pitadtag.jp^$third-party
 ||itmedia.co.jp/spv/images/career_en_300x250.jpg
 ||itmedia.co.jp/spv/images/career_en_320x50.jpg


### PR DESCRIPTION
> [workman.jp](http://workman.jp/) is one of the most popular apparel companies in Japan. A user reports that the search results on this site are blocked by Shields if it's enabled. I think this is easily reproducible at the following URL.

