### PR TITLE
Re-implementing Youtube SABR fix

### DIFF
--- a/brave-lists/brave-specific.txt
+++ b/brave-lists/brave-specific.txt
@@ -170,3 +170,6 @@ dev-pages.brave.software,dev-pages.bravesoftware.com##+js(set, window.BRAVE_TEST
 ! Fixing paywall scroll issue on scmp.com
 @@||c2.piano.io/xbuilder/experience/$xhr,domain=scmp.com
 @@||cdn.tinypass.com/api/tinypass.min.js$script,domain=scmp.com
+
+! Youtube sabr delay fix
+www.youtube.*##+js(brave-yt-sabr-fix)

--- a/brave-lists/experimental.txt
+++ b/brave-lists/experimental.txt
@@ -35,5 +35,3 @@ m.youtube.com##+js(rc, paused-mode, , stay)
 ! filters.txt
 *_ad_$media,domain=youtube.com,3p
 
-! Youtube sabr delay fix
-www.youtube.*##+js(brave-yt-sabr-fix)


### PR DESCRIPTION
After fixing the issues with uBO and Brave conflicting when the uBO lite extension was active on Brave, we can safely reintroduce the SABR fix again.