### PR TITLE
Update #2960

### DIFF
--- a/brave-lists/brave-ios-specific.txt
+++ b/brave-lists/brave-ios-specific.txt
@@ -435,7 +435,7 @@ youtube.com##ytd-rich-item-renderer:has(> #content > ytd-ad-slot-renderer)
 youtube.com###shorts-inner-container > .ytd-shorts:has(> .ytd-reel-video-renderer > ytd-ad-slot-renderer)
 ! https://community.brave.app/t/topic/655492/
 ! https://github.com/AdguardTeam/AdguardFilters/commit/3f1ba60715da29502b0a686fed38c5bb72948677
-||imasdk.googleapis.com/js/sdkloader/ima3.js$script,redirect=google-ima3,domain=sp.nicovideo.jp,important,badfilter
+@@||imasdk.googleapis.com/js/sdkloader/ima3.js$domain=sp.nicovideo.jp
 ! naver.com search is broken  https://m.search.naver.com/search.naver?where=m_image&sm=mtb_jum&query=brave
 @@||ssl.pstatic.net^$domain=naver.com
 ! aniwave.to


### PR DESCRIPTION
Now that ABP [added](https://gitlab.com/eyeo/filterlists/japanesefilters/-/commit/e1556cd52254622d37c1772d77ff48410e31aba9) the exception to their filter, I'll remove the same filter from EL and then remove `$important` from AdGuard Japanese (and uBO Quick fix). This change will be required regardless of the actual cause.