### PR TITLE
Re-adding SABR YT fix to experimental list

### DIFF
--- a/brave-lists/experimental.txt
+++ b/brave-lists/experimental.txt
@@ -34,3 +34,6 @@ m.youtube.com##+js(rc, paused-mode, , stay)
 
 ! filters.txt
 *_ad_$media,domain=youtube.com,3p
+
+! Youtube sabr delay fix
+www.youtube.*##+js(brave-yt-sabr-fix)


### PR DESCRIPTION
This PR reintroduces the SABR YT fix to the experimental list. This fix was removed due to speculation that it was causing a more widespread Youtube issue. We have determined the true cause of this issue and it is unrelated to this. 

I would like to continue monitoring user feedback with this in experimental with hopes that we can eventually bring this into the default filter list.