### PR TITLE
Disable sabr scriptlet for the time being

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -36,7 +36,7 @@ youtube.com##+js(brave-video-bg-play)
 ! Youtube sabr delay fix
 ! Hide the warning popup 
 youtube.com##.yt-notification-action-renderer
-www.youtube.com##+js(brave-yt-sabr-fix)
+! www.youtube.com##+js(brave-yt-sabr-fix)
 
 ! "This content isn't available"
 ! https://github.com/uBlockOrigin/uAssets/commit/e5d9eaeaf9a1772b60f1756c58d931d928e400e6


### PR DESCRIPTION
```
videos stuck in a load loop where it cant start
videos wont load when brave shields enabled
Youtube video constantly buffering while shields are up but once turned off the youtube video plays immediately. Been like this for at least 3 months for me anyhow
The videos won't load when blocking trackers or using ad-blocker only mode
youtube video won't load with adblock active, video stays a black screen and the video time flickers between the video length and 0:00 because the ad doesnt load
Permanent reloading of videos without ending
On Youtube the videos won't play, the total time at the bottom will keep changing constantly (0:00/4:46 to 0:00/0:00)
it does this thing where it keeps like refreshing the video and not playing it  IDK how to describe it but it is not working with it, but when i turned it off videos work fine
```