### PR TITLE
Disabling hardware concurrency farbling by default on whatsapp.com

### DIFF
--- a/brave-lists/webcompat-exceptions.json
+++ b/brave-lists/webcompat-exceptions.json
@@ -183,5 +183,14 @@
       "webgl2"
     ],
     "issue": "https://github.com/brave/brave-browser/issues/46599"
+   },
+   {
+    "include": [
+      "*://web.whatsapp.com/*"
+    ],
+    "exceptions": [
+      "hardware-concurrency"
+    ],
+    "issue": "https://github.com/brave/brave-browser/issues/56766"
    }
 ]


### PR DESCRIPTION
The following issue describes a problem on whatsapp where users on specific devices could not see reaction emojis when attempting to react to a message. By disabling hardware concurrency farbling, this feature works as expected.

This change will disable hardware concurrency farbling by default, acting as an interim fix until we can fix the underlying issue.

https://github.com/brave/brave-browser/issues/56766