### PR TITLE
removing sabr fix

### DIFF
--- a/brave-lists/brave-specific.txt
+++ b/brave-lists/brave-specific.txt
@@ -172,4 +172,4 @@ dev-pages.brave.software,dev-pages.bravesoftware.com##+js(set, window.BRAVE_TEST
 @@||cdn.tinypass.com/api/tinypass.min.js$script,domain=scmp.com
 
 ! Youtube sabr delay fix
-m.youtube.*##+js(brave-yt-sabr-fix)
+! m.youtube.*##+js(brave-yt-sabr-fix)


### PR DESCRIPTION
Due to recent spiking on m.youtube.com related to videos not loading (although I can't reproduce), we need to pull the SABR fix to ensure that is not the cause of the spike https://metabase.bsg.brave.com/question/1926-stats-daily-webcompat-totals-single-domain?domain=m.youtube.com&platform=