### PR TITLE
A: tribunnews.com

### DIFF
--- a/brave-lists/brave-firstparty-regional.txt
+++ b/brave-lists/brave-firstparty-regional.txt
@@ -1166,6 +1166,10 @@ diariodecadiz.es,laregion.es##[data-ad-type="list"]
 !! Indonesian sites
 kompas.com##.gate-kgplus
 kompas.com#@#.video-box-wrap
+tribunnews.com###div-Inside-MediumRectangle
+tribunnews.com###wideskyscraper
+tribunnews.com##.box__reserved
+tribunnews.com##.reserved-topmedium
 !! Italian sites
 libero.it,tecnologia.libero.it###admputop
 huffingtonpost.it,lastampa.it,repubblica.it###adv-TopLeft


### PR DESCRIPTION
https://github.com/ABPindo/indonesianadblockrules/pull/1106

https://m.tribunnews.com/nasional/7845771/korupsi-mbg-kejagung-dalami-41-nama-di-ponsel-sony-sonjaya?page=all

Fix:

```
tribunnews.com###div-Inside-MediumRectangle
tribunnews.com###wideskyscraper
tribunnews.com##.box__reserved
tribunnews.com##.reserved-topmedium
```

This rule is already available on EasyList but only works on aggressive blocking modes, who have a high chances of breaking other sites