### PR TITLE
[clean-urls] Add linkedin[dot]com/jobs/view/ alternateChannel,eBP,refId,trackingId parameters to the clean-urls  

### DIFF
--- a/brave-lists/clean-urls.json
+++ b/brave-lists/clean-urls.json
@@ -629,6 +629,20 @@
             "original_referer"
         ]
     },
+	{
+        "include": [
+            "*://www.linkedin.com/jobs/view/*"
+        ],
+        "exclude": [
+
+        ],
+        "params": [
+            "alternateChannel",
+            "eBP",
+            "refId",
+            "trackingId"
+        ]
+    },
     {
         "include": [
             "*://www.linkedin.com/help/*"


### PR DESCRIPTION
Remove tracking etc from LinkedIn job postings via the clean url feature