### PR TITLE
[clean-urls] Add theguardian[dot]com CMP parameter to the clean-urls

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -1199,7 +1199,7 @@
     },
     {
         "include": [
-            "://www.theguardian.com/*"
+            "*://www.theguardian.com/*"
         ],
         "exclude": [
 

--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -1196,5 +1196,16 @@
         "params": [
             "aff"
         ]
+    },
+    {
+        "include": [
+            "://www.theguardian.com/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "CMP"
+        ]
     }
 ]


### PR DESCRIPTION
Resolves https://github.com/brave/adblock-lists/issues/2991