### PR TITLE
Re-introducing YT SABR fix in experimental

### DIFF
--- a/brave-lists/experimental.txt
+++ b/brave-lists/experimental.txt
@@ -36,4 +36,4 @@ m.youtube.com##+js(rc, paused-mode, , stay)
 *_ad_$media,domain=youtube.com,3p
 
 ! Youtube sabr delay fix
-! www.youtube.*##+js(brave-yt-sabr-fix)
+www.youtube.*##+js(brave-yt-sabr-fix)


### PR DESCRIPTION
I would like to get this fix back in experimental while we continue to test this. I have resolved the issue with users using uBO extension seeing a reload loop. After my own manual and automated testing, the current fix works better. It would be good to see if any users have issues before releasing this in the main lists.