### PR TITLE
Removing albertsons exceptions

### DIFF
--- a/brave-lists/webcompat-exceptions.json
+++ b/brave-lists/webcompat-exceptions.json
@@ -10,29 +10,6 @@
   },
   {
     "include": [
-      "*://www.acmemarkets.com/*", 
-      "*://www.albertsons.com/*", 
-      "*://www.balduccis.com/*",
-      "*://www.carrsqc.com/*", 
-      "*://www.haggen.com/*", 
-      "*://www.jewelosco.com/*", 
-      "*://www.kingsfoodmarkets.com/*", 
-      "*://www.pavilions.com/*", 
-      "*://www.randalls.com/*", 
-      "*://www.safeway.com/*", 
-      "*://www.shaws.com/*", 
-      "*://www.shopamigos.com/*", 
-      "*://www.starmarket.com/*", 
-      "*://www.tomthumb.com/*", 
-      "*://www.vons.com/*"
-    ],
-    "exceptions": [
-      "language"
-    ],
-    "issue": "https://github.com/brave/brave-browser/issues/48655"
-  },
-  {
-    "include": [
       "*://www.britishairways.com/*",
       "*://www.ba.com/*"
     ],


### PR DESCRIPTION
This change resolves this issue: https://github.com/brave/adblock-lists/issues/2973.

Since the language fingerprinting was updated and now works as expected on albertsons websites, we no longer need these exceptions.