### PR TITLE
Fixing anti-adblock on winfuture.de

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -70,7 +70,9 @@ dzen.ru#@#:matches-path(/articles) div:has(> article > div > [class*="image"]:em
 @@||play.google.com/log?$domain=meet.google.com
 
 ! Ad-Shield fix
-@@||html-load.com^$script,xhr,domain=tbsradio.jp|ondemandkorea.com|tbsradio.jp
+@@||html-load.com^$script,xhr,domain=tbsradio.jp|ondemandkorea.com|tbsradio.jp|winfuture.de
+@@||html-load.com$fetch,domain=winfuture.de
+@@||html-load.com/feed$domain=winfuture.de
 ! Unsupported counters ad-shield, but also breaks when combined. Countering this:
 ! *$document,csp=script-src-attr 'none',to=m.economictimes.com|ondemandkorea.com|tbsradio.jp
 


### PR DESCRIPTION
This site is using adshield with html-load to serve ads and detect if any of them are blocked. I have found that allowing the html-load scripts, xhr requests, fetch requests and any document requests from html-load/feed will make the page run as expected.

@ryanbr - if there is a more appropriate solution here, please suggest it.

Fixes https://github.com/brave-experiments/spiking-webcompat-reports/issues/2023