### PR TITLE
Hiding anti adblock on finance.kooorazoom.net

### DIFF
--- a/brave-unbreak.txt
+++ b/brave-unbreak.txt
@@ -1556,3 +1556,5 @@ livejournal.com##+js(aopr, webpackJsonpSSPjs)
 @@||ad.pr.ameba.jp/tpc/$xmlhttprequest
 @@||amebame.com/pub/ads/$domain=ameblo.jp
 @@||stat100.ameba.jp/blogportal/img/banner/$image
+! anti-adblock on finance.kooorazoom.net
+finance.kooorazoom.net##+js(set, 'adBlockBlock', 1)


### PR DESCRIPTION
This anti adblock notice only surfaces on Brave. It does not surface on Firefox+uBO. So, the fix is only necessary in our Brave unbreak lists.