### PR TITLE
Fix https://www.superfeet.* insole-finder locking up

### DIFF
--- a/brave-lists/brave-firstparty.txt
+++ b/brave-lists/brave-firstparty.txt
@@ -2749,6 +2749,8 @@ athlonsports.com,bringmethenews.com,meidastouch.com,si.com,thestreet.com##.is-ex
 ! digitaltrends.com
 digitaltrends.com##.dt-primis
 digitaltrends.com##.dtads-location
+! https://www.superfeet.com.au/pages/insole-finder not working in standard shields
+/a/elevar/static/*
 ! planetf1.com
 planetf1.com##.ps-block-a
 ! embed.st /streamed.pk


### PR DESCRIPTION
* Visit https://www.superfeet.com/
* Click on Insole finder at the top
* Try to navigate the finder, will lock up with a loading circle.


1st-party tracker causing it. Blocking it fixes it.

`https://www.superfeet.com/a/elevar/static/configs/8c9cf296aca82a99425f63054635dbc84e03b038/config.js`