### PR TITLE
Applying sabr fix for mobile youtube

### DIFF
--- a/brave-lists/brave-specific.txt
+++ b/brave-lists/brave-specific.txt
@@ -172,4 +172,4 @@ dev-pages.brave.software,dev-pages.bravesoftware.com##+js(set, window.BRAVE_TEST
 @@||cdn.tinypass.com/api/tinypass.min.js$script,domain=scmp.com
 
 ! Youtube sabr delay fix
-! www.youtube.*##+js(brave-yt-sabr-fix)
+m.youtube.*##+js(brave-yt-sabr-fix)


### PR DESCRIPTION
Because mobile youtube cannot run alongside uBO, we can safely push the SABR fix without triggering the uBO + Brave issue. However, we may see other issues arise here. It is worth deploying as a test, since all automated and manual tests are passing